### PR TITLE
feat(sensor): dedup unchanged writes from coordinator ticks (0.3.6-beta.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.4.0-beta.1] - 2026-06-07
+## [0.3.6-beta.1] - 2026-06-07
 
 ### Changed
 - Sensor/BinarySensor: skip `async_write_ha_state` when both the native value and `extra_state_attributes` match the previously published pair. The coordinator still ticks every 30 seconds, but unchanged sensors no longer produce redundant recorder rows. Steady-state networks should see a large drop in recorder writes for the offline-count, offline-entities, low-battery, group-summary, recently-offline, recently-recovered, any-offline binary sensor, and their combined-group counterparts. First write after startup always goes through; any change in value or attrs still publishes immediately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0-beta.1] - 2026-06-07
+
+### Changed
+- Sensor/BinarySensor: skip `async_write_ha_state` when both the native value and `extra_state_attributes` match the previously published pair. The coordinator still ticks every 30 seconds, but unchanged sensors no longer produce redundant recorder rows. Steady-state networks should see a large drop in recorder writes for the offline-count, offline-entities, low-battery, group-summary, recently-offline, recently-recovered, any-offline binary sensor, and their combined-group counterparts. First write after startup always goes through; any change in value or attrs still publishes immediately.
+
 ## [0.3.5] - 2026-06-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Monitor entity availability in Home Assistant. Track offline entities, availabil
 - **Maintenance/suppression mode** -- temporarily exclude entities from monitoring
 - **Custom Lovelace card** -- traffic-light status display with at-a-glance health overview
 - **Self-managed storage** -- no recorder dependency; data stored in `.storage`
+- **Recorder-friendly writes** -- sensors only publish state when value or attributes actually change, so steady-state networks don't generate redundant history rows every coordinator tick
 - **Survives HA restarts** -- availability history persisted via HA Store
 
 ---

--- a/custom_components/entity_availability/binary_sensor.py
+++ b/custom_components/entity_availability/binary_sensor.py
@@ -5,18 +5,15 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
-    BinarySensorEntity,
-)
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 
 from .const import CONF_ENTRY_TYPE, CONF_GROUP_NAME, DOMAIN, ENTRY_TYPE_COMBINED
 from .coordinator import EntityAvailabilityCoordinator
+from .write_dedup import DedupCoordinatorBinarySensor
 
 
 async def async_setup_entry(
@@ -42,9 +39,7 @@ async def async_setup_entry(
     )
 
 
-class AnyOfflineBinarySensor(
-    CoordinatorEntity[EntityAvailabilityCoordinator], BinarySensorEntity
-):
+class AnyOfflineBinarySensor(DedupCoordinatorBinarySensor):
     """Binary sensor: ON when at least one entity is offline (problem detected)."""
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM

--- a/custom_components/entity_availability/combined_binary_sensor.py
+++ b/custom_components/entity_availability/combined_binary_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_COMBINED_GROUPS, CONF_GROUP_NAME, DOMAIN
 from .coordinator import EntityAvailabilityCoordinator
+from .write_dedup import WriteDedupMixin
 
 
 async def async_setup_entry(
@@ -42,12 +43,15 @@ async def async_setup_entry(
     )
 
 
-class CombinedGroupAnyOfflineBinarySensor(BinarySensorEntity):
+class CombinedGroupAnyOfflineBinarySensor(WriteDedupMixin, BinarySensorEntity):
     """Binary sensor: ON when any entity across included groups is offline."""
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
     _attr_icon = "mdi:alert"
     _attr_has_entity_name = True
+
+    def _ea_current_value(self) -> Any:
+        return self.is_on
 
     def __init__(
         self,
@@ -80,7 +84,8 @@ class CombinedGroupAnyOfflineBinarySensor(BinarySensorEntity):
 
         @callback
         def _on_coordinator_update() -> None:
-            self.async_write_ha_state()
+            if self._ea_should_write():
+                self.async_write_ha_state()
 
         for coordinator in self._coordinators:
             self._unsub_listeners.append(

--- a/custom_components/entity_availability/combined_binary_sensor.py
+++ b/custom_components/entity_availability/combined_binary_sensor.py
@@ -97,6 +97,7 @@ class CombinedGroupAnyOfflineBinarySensor(WriteDedupMixin, BinarySensorEntity):
         for unsub in self._unsub_listeners:
             unsub()
         self._unsub_listeners.clear()
+        self._ea_reset_cache()
 
     def _active_coordinators(self) -> list[EntityAvailabilityCoordinator]:
         domain_data = self.hass.data.get(DOMAIN, {})

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -122,6 +122,7 @@ class CombinedSensorBase(WriteDedupMixin, SensorEntity):
         for unsub in self._unsub_listeners:
             unsub()
         self._unsub_listeners.clear()
+        self._ea_reset_cache()
 
     def _active_coordinators(self) -> list[EntityAvailabilityCoordinator]:
         domain_data = self.hass.data.get(DOMAIN, {})

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -21,6 +21,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import EntityAvailabilityCoordinator
+from .write_dedup import WriteDedupMixin
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,10 +82,13 @@ def _friendly_name(hass: HomeAssistant, entity_id: str) -> str:
     return entity_id.split(".")[-1].replace("_", " ").title()
 
 
-class CombinedSensorBase(SensorEntity):
+class CombinedSensorBase(WriteDedupMixin, SensorEntity):
     """Base class for combined group sensors — handles coordinator subscriptions."""
 
     _attr_has_entity_name = True
+
+    def _ea_current_value(self) -> Any:
+        return self.native_value
 
     def __init__(
         self,
@@ -106,7 +110,8 @@ class CombinedSensorBase(SensorEntity):
     async def async_added_to_hass(self) -> None:
         @callback
         def _on_coordinator_update() -> None:
-            self.async_write_ha_state()
+            if self._ea_should_write():
+                self.async_write_ha_state()
 
         for coordinator in self._coordinators:
             self._unsub_listeners.append(

--- a/custom_components/entity_availability/manifest.json
+++ b/custom_components/entity_availability/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/italo-lombardi/Home-Assistant-EntityAvailability/issues",
     "quality_scale": "custom",
     "requirements": [],
-    "version": "0.3.5"
+    "version": "0.4.0-beta.1"
 }

--- a/custom_components/entity_availability/manifest.json
+++ b/custom_components/entity_availability/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/italo-lombardi/Home-Assistant-EntityAvailability/issues",
     "quality_scale": "custom",
     "requirements": [],
-    "version": "0.4.0-beta.1"
+    "version": "0.3.6-beta.1"
 }

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -7,11 +7,11 @@ import re
 from datetime import datetime, timezone
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 
 from .const import (
@@ -26,6 +26,7 @@ from .const import (
     ENTRY_TYPE_COMBINED,
 )
 from .coordinator import EntityAvailabilityCoordinator
+from .write_dedup import DedupCoordinatorSensor
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ async def async_setup_entry(
         len(coordinator.monitored_entities),
     )
 
-    entities: list[SensorEntity] = [
+    entities: list[Entity] = [
         OfflineCountSensor(coordinator, group_name, group_slug, entry.entry_id),
         OfflineDevicesSensor(coordinator, group_name, group_slug, entry.entry_id),
         GroupSummarySensor(coordinator, group_name, group_slug, entry.entry_id),
@@ -100,9 +101,7 @@ def _device_info(entry_id: str, group_slug: str, group_name: str) -> DeviceInfo:
     )
 
 
-class OfflineCountSensor(
-    CoordinatorEntity[EntityAvailabilityCoordinator], SensorEntity
-):
+class OfflineCountSensor(DedupCoordinatorSensor):
     """Sensor showing count of offline devices in the group."""
 
     _attr_icon = "mdi:alert-circle"
@@ -149,9 +148,7 @@ class OfflineCountSensor(
         }
 
 
-class OfflineDevicesSensor(
-    CoordinatorEntity[EntityAvailabilityCoordinator], SensorEntity
-):
+class OfflineDevicesSensor(DedupCoordinatorSensor):
     """Sensor showing comma-separated list of offline entity names."""
 
     _attr_icon = "mdi:devices"
@@ -204,9 +201,7 @@ class OfflineDevicesSensor(
         return entity_id.split(".")[-1].replace("_", " ").title()
 
 
-class DegradedDevicesSensor(
-    CoordinatorEntity[EntityAvailabilityCoordinator], SensorEntity
-):
+class DegradedDevicesSensor(DedupCoordinatorSensor):
     """Sensor showing devices with low battery."""
 
     _attr_icon = "mdi:battery-alert"
@@ -260,9 +255,7 @@ class DegradedDevicesSensor(
         return f"{name} ({device.battery_level}%)"
 
 
-class LowBatteryCountSensor(
-    CoordinatorEntity[EntityAvailabilityCoordinator], SensorEntity
-):
+class LowBatteryCountSensor(DedupCoordinatorSensor):
     """Sensor showing count of devices with low battery."""
 
     _attr_icon = "mdi:battery-alert-variant-outline"
@@ -293,9 +286,7 @@ class LowBatteryCountSensor(
         )
 
 
-class AvailabilitySensor(
-    CoordinatorEntity[EntityAvailabilityCoordinator], SensorEntity
-):
+class AvailabilitySensor(DedupCoordinatorSensor):
     """Sensor showing group availability % for a time window."""
 
     _attr_icon = "mdi:chart-line"
@@ -357,9 +348,7 @@ class AvailabilitySensor(
         return {"per_device": breakdown}
 
 
-class GroupSummarySensor(
-    CoordinatorEntity[EntityAvailabilityCoordinator], SensorEntity
-):
+class GroupSummarySensor(DedupCoordinatorSensor):
     """Sensor showing total entity count with detailed breakdown in attributes."""
 
     _attr_icon = "mdi:format-list-group"
@@ -449,9 +438,7 @@ class GroupSummarySensor(
         }
 
 
-class RecentlyOfflineSensor(
-    CoordinatorEntity[EntityAvailabilityCoordinator], SensorEntity
-):
+class RecentlyOfflineSensor(DedupCoordinatorSensor):
     """Sensor showing entities that went offline within the recovery window."""
 
     _attr_icon = "mdi:lan-disconnect"
@@ -514,9 +501,7 @@ class RecentlyOfflineSensor(
         }
 
 
-class RecentlyRecoveredSensor(
-    CoordinatorEntity[EntityAvailabilityCoordinator], SensorEntity
-):
+class RecentlyRecoveredSensor(DedupCoordinatorSensor):
     """Sensor showing entities that recovered from offline within the recovery window."""
 
     _attr_icon = "mdi:lan-connect"

--- a/custom_components/entity_availability/write_dedup.py
+++ b/custom_components/entity_availability/write_dedup.py
@@ -1,0 +1,83 @@
+"""Coordinator-aware entity bases that skip writes when state and attrs are unchanged.
+
+Home Assistant writes a new history row every time ``async_write_ha_state`` is
+called. ``CoordinatorEntity`` triggers that call on every coordinator tick
+(every ``SCAN_INTERVAL`` seconds), regardless of whether the entity's value
+actually changed. For sensors that aggregate offline counts, friendly-name
+lists, or per-device dictionaries, the value is identical the vast majority of
+ticks, so each refresh produces a redundant recorder row.
+
+The mixin and base classes in this module compare the just-computed
+``native_value``/``is_on`` and ``extra_state_attributes`` against the previously
+published pair and short-circuit ``async_write_ha_state`` when both match.
+The first write always goes through (the cache starts empty), so there is no
+risk of an entity never publishing an initial value.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.core import callback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import EntityAvailabilityCoordinator
+
+_UNSET: Any = object()
+
+
+class WriteDedupMixin:
+    """Cache the last published value and attrs and decide whether to write."""
+
+    _ea_last_value: Any = _UNSET
+    _ea_last_attrs: Any = _UNSET
+
+    def _ea_current_value(self) -> Any:
+        """Return the value subclasses publish (``native_value`` or ``is_on``)."""
+        raise NotImplementedError
+
+    def _ea_should_write(self) -> bool:
+        """Return True when value or attrs differ from the cached pair."""
+        value = self._ea_current_value()
+        attrs = getattr(self, "extra_state_attributes", None)
+        if value == self._ea_last_value and attrs == self._ea_last_attrs:
+            return False
+        self._ea_last_value = value
+        self._ea_last_attrs = attrs
+        return True
+
+
+class DedupCoordinatorSensor(
+    WriteDedupMixin,
+    CoordinatorEntity[EntityAvailabilityCoordinator],
+    SensorEntity,
+):
+    """``SensorEntity`` base that skips unchanged coordinator-driven writes."""
+
+    def _ea_current_value(self) -> Any:
+        return self.native_value
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Write only when the published value or attrs changed."""
+        if self._ea_should_write():
+            self.async_write_ha_state()
+
+
+class DedupCoordinatorBinarySensor(
+    WriteDedupMixin,
+    CoordinatorEntity[EntityAvailabilityCoordinator],
+    BinarySensorEntity,
+):
+    """``BinarySensorEntity`` base with the same dedup behavior."""
+
+    def _ea_current_value(self) -> Any:
+        return self.is_on
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Write only when the published value or attrs changed."""
+        if self._ea_should_write():
+            self.async_write_ha_state()

--- a/custom_components/entity_availability/write_dedup.py
+++ b/custom_components/entity_availability/write_dedup.py
@@ -8,10 +8,12 @@ lists, or per-device dictionaries, the value is identical the vast majority of
 ticks, so each refresh produces a redundant recorder row.
 
 The mixin and base classes in this module compare the just-computed
-``native_value``/``is_on`` and ``extra_state_attributes`` against the previously
-published pair and short-circuit ``async_write_ha_state`` when both match.
-The first write always goes through (the cache starts empty), so there is no
-risk of an entity never publishing an initial value.
+``native_value``/``is_on``, ``extra_state_attributes`` and ``available``
+against the previously published triple and short-circuit
+``async_write_ha_state`` when all three match. The first write always goes
+through (the cache starts empty), so an entity always publishes an initial
+state, and a coordinator failure that flips ``available`` from True to False
+still propagates even when the cached value would otherwise look unchanged.
 """
 
 from __future__ import annotations
@@ -29,24 +31,37 @@ _UNSET: Any = object()
 
 
 class WriteDedupMixin:
-    """Cache the last published value and attrs and decide whether to write."""
+    """Cache the last published triple and decide whether to write."""
 
     _ea_last_value: Any = _UNSET
     _ea_last_attrs: Any = _UNSET
+    _ea_last_available: Any = _UNSET
 
     def _ea_current_value(self) -> Any:
         """Return the value subclasses publish (``native_value`` or ``is_on``)."""
         raise NotImplementedError
 
     def _ea_should_write(self) -> bool:
-        """Return True when value or attrs differ from the cached pair."""
+        """Return True when value, attrs, or availability differ from cache."""
         value = self._ea_current_value()
         attrs = getattr(self, "extra_state_attributes", None)
-        if value == self._ea_last_value and attrs == self._ea_last_attrs:
+        available = getattr(self, "available", True)
+        if (
+            value == self._ea_last_value
+            and attrs == self._ea_last_attrs
+            and available == self._ea_last_available
+        ):
             return False
         self._ea_last_value = value
         self._ea_last_attrs = attrs
+        self._ea_last_available = available
         return True
+
+    def _ea_reset_cache(self) -> None:
+        """Clear cached publish state so the next call always writes."""
+        self._ea_last_value = _UNSET
+        self._ea_last_attrs = _UNSET
+        self._ea_last_available = _UNSET
 
 
 class DedupCoordinatorSensor(
@@ -61,9 +76,14 @@ class DedupCoordinatorSensor(
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Write only when the published value or attrs changed."""
+        """Write only when the published value, attrs, or availability changed."""
         if self._ea_should_write():
             self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clear cache on removal so a re-added instance writes its first state."""
+        self._ea_reset_cache()
+        await super().async_will_remove_from_hass()
 
 
 class DedupCoordinatorBinarySensor(
@@ -78,6 +98,11 @@ class DedupCoordinatorBinarySensor(
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Write only when the published value or attrs changed."""
+        """Write only when the published value, attrs, or availability changed."""
         if self._ea_should_write():
             self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clear cache on removal so a re-added instance writes its first state."""
+        self._ea_reset_cache()
+        await super().async_will_remove_from_hass()

--- a/tests/test_write_dedup.py
+++ b/tests/test_write_dedup.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -15,17 +16,34 @@ from custom_components.entity_availability.binary_sensor import AnyOfflineBinary
 from custom_components.entity_availability.combined_binary_sensor import (
     CombinedGroupAnyOfflineBinarySensor,
 )
-from custom_components.entity_availability.combined_sensor import CombinedGroupSensor
+from custom_components.entity_availability.combined_sensor import (
+    CombinedGroupSensor,
+    CombinedLowBatteryCountSensor,
+    CombinedLowBatterySensor,
+    CombinedOfflineEntitiesSensor,
+    CombinedRecentlyOfflineSensor,
+    CombinedRecentlyRecoveredSensor,
+)
 from custom_components.entity_availability.const import DOMAIN
 from custom_components.entity_availability.coordinator import (
     EntityAvailabilityCoordinator,
 )
 from custom_components.entity_availability.models import DeviceState
-from custom_components.entity_availability.sensor import OfflineCountSensor
+from custom_components.entity_availability.sensor import (
+    AvailabilitySensor,
+    DegradedDevicesSensor,
+    GroupSummarySensor,
+    LowBatteryCountSensor,
+    OfflineCountSensor,
+    OfflineDevicesSensor,
+    RecentlyOfflineSensor,
+    RecentlyRecoveredSensor,
+)
 from custom_components.entity_availability.write_dedup import (
     DedupCoordinatorBinarySensor,
     DedupCoordinatorSensor,
     WriteDedupMixin,
+    _UNSET,
 )
 
 
@@ -284,3 +302,399 @@ async def test_combined_binary_sensor_dedup(
     assert write.call_count == 2
 
     await sensor.async_will_remove_from_hass()
+
+
+# ----------------------------------------------------------------------------
+# Edge cases: None transitions, attrs {} ↔ None, nested mutables, multi-revert
+# ----------------------------------------------------------------------------
+
+
+def test_mixin_none_to_value_writes() -> None:
+    """Value flipping None -> int triggers a write after the first publish."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value: object = None
+            self.extra_state_attributes: dict = {}
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True  # first publish (None)
+    assert s._ea_should_write() is False  # still None, dedup
+    s.value = 42
+    assert s._ea_should_write() is True  # None -> 42
+    s.value = None
+    assert s._ea_should_write() is True  # 42 -> None
+
+
+def test_mixin_attrs_empty_to_none_and_back() -> None:
+    """Attrs flipping {} -> None and None -> {} both trigger writes."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes: dict | None = {}
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True
+    s.extra_state_attributes = None
+    assert s._ea_should_write() is True
+    s.extra_state_attributes = {}
+    assert s._ea_should_write() is True
+
+
+def test_mixin_nested_mutable_attrs_dedup() -> None:
+    """Identical-content nested lists/dicts dedup even when the wrapper is fresh."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes = {"entities": ["a", "b"], "count": 2}
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True
+    # Replace with a new dict carrying the same content — dict == is value-based.
+    s.extra_state_attributes = {"entities": ["a", "b"], "count": 2}
+    assert s._ea_should_write() is False
+    s.extra_state_attributes = {"entities": ["a", "b", "c"], "count": 3}
+    assert s._ea_should_write() is True
+
+
+def test_mixin_multi_step_revert_writes_each_change() -> None:
+    """Reverting to the original value still counts as a change vs the cached pair."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes: dict = {}
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True  # initial
+    s.value = 2
+    assert s._ea_should_write() is True
+    s.value = 1  # revert
+    assert s._ea_should_write() is True
+    assert s._ea_should_write() is False  # stable
+
+
+def test_mixin_reset_cache_forces_next_write() -> None:
+    """`_ea_reset_cache` makes the next `_ea_should_write` write through."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes: dict = {}
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True
+    assert s._ea_should_write() is False
+    s._ea_reset_cache()
+    assert s._ea_last_value is _UNSET
+    assert s._ea_last_attrs is _UNSET
+    assert s._ea_last_available is _UNSET
+    assert s._ea_should_write() is True  # cache cleared -> write
+
+
+def test_mixin_available_flip_writes() -> None:
+    """`available` flipping True -> False triggers a write even with same value."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes: dict = {}
+            self.available = True
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True
+    assert s._ea_should_write() is False
+    s.available = False
+    assert s._ea_should_write() is True
+    assert s._ea_should_write() is False
+    s.available = True
+    assert s._ea_should_write() is True
+
+
+# ----------------------------------------------------------------------------
+# Per-subclass dedup smoke tests
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sensor_cls",
+    [
+        OfflineCountSensor,
+        OfflineDevicesSensor,
+        DegradedDevicesSensor,
+        LowBatteryCountSensor,
+        GroupSummarySensor,
+        RecentlyOfflineSensor,
+        RecentlyRecoveredSensor,
+    ],
+)
+def test_each_dedup_sensor_subclass_skips_unchanged(
+    mock_coordinator, mock_hass, sensor_cls
+) -> None:
+    """Every concrete `DedupCoordinatorSensor` subclass dedups identical ticks."""
+    sensor = sensor_cls(mock_coordinator, "Test Group", "test_group", "eid")
+    sensor.hass = mock_hass
+    assert isinstance(sensor, DedupCoordinatorSensor)
+    with patch.object(sensor, "async_write_ha_state") as write:
+        sensor._handle_coordinator_update()
+        sensor._handle_coordinator_update()
+        sensor._handle_coordinator_update()
+    assert write.call_count == 1
+
+
+def test_availability_sensor_dedup_skips_unchanged(mock_coordinator, mock_hass) -> None:
+    """`AvailabilitySensor` (constructor signature differs) also dedups."""
+    sensor = AvailabilitySensor(
+        mock_coordinator, "Test Group", "test_group", "today", "eid"
+    )
+    sensor.hass = mock_hass
+    assert isinstance(sensor, DedupCoordinatorSensor)
+    with patch.object(sensor, "async_write_ha_state") as write:
+        sensor._handle_coordinator_update()
+        sensor._handle_coordinator_update()
+    assert write.call_count == 1
+
+
+def test_dedup_sensor_first_write_after_construction(mock_coordinator) -> None:
+    """A freshly constructed concrete sensor writes on its first refresh."""
+    sensor = OfflineCountSensor(mock_coordinator, "Test Group", "test_group", "eid")
+    # Cache must start unset.
+    assert sensor._ea_last_value is _UNSET
+    assert sensor._ea_last_attrs is _UNSET
+    assert sensor._ea_last_available is _UNSET
+    with patch.object(sensor, "async_write_ha_state") as write:
+        sensor._handle_coordinator_update()
+    assert write.call_count == 1
+
+
+def test_dedup_binary_sensor_first_write_after_construction(mock_coordinator) -> None:
+    """A freshly constructed binary sensor writes on its first refresh."""
+    sensor = AnyOfflineBinarySensor(mock_coordinator, "Test Group", "test_group", "eid")
+    assert sensor._ea_last_value is _UNSET
+    with patch.object(sensor, "async_write_ha_state") as write:
+        sensor._handle_coordinator_update()
+    assert write.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_dedup_sensor_remove_resets_cache(mock_coordinator) -> None:
+    """`async_will_remove_from_hass` clears the cache for the per-group sensor."""
+    sensor = OfflineCountSensor(mock_coordinator, "Test Group", "test_group", "eid")
+    sensor._ea_last_value = 5
+    sensor._ea_last_attrs = {"a": 1}
+    sensor._ea_last_available = False
+    with patch.object(
+        CoordinatorEntity, "async_will_remove_from_hass", new_callable=AsyncMock
+    ):
+        await sensor.async_will_remove_from_hass()
+    assert sensor._ea_last_value is _UNSET
+    assert sensor._ea_last_attrs is _UNSET
+    assert sensor._ea_last_available is _UNSET
+
+
+@pytest.mark.asyncio
+async def test_dedup_binary_sensor_remove_resets_cache(mock_coordinator) -> None:
+    """`async_will_remove_from_hass` clears the cache for the binary sensor."""
+    sensor = AnyOfflineBinarySensor(mock_coordinator, "Test Group", "test_group", "eid")
+    sensor._ea_last_value = True
+    sensor._ea_last_attrs = {"x": 1}
+    sensor._ea_last_available = True
+    with patch.object(
+        CoordinatorEntity, "async_will_remove_from_hass", new_callable=AsyncMock
+    ):
+        await sensor.async_will_remove_from_hass()
+    assert sensor._ea_last_value is _UNSET
+    assert sensor._ea_last_attrs is _UNSET
+    assert sensor._ea_last_available is _UNSET
+
+
+def test_dedup_sensor_available_flip_writes(mock_coordinator) -> None:
+    """Coordinator failure flipping `available` triggers a write even when value sticks."""
+    sensor = OfflineCountSensor(mock_coordinator, "Test Group", "test_group", "eid")
+    with patch.object(sensor, "async_write_ha_state") as write:
+        sensor._handle_coordinator_update()
+        # Same value/attrs -> dedup.
+        sensor._handle_coordinator_update()
+        # Coordinator's update fails: `available` flips True -> False but
+        # device_states (and so native_value/extra_state_attributes) stays the same.
+        mock_coordinator.last_update_success = False
+        sensor._handle_coordinator_update()
+    assert write.call_count == 2
+
+
+# ----------------------------------------------------------------------------
+# Combined sensor coverage: every concrete subclass exercises the listener path
+# ----------------------------------------------------------------------------
+
+
+def _build_combined_coord(mock_hass, mock_config_entry):
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(mock_hass, mock_config_entry)
+    coord._device_states = {
+        "binary_sensor.device_a": DeviceState(
+            entity_id="binary_sensor.device_a",
+            is_offline=True,
+            offline_since=datetime.now(timezone.utc),
+            recently_offline_at=datetime.now(timezone.utc),
+        ),
+    }
+    mock_hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = coord
+    return coord
+
+
+@pytest.mark.parametrize(
+    "sensor_cls",
+    [
+        CombinedGroupSensor,
+        CombinedOfflineEntitiesSensor,
+        CombinedLowBatterySensor,
+        CombinedLowBatteryCountSensor,
+        CombinedRecentlyOfflineSensor,
+        CombinedRecentlyRecoveredSensor,
+    ],
+)
+@pytest.mark.asyncio
+async def test_each_combined_sensor_subclass_dedups(
+    mock_hass: HomeAssistant, mock_config_entry, sensor_cls
+) -> None:
+    """Every combined sensor subclass dedups identical ticks via the mixin."""
+    coord = _build_combined_coord(mock_hass, mock_config_entry)
+    combined_entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Combined",
+        data={},
+        entry_id=f"combined_{sensor_cls.__name__}",
+    )
+    sensor = sensor_cls(
+        mock_hass,
+        combined_entry,
+        "Combined",
+        "combined",
+        [coord],
+        [mock_config_entry.entry_id],
+    )
+
+    captured: list = []
+
+    def _fake_add_listener(cb):
+        captured.append(cb)
+        return lambda: None
+
+    coord.async_add_listener = MagicMock(side_effect=_fake_add_listener)
+    with patch.object(sensor, "async_write_ha_state") as write:
+        await sensor.async_added_to_hass()
+        callback_fn = captured[0]
+        callback_fn()  # first
+        callback_fn()  # unchanged
+        callback_fn()  # unchanged
+    assert write.call_count == 1
+
+    await sensor.async_will_remove_from_hass()
+    # Cache reset on remove → next listener invocation publishes again.
+    assert sensor._ea_last_value is _UNSET
+    assert sensor._ea_last_attrs is _UNSET
+    assert sensor._ea_last_available is _UNSET
+
+
+@pytest.mark.asyncio
+async def test_combined_sensor_listener_uses_self_after_revert(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Listener captures `self`, so reverting state then back still publishes each step."""
+    coord = _build_combined_coord(mock_hass, mock_config_entry)
+    combined_entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Combined",
+        data={},
+        entry_id="combined_revert_eid",
+    )
+    sensor = CombinedGroupSensor(
+        mock_hass,
+        combined_entry,
+        "Combined",
+        "combined",
+        [coord],
+        [mock_config_entry.entry_id],
+    )
+
+    captured: list = []
+
+    def _fake_add_listener(cb):
+        captured.append(cb)
+        return lambda: None
+
+    coord.async_add_listener = MagicMock(side_effect=_fake_add_listener)
+    with patch.object(sensor, "async_write_ha_state") as write:
+        await sensor.async_added_to_hass()
+        cb = captured[0]
+        cb()  # initial: 1 write
+        coord.device_states["binary_sensor.device_a"].is_offline = False
+        cb()  # change: 2nd write
+        coord.device_states["binary_sensor.device_a"].is_offline = True
+        cb()  # revert: 3rd write
+        cb()  # stable: skipped
+    assert write.call_count == 3
+
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_combined_binary_sensor_remove_resets_cache(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Combined binary sensor's removal also clears the dedup cache."""
+    coord = _build_combined_coord(mock_hass, mock_config_entry)
+    combined_entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Combined",
+        data={},
+        entry_id="combined_b_remove_eid",
+    )
+    sensor = CombinedGroupAnyOfflineBinarySensor(
+        mock_hass,
+        combined_entry,
+        "Combined",
+        "combined",
+        [coord],
+        [mock_config_entry.entry_id],
+    )
+
+    captured: list = []
+
+    def _fake_add_listener(cb):
+        captured.append(cb)
+        return lambda: None
+
+    coord.async_add_listener = MagicMock(side_effect=_fake_add_listener)
+    await sensor.async_added_to_hass()
+    captured[0]()
+    assert sensor._ea_last_value is not _UNSET
+    await sensor.async_will_remove_from_hass()
+    assert sensor._ea_last_value is _UNSET
+    assert sensor._ea_last_attrs is _UNSET
+    assert sensor._ea_last_available is _UNSET

--- a/tests/test_write_dedup.py
+++ b/tests/test_write_dedup.py
@@ -1,0 +1,286 @@
+"""Tests for write-dedup mixin and integration into sensor platforms."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.entity_availability.binary_sensor import AnyOfflineBinarySensor
+from custom_components.entity_availability.combined_binary_sensor import (
+    CombinedGroupAnyOfflineBinarySensor,
+)
+from custom_components.entity_availability.combined_sensor import CombinedGroupSensor
+from custom_components.entity_availability.const import DOMAIN
+from custom_components.entity_availability.coordinator import (
+    EntityAvailabilityCoordinator,
+)
+from custom_components.entity_availability.models import DeviceState
+from custom_components.entity_availability.sensor import OfflineCountSensor
+from custom_components.entity_availability.write_dedup import (
+    DedupCoordinatorBinarySensor,
+    DedupCoordinatorSensor,
+    WriteDedupMixin,
+)
+
+
+@pytest.fixture
+def mock_coordinator(mock_hass: HomeAssistant, mock_config_entry):
+    """Coordinator with one offline device."""
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(mock_hass, mock_config_entry)
+        coord._device_states = {
+            "binary_sensor.device_a": DeviceState(
+                entity_id="binary_sensor.device_a",
+                is_offline=False,
+            ),
+            "binary_sensor.device_b": DeviceState(
+                entity_id="binary_sensor.device_b",
+                is_offline=True,
+                offline_since=datetime.now(timezone.utc) - timedelta(minutes=5),
+            ),
+        }
+        yield coord
+
+
+def test_mixin_first_call_writes() -> None:
+    """First call always returns True because cache is _UNSET."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes: dict = {"a": 1}
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True
+    # cache populated
+    assert s._ea_should_write() is False
+
+
+def test_mixin_value_change_writes() -> None:
+    """Different value triggers write; same value does not."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes: dict = {}
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True
+    assert s._ea_should_write() is False
+    s.value = 2
+    assert s._ea_should_write() is True
+    assert s._ea_should_write() is False
+
+
+def test_mixin_attrs_change_writes() -> None:
+    """Same value but changed attrs still triggers write."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes: dict = {"a": 1}
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True
+    assert s._ea_should_write() is False
+    s.extra_state_attributes = {"a": 2}
+    assert s._ea_should_write() is True
+
+
+def test_mixin_no_attrs_property() -> None:
+    """Subclass without extra_state_attributes uses None and still dedups."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value = 1
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True
+    assert s._ea_should_write() is False
+
+
+def test_mixin_default_value_raises() -> None:
+    """Base mixin's _ea_current_value is abstract."""
+    with pytest.raises(NotImplementedError):
+        WriteDedupMixin()._ea_current_value()
+
+
+def test_dedup_coordinator_sensor_skips_unchanged(mock_coordinator) -> None:
+    """`OfflineCountSensor._handle_coordinator_update` writes once, then dedups."""
+    sensor = OfflineCountSensor(mock_coordinator, "Test Group", "test_group", "eid")
+    with patch.object(sensor, "async_write_ha_state") as write:
+        sensor._handle_coordinator_update()
+        sensor._handle_coordinator_update()
+        sensor._handle_coordinator_update()
+    assert write.call_count == 1
+
+
+def test_dedup_coordinator_sensor_writes_on_change(mock_coordinator) -> None:
+    """Bringing a new device offline triggers a fresh write."""
+    sensor = OfflineCountSensor(mock_coordinator, "Test Group", "test_group", "eid")
+    with patch.object(sensor, "async_write_ha_state") as write:
+        sensor._handle_coordinator_update()
+        # Take device_a offline; native_value goes 1 -> 2
+        mock_coordinator.device_states["binary_sensor.device_a"].is_offline = True
+        mock_coordinator.device_states[
+            "binary_sensor.device_a"
+        ].offline_since = datetime.now(timezone.utc)
+        sensor._handle_coordinator_update()
+    assert write.call_count == 2
+
+
+def test_dedup_coordinator_binary_sensor_skips_unchanged(mock_coordinator) -> None:
+    """Binary sensor variant dedups too."""
+    sensor = AnyOfflineBinarySensor(mock_coordinator, "Test Group", "test_group", "eid")
+    with patch.object(sensor, "async_write_ha_state") as write:
+        sensor._handle_coordinator_update()
+        sensor._handle_coordinator_update()
+    assert write.call_count == 1
+
+
+def test_dedup_coordinator_binary_sensor_writes_on_change(mock_coordinator) -> None:
+    """Flipping every device online flips is_on False -> True path."""
+    sensor = AnyOfflineBinarySensor(mock_coordinator, "Test Group", "test_group", "eid")
+    with patch.object(sensor, "async_write_ha_state") as write:
+        sensor._handle_coordinator_update()
+        # Bring device_b back online
+        mock_coordinator.device_states["binary_sensor.device_b"].is_offline = False
+        sensor._handle_coordinator_update()
+    assert write.call_count == 2
+
+
+def test_dedup_subclasses_provide_current_value(mock_coordinator) -> None:
+    """Sensor subclass returns native_value, binary subclass returns is_on."""
+    s = OfflineCountSensor(mock_coordinator, "Test Group", "test_group", "eid")
+    assert isinstance(s, DedupCoordinatorSensor)
+    assert s._ea_current_value() == s.native_value
+
+    b = AnyOfflineBinarySensor(mock_coordinator, "Test Group", "test_group", "eid")
+    assert isinstance(b, DedupCoordinatorBinarySensor)
+    assert b._ea_current_value() == b.is_on
+
+
+@pytest.mark.asyncio
+async def test_combined_sensor_dedup(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Combined sensor's added-to-hass listener dedups using the mixin."""
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(mock_hass, mock_config_entry)
+        coord._device_states = {
+            "binary_sensor.device_a": DeviceState(
+                entity_id="binary_sensor.device_a",
+                is_offline=True,
+                offline_since=datetime.now(timezone.utc),
+            ),
+        }
+
+    mock_hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = coord
+
+    combined_entry = MockConfigEntry(
+        version=1, domain=DOMAIN, title="Combined", data={}, entry_id="combined_eid"
+    )
+    sensor = CombinedGroupSensor(
+        mock_hass,
+        combined_entry,
+        "Combined",
+        "combined",
+        [coord],
+        [mock_config_entry.entry_id],
+    )
+
+    captured: list = []
+
+    def _fake_add_listener(cb):
+        captured.append(cb)
+
+        def _unsub():
+            return None
+
+        return _unsub
+
+    coord.async_add_listener = MagicMock(side_effect=_fake_add_listener)
+    with patch.object(sensor, "async_write_ha_state") as write:
+        await sensor.async_added_to_hass()
+        assert captured, "listener registered"
+        callback_fn = captured[0]
+        callback_fn()  # first invocation -> write
+        callback_fn()  # unchanged -> skip
+        # Mutate value
+        coord.device_states["binary_sensor.device_a"].is_offline = False
+        callback_fn()  # changed -> write
+    assert write.call_count == 2
+
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_combined_binary_sensor_dedup(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Combined binary sensor's added-to-hass listener dedups."""
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(mock_hass, mock_config_entry)
+        coord._device_states = {
+            "binary_sensor.device_a": DeviceState(
+                entity_id="binary_sensor.device_a",
+                is_offline=True,
+                offline_since=datetime.now(timezone.utc),
+            ),
+        }
+
+    mock_hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = coord
+
+    combined_entry = MockConfigEntry(
+        version=1, domain=DOMAIN, title="Combined", data={}, entry_id="combined_eid_b"
+    )
+    sensor = CombinedGroupAnyOfflineBinarySensor(
+        mock_hass,
+        combined_entry,
+        "Combined",
+        "combined",
+        [coord],
+        [mock_config_entry.entry_id],
+    )
+
+    captured: list = []
+
+    def _fake_add_listener(cb):
+        captured.append(cb)
+        return lambda: None
+
+    coord.async_add_listener = MagicMock(side_effect=_fake_add_listener)
+    with patch.object(sensor, "async_write_ha_state") as write:
+        await sensor.async_added_to_hass()
+        callback_fn = captured[0]
+        callback_fn()
+        callback_fn()
+        coord.device_states["binary_sensor.device_a"].is_offline = False
+        callback_fn()
+    assert write.call_count == 2
+
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary

Reduce Home Assistant recorder writes for the integration's aggregate sensors by skipping `async_write_ha_state` when the published `native_value`/`is_on`, `extra_state_attributes`, AND `available` all match the previously published triple. Coordinator continues to tick every 30 s; only the redundant re-publish is suppressed.

## Why

`CoordinatorEntity._handle_coordinator_update` calls `async_write_ha_state` on every coordinator update regardless of whether anything changed. For sensors like `Offline Count`, `Offline Entities`, `Group Summary`, `Recently Offline`, `Recently Recovered`, `Low Battery`, `Low Battery Count`, `Any Offline` (binary), and their combined-group counterparts, the value is identical the vast majority of ticks on a healthy network — so each tick produces a redundant recorder row.

## Approach

- `WriteDedupMixin` (`write_dedup.py`) caches the last published `(value, attrs, available)` triple and decides whether to write. `_ea_reset_cache` clears the cache on entity removal so a re-added instance always publishes its first state.
- `DedupCoordinatorSensor` / `DedupCoordinatorBinarySensor` bases override `_handle_coordinator_update` (single-coordinator path: `sensor.py`, `binary_sensor.py`).
- The combined-group bases (`combined_sensor.py`, `combined_binary_sensor.py`) maintain their own listener wiring across multiple coordinators; the mixin is applied directly inside the manual `_on_coordinator_update` callback.
- `available` is part of the dedup key so a coordinator failure flipping `coordinator.last_update_success` from True to False still publishes (otherwise the entity would stay "available" with stale data).
- All four bases reset the dedup cache in `async_will_remove_from_hass`.

## Tests

`tests/test_write_dedup.py` — 39 tests, including:
- Mixin: first-call writes, value/attrs/available change paths, None ↔ real value, attrs `{} ↔ None`, nested mutable-list dedup, multi-step revert, `_ea_reset_cache` semantics.
- Parametrized smoke tests for every concrete `DedupCoordinatorSensor` subclass (8: `OfflineCountSensor`, `OfflineDevicesSensor`, `DegradedDevicesSensor`, `LowBatteryCountSensor`, `GroupSummarySensor`, `RecentlyOfflineSensor`, `RecentlyRecoveredSensor`, `AvailabilitySensor`) and every `CombinedSensorBase` subclass (6).
- First-write-after-construction tests for both sensor and binary sensor.
- `async_will_remove_from_hass` cache-reset tests for all four bases.
- Coordinator-failure test: `available` flips True → False, dedup must publish even though `native_value`/`extra_state_attributes` are identical.
- Listener-closure correctness across revert ticks.

Full suite: **370 tests pass.** Coverage: **100% across all integration modules** including `write_dedup.py` (48/48 stmts). `ruff format --check` + `ruff check` clean.

## Release

- `manifest.json`: `0.3.5` → `0.3.6-beta.1` (patch + beta — internal optimization, no user-facing API change).
- `CHANGELOG.md`: new `0.3.6-beta.1` entry under Changed.
- `README.md`: feature bullet for recorder-friendly writes.

After CI passes, this can be tagged `0.3.6-beta.1` for testing before promoting to a stable `0.3.6` release.

## Review history

PR initially reviewed by 5 parallel agents + an external reviewer. Two real bugs found and fixed in the latest commit:
1. 🔴 dedup key omitted `available` — coordinator failures suppressed (FIXED).
2. 🔴 cache not reset on `async_will_remove_from_hass` — re-added instance could swallow first write (FIXED).
