### PR TITLE
fix: resolve 10 high + 8 medium audit findings (0.3.7)

### DIFF
--- a/custom_components/entity_availability/__init__.py
+++ b/custom_components/entity_availability/__init__.py
@@ -85,6 +85,7 @@ async def _async_install_card(hass: HomeAssistant) -> None:
     source = Path(__file__).parent / "frontend" / CARD_FILENAME
     if not source.exists():
         _LOGGER.warning("Card JS not found at %s", source)
+        domain_data.pop(_CARD_INSTALLED_KEY, None)
         return
 
     version = await hass.async_add_executor_job(_get_version)
@@ -96,7 +97,11 @@ async def _async_install_card(hass: HomeAssistant) -> None:
     except Exception:  # noqa: BLE001
         _LOGGER.debug("Static path %s already registered", CARD_URL)
 
-    await _async_register_lovelace_resource(hass, version)
+    try:
+        await _async_register_lovelace_resource(hass, version)
+    except Exception:  # noqa: BLE001
+        _LOGGER.warning("Failed to register Lovelace resource for %s", CARD_URL)
+        domain_data.pop(_CARD_INSTALLED_KEY, None)
 
 
 async def _async_register_lovelace_resource(hass: HomeAssistant, version: str) -> None:

--- a/custom_components/entity_availability/__init__.py
+++ b/custom_components/entity_availability/__init__.py
@@ -78,6 +78,10 @@ async def _async_install_card(hass: HomeAssistant) -> None:
     if domain_data.get(_CARD_INSTALLED_KEY):
         return
 
+    # Claim the slot before first await to prevent TOCTOU race when multiple
+    # entries finish setup concurrently — only one proceeds past this point.
+    domain_data[_CARD_INSTALLED_KEY] = True
+
     source = Path(__file__).parent / "frontend" / CARD_FILENAME
     if not source.exists():
         _LOGGER.warning("Card JS not found at %s", source)
@@ -93,7 +97,6 @@ async def _async_install_card(hass: HomeAssistant) -> None:
         _LOGGER.debug("Static path %s already registered", CARD_URL)
 
     await _async_register_lovelace_resource(hass, version)
-    hass.data[DOMAIN][_CARD_INSTALLED_KEY] = True
 
 
 async def _async_register_lovelace_resource(hass: HomeAssistant, version: str) -> None:
@@ -147,10 +150,11 @@ async def _async_register_lovelace_resource(hass: HomeAssistant, version: str) -
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    if entry.data.get(CONF_ENTRY_TYPE) == ENTRY_TYPE_COMBINED:
-        return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    is_combined = entry.data.get(CONF_ENTRY_TYPE) == ENTRY_TYPE_COMBINED
 
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if not is_combined and unload_ok:
         hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
 
     remaining = [

--- a/custom_components/entity_availability/binary_sensor.py
+++ b/custom_components/entity_availability/binary_sensor.py
@@ -31,6 +31,8 @@ async def async_setup_entry(
     coordinator: EntityAvailabilityCoordinator = hass.data[DOMAIN][entry.entry_id]
     group_name = entry.data[CONF_GROUP_NAME]
     group_slug = re.sub(r"[^a-z0-9_]+", "_", group_name.lower()).strip("_")
+    if not group_slug:
+        group_slug = entry.entry_id[:8].lower()
 
     async_add_entities(
         [
@@ -64,25 +66,26 @@ class AnyOfflineBinarySensor(DedupCoordinatorBinarySensor):
             manufacturer="Entity Availability",
             entry_type=DeviceEntryType.SERVICE,
         )
+        self._offline_entities: list[str] = []
 
-    @property
-    def is_on(self) -> bool:
-        """Return True if any non-suppressed entity is offline."""
-        for device in self.coordinator.device_states.values():
-            if device.is_suppressed:
-                continue
-            if device.is_offline:
-                return True
-        return False
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return offline entity details."""
-        offline_entities = [
+    def _refresh_offline(self) -> list[str]:
+        """Snapshot offline entities once; shared by is_on and extra_state_attributes."""
+        self._offline_entities = [
             d.entity_id
             for d in self.coordinator.device_states.values()
             if d.is_offline and not d.is_suppressed
         ]
+        return self._offline_entities
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if any non-suppressed entity is offline."""
+        return len(self._refresh_offline()) > 0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return offline entity details."""
+        offline_entities = self._offline_entities
         return {
             "offline_entities": offline_entities,
             "offline_count": len(offline_entities),

--- a/custom_components/entity_availability/binary_sensor.py
+++ b/custom_components/entity_availability/binary_sensor.py
@@ -85,7 +85,7 @@ class AnyOfflineBinarySensor(DedupCoordinatorBinarySensor):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return offline entity details."""
-        offline_entities = self._offline_entities
+        offline_entities = self._refresh_offline()
         return {
             "offline_entities": offline_entities,
             "offline_count": len(offline_entities),

--- a/custom_components/entity_availability/binary_sensor.py
+++ b/custom_components/entity_availability/binary_sensor.py
@@ -69,7 +69,7 @@ class AnyOfflineBinarySensor(DedupCoordinatorBinarySensor):
         self._offline_entities: list[str] = []
 
     def _refresh_offline(self) -> list[str]:
-        """Snapshot offline entities once; shared by is_on and extra_state_attributes."""
+        """Compute and return the current list of offline, non-suppressed entity IDs."""
         self._offline_entities = [
             d.entity_id
             for d in self.coordinator.device_states.values()

--- a/custom_components/entity_availability/combined_binary_sensor.py
+++ b/custom_components/entity_availability/combined_binary_sensor.py
@@ -49,6 +49,7 @@ class CombinedGroupAnyOfflineBinarySensor(WriteDedupMixin, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
     _attr_icon = "mdi:alert"
     _attr_has_entity_name = True
+    _attr_should_poll = False
 
     def _ea_current_value(self) -> Any:
         return self.is_on
@@ -101,7 +102,18 @@ class CombinedGroupAnyOfflineBinarySensor(WriteDedupMixin, BinarySensorEntity):
 
     def _active_coordinators(self) -> list[EntityAvailabilityCoordinator]:
         domain_data = self.hass.data.get(DOMAIN, {})
-        return [c for c in self._coordinators if c.entry.entry_id in domain_data]
+        return [
+            c
+            for c in self._coordinators
+            if isinstance(
+                domain_data.get(c.entry.entry_id), EntityAvailabilityCoordinator
+            )
+        ]
+
+    @property
+    def available(self) -> bool:
+        """Return False when all source coordinators have been unloaded."""
+        return len(self._active_coordinators()) > 0
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/entity_availability/combined_binary_sensor.py
+++ b/custom_components/entity_availability/combined_binary_sensor.py
@@ -28,6 +28,8 @@ async def async_setup_entry(
     """Set up combined group binary sensors."""
     group_name = entry.data[CONF_GROUP_NAME]
     group_slug = re.sub(r"[^a-z0-9_]+", "_", group_name.lower()).strip("_")
+    if not group_slug:
+        group_slug = entry.entry_id[:8].lower()
     combined_entry_ids: list[str] = entry.data.get(CONF_COMBINED_GROUPS, [])
 
     coordinators: list[EntityAvailabilityCoordinator] = [

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -108,6 +108,9 @@ class CombinedSensorBase(WriteDedupMixin, SensorEntity):
         self._unsub_listeners: list[Callable[[], None]] = []
 
     async def async_added_to_hass(self) -> None:
+        """Subscribe to all included coordinators."""
+        await super().async_added_to_hass()
+
         @callback
         def _on_coordinator_update() -> None:
             if self._ea_should_write():
@@ -119,14 +122,22 @@ class CombinedSensorBase(WriteDedupMixin, SensorEntity):
             )
 
     async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from all coordinators."""
         for unsub in self._unsub_listeners:
             unsub()
         self._unsub_listeners.clear()
         self._ea_reset_cache()
+        await super().async_will_remove_from_hass()
 
     def _active_coordinators(self) -> list[EntityAvailabilityCoordinator]:
         domain_data = self.hass.data.get(DOMAIN, {})
-        return [c for c in self._coordinators if c.entry.entry_id in domain_data]
+        return [
+            c
+            for c in self._coordinators
+            if isinstance(
+                domain_data.get(c.entry.entry_id), EntityAvailabilityCoordinator
+            )
+        ]
 
 
 class CombinedGroupSensor(CombinedSensorBase):
@@ -206,7 +217,8 @@ class CombinedGroupSensor(CombinedSensorBase):
                 if d.is_degraded and not d.is_suppressed and d.battery_level is not None
             ]
             gname = coord.group_name
-            groups[gname] = {
+            groups[coord.entry.entry_id] = {
+                "name": gname,
                 "total": g_total,
                 "online": g_online,
                 "offline": g_offline,

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -36,6 +36,8 @@ async def async_setup_entry(
     """Set up combined group sensors."""
     group_name = entry.data[CONF_GROUP_NAME]
     group_slug = re.sub(r"[^a-z0-9_]+", "_", group_name.lower()).strip("_")
+    if not group_slug:
+        group_slug = entry.entry_id[:8].lower()
     combined_entry_ids: list[str] = entry.data.get(CONF_COMBINED_GROUPS, [])
 
     coordinators: list[EntityAvailabilityCoordinator] = [
@@ -197,7 +199,9 @@ class CombinedGroupSensor(CombinedSensorBase):
                 g_battery_powered = sum(1 for v in battery_map.values() if v)
             else:
                 g_battery_powered = sum(
-                    1 for d in states.values() if d.battery_level is not None
+                    1
+                    for d in states.values()
+                    if d.battery_level is not None and not d.is_suppressed
                 )
             total += g_total
             online += g_online

--- a/custom_components/entity_availability/config_flow.py
+++ b/custom_components/entity_availability/config_flow.py
@@ -95,7 +95,7 @@ class EntityAvailabilityConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors[CONF_ENTITIES] = "no_entities"
             else:
                 await self.async_set_unique_id(
-                    f"{DOMAIN}_group_{group_name.lower().replace(' ', '_')}"
+                    f"{DOMAIN}_{group_name.lower().replace(' ', '_')}"
                 )
                 self._abort_if_unique_id_configured()
 

--- a/custom_components/entity_availability/config_flow.py
+++ b/custom_components/entity_availability/config_flow.py
@@ -86,16 +86,16 @@ class EntityAvailabilityConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            group_name = user_input[CONF_GROUP_NAME]
+            group_name = user_input[CONF_GROUP_NAME].strip()
             entities = user_input[CONF_ENTITIES]
 
-            if not group_name.strip():
+            if not group_name:
                 errors[CONF_GROUP_NAME] = "empty_group_name"
             elif not entities:
                 errors[CONF_ENTITIES] = "no_entities"
             else:
                 await self.async_set_unique_id(
-                    f"{DOMAIN}_{group_name.lower().replace(' ', '_')}"
+                    f"{DOMAIN}_group_{group_name.lower().replace(' ', '_')}"
                 )
                 self._abort_if_unique_id_configured()
 
@@ -135,10 +135,10 @@ class EntityAvailabilityConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="not_enough_groups")
 
         if user_input is not None:
-            group_name = user_input[CONF_GROUP_NAME]
+            group_name = user_input[CONF_GROUP_NAME].strip()
             combined_groups = user_input[CONF_COMBINED_GROUPS]
 
-            if not group_name.strip():
+            if not group_name:
                 errors[CONF_GROUP_NAME] = "empty_group_name"
             elif len(combined_groups) < 2:
                 errors[CONF_COMBINED_GROUPS] = "not_enough_groups_selected"
@@ -511,10 +511,10 @@ class CombinedGroupOptionsFlow(OptionsFlow):
         ]
 
         if user_input is not None:
-            group_name = user_input[CONF_GROUP_NAME]
+            group_name = user_input[CONF_GROUP_NAME].strip()
             combined_groups = user_input[CONF_COMBINED_GROUPS]
 
-            if not group_name.strip():
+            if not group_name:
                 errors[CONF_GROUP_NAME] = "empty_group_name"
             elif len(combined_groups) < 2:
                 errors[CONF_COMBINED_GROUPS] = "not_enough_groups_selected"
@@ -530,6 +530,10 @@ class CombinedGroupOptionsFlow(OptionsFlow):
                 return self.async_create_entry(title="", data={})
 
         current = self.config_entry.data
+        valid_ids = {e.entry_id for e in existing_groups}
+        default_combined = [
+            eid for eid in current.get(CONF_COMBINED_GROUPS, []) if eid in valid_ids
+        ]
         group_options = [
             selector.SelectOptionDict(value=e.entry_id, label=e.title)
             for e in existing_groups
@@ -544,7 +548,7 @@ class CombinedGroupOptionsFlow(OptionsFlow):
                     ): str,
                     vol.Required(
                         CONF_COMBINED_GROUPS,
-                        default=current.get(CONF_COMBINED_GROUPS, []),
+                        default=default_combined,
                     ): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=group_options,

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -80,7 +80,6 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
         self._last_update: datetime | None = None
         self._startup_time: datetime | None = None
         self._unsub_state_change: CALLBACK_TYPE | None = None
-        self._debounce_cancel: CALLBACK_TYPE | None = None
         self._debounce_cancel_map: dict[str, CALLBACK_TYPE] = {}
         self._device_states: dict[str, DeviceState] = {}
         self._suppressed: dict[str, datetime | None] = {}
@@ -154,9 +153,6 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
         if self._unsub_state_change is not None:
             self._unsub_state_change()
             self._unsub_state_change = None
-        if self._debounce_cancel is not None:
-            self._debounce_cancel()
-            self._debounce_cancel = None
         for cancel in self._debounce_cancel_map.values():
             cancel()
         self._debounce_cancel_map.clear()

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -81,6 +81,7 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
         self._startup_time: datetime | None = None
         self._unsub_state_change: CALLBACK_TYPE | None = None
         self._debounce_cancel: CALLBACK_TYPE | None = None
+        self._debounce_cancel_map: dict[str, CALLBACK_TYPE] = {}
         self._device_states: dict[str, DeviceState] = {}
         self._suppressed: dict[str, datetime | None] = {}
         self._update_count: int = 0
@@ -156,6 +157,9 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
         if self._debounce_cancel is not None:
             self._debounce_cancel()
             self._debounce_cancel = None
+        for cancel in self._debounce_cancel_map.values():
+            cancel()
+        self._debounce_cancel_map.clear()
         # Final save
         if self._dirty:
             _LOGGER.debug("[%s] Saving dirty storage on shutdown", self.group_name)
@@ -298,7 +302,7 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
 
     @callback
     def _handle_state_change(self, event: Event) -> None:
-        """Handle state change for a monitored entity (debounced)."""
+        """Handle state change for a monitored entity (debounced per entity)."""
         entity_id = event.data.get("entity_id", "unknown")
         new_state = event.data.get("new_state")
         old_state = event.data.get("old_state")
@@ -309,18 +313,20 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
             old_state.state if old_state else "None",
             new_state.state if new_state else "None",
         )
-        # Cancel any pending debounce timer
-        if self._debounce_cancel is not None:
-            self._debounce_cancel()
+        # Per-entity debounce: cancel only this entity's pending timer.
+        # A shared group-wide timer would drop all but the last entity's
+        # state change when multiple entities change within the debounce window.
+        existing = self._debounce_cancel_map.get(entity_id)
+        if existing is not None:
+            existing()
 
         @callback
         def _debounced_refresh(_now: Any) -> None:
             """Trigger a coordinator refresh after debounce."""
-            self._debounce_cancel = None
+            self._debounce_cancel_map.pop(entity_id, None)
             self.hass.async_create_task(self.async_request_refresh())
 
-        # Schedule a debounced refresh
-        self._debounce_cancel = async_call_later(
+        self._debounce_cancel_map[entity_id] = async_call_later(
             self.hass, _STATE_CHANGE_DEBOUNCE, _debounced_refresh
         )
 
@@ -493,8 +499,15 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
         self._dirty = True
         self._update_count += 1
         if self._update_count >= _SAVE_INTERVAL_UPDATES:
-            self._update_count = 0
-            await self._async_save_storage()
+            try:
+                await self._async_save_storage()
+            except Exception:  # noqa: BLE001
+                _LOGGER.warning(
+                    "[%s] Failed to save storage — will retry next interval",
+                    self.group_name,
+                )
+            finally:
+                self._update_count = 0
 
         return EntityAvailabilityData(
             devices=dict(self._device_states),

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -186,6 +186,8 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                     else:
                         try:
                             until = datetime.fromisoformat(until_str)
+                            if until.tzinfo is None:
+                                until = until.replace(tzinfo=timezone.utc)
                             if until > datetime.now(timezone.utc):
                                 self._suppressed[entity_id] = until
                                 _LOGGER.debug(
@@ -220,6 +222,8 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                         raw = ds.get("recently_offline_at")
                         if raw:
                             ts = datetime.fromisoformat(raw)
+                            if ts.tzinfo is None:
+                                ts = ts.replace(tzinfo=timezone.utc)
                             window_seconds = (
                                 self.entry.data.get(
                                     CONF_RECOVERY_WINDOW, DEFAULT_RECOVERY_WINDOW
@@ -241,7 +245,11 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
         for entity_id, device in self._device_states.items():
             if entity_id not in self._entities:
                 continue
-            if device.is_offline or device.cooldown_start is not None:
+            if (
+                device.is_offline
+                or device.cooldown_start is not None
+                or device.recently_offline_at is not None
+            ):
                 device_states_data[entity_id] = {
                     "is_offline": device.is_offline,
                     "offline_since": device.offline_since.isoformat()
@@ -351,9 +359,13 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                     device.is_suppressed = False
                     device.suppress_until = None
                     self._suppressed.pop(entity_id, None)
+                    self._dirty = True
 
-            # Skip suppressed devices for availability tracking
+            # Skip suppressed devices for availability tracking;
+            # clear degraded/stale flags so suppressed entities don't surface
             if device.is_suppressed:
+                device.is_degraded = False
+                device.is_stale = False
                 _LOGGER.debug(
                     "[%s] Skipping suppressed entity %s (until=%s)",
                     self.group_name,
@@ -464,8 +476,13 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                 self._availability_storage.record_online(entity_id, elapsed, now)
 
             # Record offline time (offline seconds are implicitly tracked
-            # as total_seconds - online_seconds in the bucket)
-            if device.is_offline:
+            # as total_seconds - online_seconds in the bucket).
+            # Skip if still in cooldown — recorded as online above.
+            if device.is_offline and not (
+                is_bad
+                and device.cooldown_start is not None
+                and (now - device.cooldown_start).total_seconds() < self._cooldown
+            ):
                 self._availability_storage.record_offline(entity_id, elapsed, now)
 
             # Degraded = not offline but battery low or stale
@@ -480,8 +497,8 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
             await self._async_save_storage()
 
         return EntityAvailabilityData(
-            devices=self._device_states,
-            buckets=self._availability_storage.buckets,
+            devices=dict(self._device_states),
+            buckets=dict(self._availability_storage.buckets),
         )
 
     def _get_battery_level(self, entity_id: str) -> int | None:

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -207,19 +207,25 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                     device = DeviceState(entity_id=entity_id)
                     device.is_offline = ds.get("is_offline", False)
                     try:
-                        device.offline_since = (
-                            datetime.fromisoformat(ds["offline_since"])
-                            if ds.get("offline_since")
-                            else None
-                        )
+                        raw_os = ds.get("offline_since")
+                        if raw_os:
+                            ts = datetime.fromisoformat(raw_os)
+                            if ts.tzinfo is None:
+                                ts = ts.replace(tzinfo=timezone.utc)
+                            device.offline_since = ts
+                        else:
+                            device.offline_since = None
                     except (ValueError, TypeError):
                         device.offline_since = None
                     try:
-                        device.cooldown_start = (
-                            datetime.fromisoformat(ds["cooldown_start"])
-                            if ds.get("cooldown_start")
-                            else None
-                        )
+                        raw_cs = ds.get("cooldown_start")
+                        if raw_cs:
+                            ts = datetime.fromisoformat(raw_cs)
+                            if ts.tzinfo is None:
+                                ts = ts.replace(tzinfo=timezone.utc)
+                            device.cooldown_start = ts
+                        else:
+                            device.cooldown_start = None
                     except (ValueError, TypeError):
                         device.cooldown_start = None
                     try:

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -801,7 +801,9 @@ class EntityAvailabilityCard extends LitElement {
     if (entries.length === 0) return nothing;
 
     const sortBy = this._config.group_sort_by || "name_asc";
-    entries.sort(([nameA, gA], [nameB, gB]) => {
+    entries.sort(([, gA], [, gB]) => {
+      const nameA = gA.name ?? "";
+      const nameB = gB.name ?? "";
       if (sortBy === "name_desc") return nameB.localeCompare(nameA);
       if (sortBy === "offline_desc") {
         const diff = (gB.offline ?? 0) - (gA.offline ?? 0);
@@ -825,9 +827,9 @@ class EntityAvailabilityCard extends LitElement {
           <span style="text-align:center">Offline</span>
           <span style="text-align:center">Bat.</span>
         </div>
-        ${entries.map(([name, g]) => html`
+        ${entries.map(([, g]) => html`
           <div class="group-breakdown-row">
-            <span class="group-breakdown-name">${name}</span>
+            <span class="group-breakdown-name">${g.name ?? ""}</span>
             <span class="group-breakdown-count online">${g.online ?? 0}</span>
             <span class="group-breakdown-count ${g.offline > 0 ? "offline" : "neutral"}">${g.offline ?? 0}</span>
             <span class="group-breakdown-count ${g.low_battery > 0 ? "battery" : "neutral"}">${g.low_battery ?? 0}</span>

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1,9 +1,9 @@
 /**
- * Entity Availability Card v0.3.6
+ * Entity Availability Card v0.3.7
  * Custom Lovelace card for the Home Assistant Entity Availability integration.
  */
 
-const CARD_VERSION = "0.3.6";
+const CARD_VERSION = "0.3.7";
 
 console.info(
   `%c ENTITY-AVAILABILITY-CARD %c v${CARD_VERSION} %c — github.com/italo-lombardi `,

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1,9 +1,9 @@
 /**
- * Entity Availability Card v0.3.5
+ * Entity Availability Card v0.3.6
  * Custom Lovelace card for the Home Assistant Entity Availability integration.
  */
 
-const CARD_VERSION = "0.3.5";
+const CARD_VERSION = "0.3.6";
 
 console.info(
   `%c ENTITY-AVAILABILITY-CARD %c v${CARD_VERSION} %c — github.com/italo-lombardi `,
@@ -621,7 +621,7 @@ class EntityAvailabilityCard extends LitElement {
           ${this._renderHeader(title, statusColor, statusText)}
           <div class="divider"></div>
           ${this._renderStats(online, offline, lowBattery, suppressed)}
-          ${suppressed > 0 ? html`<div class="suppressed-banner">${suppressed} entity${suppressed > 1 ? "ies" : ""} suppressed</div>` : nothing}
+          ${suppressed > 0 ? html`<div class="suppressed-banner">${suppressed} ${suppressed > 1 ? "entities" : "entity"} suppressed</div>` : nothing}
           ${this._config.show_entities ? this._renderCombinedGroupBreakdown(groups) : nothing}
         </ha-card>
       `;
@@ -668,7 +668,7 @@ class EntityAvailabilityCard extends LitElement {
         ${this._renderHeader(title, statusColor, statusText)}
         <div class="divider"></div>
         ${this._renderStats(online, offline, lowBattery, suppressed)}
-        ${suppressed > 0 ? html`<div class="suppressed-banner">${suppressed} entity${suppressed > 1 ? "ies" : ""} suppressed</div>` : nothing}
+        ${suppressed > 0 ? html`<div class="suppressed-banner">${suppressed} ${suppressed > 1 ? "entities" : "entity"} suppressed</div>` : nothing}
         ${this._config.show_availability ? this._renderAvailability(prefix) : nothing}
         ${this._config.show_entities ? this._renderEntityList(entities, batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities) : nothing}
         ${this._config.show_actions ? this._renderActions(prefix) : nothing}
@@ -1126,8 +1126,14 @@ class EntityAvailabilityCard extends LitElement {
 
   async _handleUnsuppressAll(e) {
     e.stopPropagation();
-    const prefix = `entity_availability_${this._config.group}`;
-    const summary = this._getEntity(`sensor.${prefix}_group_summary`);
+    const isCombined = this._isCombinedGroup();
+    const prefix = isCombined
+      ? `entity_availability_combined_${this._config.group}`
+      : `entity_availability_${this._config.group}`;
+    const summaryId = isCombined
+      ? `sensor.${prefix}_combined_summary`
+      : `sensor.${prefix}_group_summary`;
+    const summary = this._getEntity(summaryId);
     const entities = summary?.attributes?.entities || [];
     for (const entityId of entities) {
       await this.hass.callService("entity_availability", "unsuppress", {

--- a/custom_components/entity_availability/manifest.json
+++ b/custom_components/entity_availability/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/italo-lombardi/Home-Assistant-EntityAvailability/issues",
     "quality_scale": "custom",
     "requirements": [],
-    "version": "0.3.6"
+    "version": "0.3.7"
 }

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -472,7 +472,7 @@ class RecentlyOfflineSensor(DedupCoordinatorSensor):
         return self.coordinator.recovery_window_minutes * 60
 
     def _refresh_cache(self) -> list:
-        """Recompute matching devices once per call; cache for the other property."""
+        """Compute and return devices that went offline within the recovery window."""
         now = datetime.now(timezone.utc)
         cutoff = self._window_seconds()
         self._cached_devices = [
@@ -538,7 +538,7 @@ class RecentlyRecoveredSensor(DedupCoordinatorSensor):
         return self.coordinator.recovery_window_minutes * 60
 
     def _refresh_cache(self) -> list:
-        """Recompute matching devices once per call; cache for the other property."""
+        """Compute and return devices that went offline within the recovery window."""
         now = datetime.now(timezone.utc)
         cutoff = self._window_seconds()
         self._cached_devices = [

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -398,13 +398,18 @@ class GroupSummarySensor(DedupCoordinatorSensor):
             battery_powered = sum(1 for v in battery_map.values() if v)
         else:
             battery_powered = sum(
-                1 for d in states.values() if d.battery_level is not None
+                1
+                for eid in self.coordinator.monitored_entities
+                if states.get(eid) and states[eid].battery_level is not None
             )
 
         low_battery_entities = [
             eid
-            for eid, d in states.items()
-            if d.is_degraded and not d.is_suppressed and d.battery_level is not None
+            for eid in self.coordinator.monitored_entities
+            if states.get(eid)
+            and states[eid].is_degraded
+            and not states[eid].is_suppressed
+            and states[eid].battery_level is not None
         ]
         low_battery = len(low_battery_entities)
 

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -402,7 +402,9 @@ class GroupSummarySensor(DedupCoordinatorSensor):
             battery_powered = sum(
                 1
                 for eid in self.coordinator.monitored_entities
-                if states.get(eid) and states[eid].battery_level is not None
+                if states.get(eid)
+                and states[eid].battery_level is not None
+                and not states[eid].is_suppressed
             )
 
         low_battery_entities = [
@@ -503,7 +505,7 @@ class RecentlyOfflineSensor(DedupCoordinatorSensor):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return list of entity IDs that recently went offline."""
-        devices = self._cached_devices
+        devices = self._refresh_cache()
         return {
             "entities": [d.entity_id for d in devices],
             "count": len(devices),
@@ -569,7 +571,7 @@ class RecentlyRecoveredSensor(DedupCoordinatorSensor):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return list of entity IDs that recently recovered."""
-        devices = self._cached_devices
+        devices = self._refresh_cache()
         return {
             "entities": [d.entity_id for d in devices],
             "count": len(devices),

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -48,6 +48,8 @@ async def async_setup_entry(
     coordinator: EntityAvailabilityCoordinator = hass.data[DOMAIN][entry.entry_id]
     group_name = entry.data[CONF_GROUP_NAME]
     group_slug = re.sub(r"[^a-z0-9_]+", "_", group_name.lower()).strip("_")
+    if not group_slug:
+        group_slug = entry.entry_id[:8].lower()
     windows = entry.data.get(CONF_AVAILABILITY_WINDOWS, DEFAULT_AVAILABILITY_WINDOWS)
 
     _LOGGER.debug(
@@ -462,14 +464,16 @@ class RecentlyOfflineSensor(DedupCoordinatorSensor):
         self.entity_id = f"sensor.entity_availability_{group_slug}_recently_offline"
         self._attr_name = "Recently Offline"
         self._attr_device_info = _device_info(entry_id, group_slug, group_name)
+        self._cached_devices: list = []
 
     def _window_seconds(self) -> float:
         return self.coordinator.recovery_window_minutes * 60
 
-    def _matching_devices(self):
+    def _refresh_cache(self) -> list:
+        """Recompute matching devices once per call; cache for the other property."""
         now = datetime.now(timezone.utc)
         cutoff = self._window_seconds()
-        return [
+        self._cached_devices = [
             d
             for d in self.coordinator.device_states.values()
             if d.is_offline
@@ -477,6 +481,7 @@ class RecentlyOfflineSensor(DedupCoordinatorSensor):
             and d.recently_offline_at is not None
             and (now - d.recently_offline_at).total_seconds() <= cutoff
         ]
+        return self._cached_devices
 
     def _friendly_name(self, entity_id: str) -> str:
         state = self.hass.states.get(entity_id)
@@ -487,7 +492,7 @@ class RecentlyOfflineSensor(DedupCoordinatorSensor):
     @property
     def native_value(self) -> str:
         """Return comma-separated friendly names of recently offline entities."""
-        devices = self._matching_devices()
+        devices = self._refresh_cache()
         if not devices:
             return "None"
         result = ", ".join(self._friendly_name(d.entity_id) for d in devices)
@@ -498,7 +503,7 @@ class RecentlyOfflineSensor(DedupCoordinatorSensor):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return list of entity IDs that recently went offline."""
-        devices = self._matching_devices()
+        devices = self._cached_devices
         return {
             "entities": [d.entity_id for d in devices],
             "count": len(devices),
@@ -525,14 +530,16 @@ class RecentlyRecoveredSensor(DedupCoordinatorSensor):
         self.entity_id = f"sensor.entity_availability_{group_slug}_recently_recovered"
         self._attr_name = "Recently Recovered"
         self._attr_device_info = _device_info(entry_id, group_slug, group_name)
+        self._cached_devices: list = []
 
     def _window_seconds(self) -> float:
         return self.coordinator.recovery_window_minutes * 60
 
-    def _matching_devices(self):
+    def _refresh_cache(self) -> list:
+        """Recompute matching devices once per call; cache for the other property."""
         now = datetime.now(timezone.utc)
         cutoff = self._window_seconds()
-        return [
+        self._cached_devices = [
             d
             for d in self.coordinator.device_states.values()
             if not d.is_offline
@@ -540,6 +547,7 @@ class RecentlyRecoveredSensor(DedupCoordinatorSensor):
             and d.last_recovery is not None
             and (now - d.last_recovery).total_seconds() <= cutoff
         ]
+        return self._cached_devices
 
     def _friendly_name(self, entity_id: str) -> str:
         state = self.hass.states.get(entity_id)
@@ -550,7 +558,7 @@ class RecentlyRecoveredSensor(DedupCoordinatorSensor):
     @property
     def native_value(self) -> str:
         """Return comma-separated friendly names of recently recovered entities."""
-        devices = self._matching_devices()
+        devices = self._refresh_cache()
         if not devices:
             return "None"
         result = ", ".join(self._friendly_name(d.entity_id) for d in devices)
@@ -561,7 +569,7 @@ class RecentlyRecoveredSensor(DedupCoordinatorSensor):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return list of entity IDs that recently recovered."""
-        devices = self._matching_devices()
+        devices = self._cached_devices
         return {
             "entities": [d.entity_id for d in devices],
             "count": len(devices),

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -90,6 +90,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 _LOGGER.warning("Group '%s' not found", group)
             return
 
+        found = False
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
@@ -97,9 +98,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 coordinator.suppress_entity(entity_id, until)
                 coordinator.async_set_updated_data(coordinator.data)
                 _LOGGER.info("Suppressed %s until %s", entity_id, until.isoformat())
-                return
+                found = True
 
-        _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
+        if not found:
+            _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
 
     async def handle_suppress_indefinitely(call: ServiceCall) -> None:
         """Handle suppress_indefinitely service call."""
@@ -124,6 +126,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 _LOGGER.warning("Group '%s' not found", group)
             return
 
+        found = False
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
@@ -131,9 +134,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 coordinator.suppress_entity(entity_id, until=None)
                 coordinator.async_set_updated_data(coordinator.data)
                 _LOGGER.info("Suppressed %s indefinitely", entity_id)
-                return
+                found = True
 
-        _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
+        if not found:
+            _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
 
     async def handle_unsuppress(call: ServiceCall) -> None:
         """Handle unsuppress service call."""
@@ -158,6 +162,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 _LOGGER.warning("Group '%s' not found", group)
             return
 
+        found = False
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
@@ -165,9 +170,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 coordinator.unsuppress_entity(entity_id)
                 coordinator.async_set_updated_data(coordinator.data)
                 _LOGGER.info("Unsuppressed %s", entity_id)
-                return
+                found = True
 
-        _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
+        if not found:
+            _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SUPPRESS, handle_suppress, schema=SUPPRESS_SCHEMA

--- a/custom_components/entity_availability/storage.py
+++ b/custom_components/entity_availability/storage.py
@@ -92,8 +92,12 @@ class AvailabilityStorage:
         if entity_id not in self._buckets or not self._buckets[entity_id]:
             return None
 
-        window_hours = self._window_to_hours(window)
-        cutoff = now - timedelta(hours=window_hours)
+        if window == "today":
+            # Calendar day: midnight local time → now (not rolling 24 h).
+            cutoff = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        else:
+            window_hours = self._window_to_hours(window)
+            cutoff = now - timedelta(hours=window_hours)
 
         relevant_buckets = [
             b for b in self._buckets[entity_id] if b.interval_start >= cutoff
@@ -109,8 +113,11 @@ class AvailabilityStorage:
             return None
 
         # Require at least 1 bucket for "today", 10% for longer windows
-        expected_buckets = window_hours * 12  # 12 buckets per hour
-        min_required = 1 if window == "today" else max(1, int(expected_buckets * 0.1))
+        if window == "today":
+            min_required = 1
+        else:
+            expected_buckets = window_hours * 12  # 12 buckets per hour
+            min_required = max(1, int(expected_buckets * 0.1))
         if len(relevant_buckets) < min_required:
             _LOGGER.debug(
                 "Insufficient data for %s window '%s': have %d buckets, need %d",

--- a/custom_components/entity_availability/storage.py
+++ b/custom_components/entity_availability/storage.py
@@ -93,8 +93,8 @@ class AvailabilityStorage:
             return None
 
         if window == "today":
-            # Calendar day: midnight local time → now (not rolling 24 h).
-            cutoff = now.replace(hour=0, minute=0, second=0, microsecond=0)
+            # Rolling 24h window — timezone-agnostic and consistent across DST changes.
+            cutoff = now - timedelta(hours=24)
         else:
             window_hours = self._window_to_hours(window)
             cutoff = now - timedelta(hours=window_hours)

--- a/custom_components/entity_availability/storage.py
+++ b/custom_components/entity_availability/storage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from .const import BUCKET_INTERVAL, BUCKETS_MAX
@@ -165,8 +165,11 @@ class AvailabilityStorage:
                 for b in buckets_data:
                     try:
                         online = float(b["o"])
+                        interval_start = datetime.fromisoformat(b["s"])
+                        if interval_start.tzinfo is None:
+                            interval_start = interval_start.replace(tzinfo=timezone.utc)
                         bucket = AvailabilityBucket(
-                            interval_start=datetime.fromisoformat(b["s"]),
+                            interval_start=interval_start,
                             online_seconds=min(online, float(BUCKET_INTERVAL)),
                         )
                         buckets.append(bucket)

--- a/custom_components/entity_availability/storage.py
+++ b/custom_components/entity_availability/storage.py
@@ -154,16 +154,19 @@ class AvailabilityStorage:
         storage = cls()
         for entity_id, buckets_data in data.items():
             buckets: list[AvailabilityBucket] = []
-            for b in buckets_data:
-                try:
-                    buckets.append(
-                        AvailabilityBucket(
+            try:
+                for b in buckets_data:
+                    try:
+                        online = float(b["o"])
+                        bucket = AvailabilityBucket(
                             interval_start=datetime.fromisoformat(b["s"]),
-                            online_seconds=float(b["o"]),
+                            online_seconds=min(online, float(BUCKET_INTERVAL)),
                         )
-                    )
-                except (KeyError, ValueError, TypeError):
-                    continue
+                        buckets.append(bucket)
+                    except (KeyError, ValueError, TypeError):
+                        continue
+            except TypeError:
+                continue
             storage._buckets[entity_id] = buckets
         return storage
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -124,6 +124,7 @@ class TestAnyOfflineBinarySensor:
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
         )
         sensor.hass = mock_hass
+        sensor.is_on
         attrs = sensor.extra_state_attributes
         assert attrs["offline_count"] == 2
         assert "binary_sensor.device_a" in attrs["offline_entities"]
@@ -140,6 +141,7 @@ class TestAnyOfflineBinarySensor:
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
         )
         sensor.hass = mock_hass
+        sensor.is_on
         attrs = sensor.extra_state_attributes
         assert attrs["offline_count"] == 1
         assert "binary_sensor.device_a" not in attrs["offline_entities"]
@@ -174,6 +176,42 @@ async def test_binary_sensor_setup_entry_group_path(
 
     assert len(added) == 1
     assert isinstance(added[0], AnyOfflineBinarySensor)
+
+
+async def test_binary_sensor_setup_entry_slug_fallback(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """When group name produces empty slug, entry_id[:8] is used instead."""
+    hass = mock_hass
+    config = dict(mock_config_data)
+    config[CONF_GROUP_NAME] = "!!!"
+
+    entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="!!!",
+        data=config,
+        entry_id="abcdef1234567890",
+        unique_id=f"{DOMAIN}_fallback_slug",
+    )
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, entry)
+    hass.data[DOMAIN][entry.entry_id] = coord
+
+    added = []
+
+    def capture(entities):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, capture)
+
+    assert len(added) == 1
+    assert "abcdef12" in added[0].entity_id
 
 
 async def test_binary_sensor_setup_entry_combined_path(

--- a/tests/test_combined_binary_sensor.py
+++ b/tests/test_combined_binary_sensor.py
@@ -440,3 +440,33 @@ async def test_combined_binary_sensor_setup_entry_slug_sanitizes_slash_in_group_
         assert "/" not in entity.entity_id, (
             f"entity_id '{entity.entity_id}' contains forward slash"
         )
+
+
+async def test_combined_binary_sensor_slug_fallback(
+    mock_hass: HomeAssistant, group_entry_a, group_entry_b
+) -> None:
+    """All-special-char group name falls back to entry_id[:8] for the slug."""
+    combined_entry = _make_combined_entry(
+        "abcdef1234567890",
+        "!!!",
+        ["entry_a", "entry_b"],
+    )
+    coord_a = MagicMock(spec=EntityAvailabilityCoordinator)
+    coord_a.entry = group_entry_a
+    coord_b = MagicMock(spec=EntityAvailabilityCoordinator)
+    coord_b.entry = group_entry_b
+    mock_hass.data[DOMAIN] = {"entry_a": coord_a, "entry_b": coord_b}
+
+    group_entry_a.add_to_hass(mock_hass)
+    group_entry_b.add_to_hass(mock_hass)
+    combined_entry.add_to_hass(mock_hass)
+
+    added = []
+
+    def _fake_add(entities):
+        added.extend(entities)
+
+    await async_setup_entry(mock_hass, combined_entry, _fake_add)
+
+    assert len(added) == 1
+    assert "abcdef12" in added[0].entity_id

--- a/tests/test_combined_binary_sensor.py
+++ b/tests/test_combined_binary_sensor.py
@@ -303,6 +303,20 @@ class TestCombinedGroupAnyOfflineBinarySensor:
         assert len(active) == 1
         assert active[0] is coordinators[0]
 
+    def test_available_false_when_all_coordinators_unloaded(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """available is False when all source coordinators have been removed from hass.data."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        sensor = self._sensor(mock_hass, combined_entry, coordinators)
+        # Simulate all group entries being unloaded
+        mock_hass.data[DOMAIN].pop("entry_a", None)
+        mock_hass.data[DOMAIN].pop("entry_b", None)
+        assert sensor.available is False
+
 
 # ---------------------------------------------------------------------------
 # async_setup_entry

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -1100,3 +1100,34 @@ async def test_combined_sensor_setup_entry_slug_sanitizes_slash_in_group_name(
         assert "/" not in entity.entity_id, (
             f"entity_id '{entity.entity_id}' contains forward slash"
         )
+
+
+async def test_combined_sensor_slug_fallback(
+    mock_hass: HomeAssistant, group_entry_a, group_entry_b
+) -> None:
+    """All-special-char group name falls back to entry_id[:8] for the slug."""
+    combined_entry = _make_combined_entry(
+        "abcdef1234567890",
+        "!!!",
+        ["entry_a", "entry_b"],
+    )
+    coord_a = MagicMock(spec=EntityAvailabilityCoordinator)
+    coord_a.entry = group_entry_a
+    coord_b = MagicMock(spec=EntityAvailabilityCoordinator)
+    coord_b.entry = group_entry_b
+    mock_hass.data[DOMAIN] = {"entry_a": coord_a, "entry_b": coord_b}
+
+    group_entry_a.add_to_hass(mock_hass)
+    group_entry_b.add_to_hass(mock_hass)
+    combined_entry.add_to_hass(mock_hass)
+
+    added = []
+
+    def _fake_add(entities):
+        added.extend(entities)
+
+    await async_setup_entry(mock_hass, combined_entry, _fake_add)
+
+    assert len(added) > 0
+    for entity in added:
+        assert "abcdef12" in entity.entity_id

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -293,6 +293,7 @@ class TestCombinedGroupSensor:
         assert "groups" in attrs
         assert "entry_a" in attrs["groups"]
         assert "entry_b" in attrs["groups"]
+        assert attrs["groups"]["entry_a"]["name"] == "Group A"
 
     def test_attributes_battery_powered_via_device_states(
         self, mock_hass, combined_entry, coordinators

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -291,8 +291,8 @@ class TestCombinedGroupSensor:
         assert attrs["online"] == 2
         assert "binary_sensor.a2" in attrs["offline_entities"]
         assert "groups" in attrs
-        assert "Group A" in attrs["groups"]
-        assert "Group B" in attrs["groups"]
+        assert "entry_a" in attrs["groups"]
+        assert "entry_b" in attrs["groups"]
 
     def test_attributes_battery_powered_via_device_states(
         self, mock_hass, combined_entry, coordinators
@@ -307,8 +307,8 @@ class TestCombinedGroupSensor:
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
         attrs = sensor.extra_state_attributes
         assert attrs["battery_powered"] == 2
-        assert attrs["groups"]["Group A"]["battery_powered"] == 1
-        assert attrs["groups"]["Group B"]["battery_powered"] == 1
+        assert attrs["groups"]["entry_a"]["battery_powered"] == 1
+        assert attrs["groups"]["entry_b"]["battery_powered"] == 1
 
     def test_attributes_battery_powered_via_battery_map(
         self, mock_hass, group_entry_a, group_entry_b, coordinators
@@ -364,8 +364,8 @@ class TestCombinedGroupSensor:
         )
         attrs = sensor.extra_state_attributes
         # Group A: 1 non-None value in map; Group B: no map → 0
-        assert attrs["groups"]["Group A"]["battery_powered"] == 1
-        assert attrs["groups"]["Group B"]["battery_powered"] == 0
+        assert attrs["groups"]["entry_a"]["battery_powered"] == 1
+        assert attrs["groups"]["entry_b"]["battery_powered"] == 0
         assert attrs["battery_powered"] == 1
 
     def test_attributes_battery_powered_zero_when_no_battery(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1280,6 +1280,70 @@ async def test_save_storage_skips_suppression_for_removed_entities(
     assert "binary_sensor.device_removed" not in saved["suppressed"]
 
 
+async def test_load_storage_naive_offline_since_gets_utc(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Naive offline_since ISO string is restored with tzinfo=UTC."""
+    hass = mock_hass
+    naive_ts = (datetime.now(timezone.utc) - timedelta(minutes=5)).replace(tzinfo=None)
+
+    stored_data = {
+        "availability": {},
+        "suppressed": {},
+        "device_states": {
+            "binary_sensor.device_a": {
+                "is_offline": True,
+                "offline_since": naive_ts.isoformat(),
+                "cooldown_start": None,
+                "recently_offline_at": None,
+            }
+        },
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    device = coord._device_states["binary_sensor.device_a"]
+    assert device.offline_since is not None
+    assert device.offline_since.tzinfo is not None
+
+
+async def test_load_storage_naive_cooldown_start_gets_utc(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Naive cooldown_start ISO string is restored with tzinfo=UTC."""
+    hass = mock_hass
+    naive_ts = (datetime.now(timezone.utc) - timedelta(seconds=30)).replace(tzinfo=None)
+
+    stored_data = {
+        "availability": {},
+        "suppressed": {},
+        "device_states": {
+            "binary_sensor.device_a": {
+                "is_offline": False,
+                "offline_since": None,
+                "cooldown_start": naive_ts.isoformat(),
+                "recently_offline_at": None,
+            }
+        },
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    device = coord._device_states["binary_sensor.device_a"]
+    assert device.cooldown_start is not None
+    assert device.cooldown_start.tzinfo is not None
+
+
 # ---------------------------------------------------------------------------
 # Battery detection — device_class=battery entity reads own state
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1592,7 +1592,7 @@ async def test_shutdown_cancels_state_change_listener(
 async def test_shutdown_cancels_debounce(
     mock_hass: HomeAssistant, mock_config_entry
 ) -> None:
-    """async_shutdown cancels the debounce timer when it exists."""
+    """async_shutdown cancels all per-entity debounce timers."""
     hass = mock_hass
 
     with patch.object(
@@ -1605,12 +1605,12 @@ async def test_shutdown_cancels_debounce(
     def debounce_cancel():
         debounce_called.append(True)
 
-    coord._debounce_cancel = debounce_cancel
+    coord._debounce_cancel_map["binary_sensor.device_a"] = debounce_cancel
     coord._dirty = False
     await coord.async_shutdown()
 
     assert len(debounce_called) == 1
-    assert coord._debounce_cancel is None
+    assert len(coord._debounce_cancel_map) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -1940,12 +1940,12 @@ async def test_debounced_refresh_callback_creates_task(
 
     assert len(captured_callbacks) == 1
 
-    # Now invoke the callback: _debounce_cancel should be cleared and refresh scheduled
+    # Now invoke the callback: entry removed from map and refresh scheduled
     with patch.object(coord, "async_request_refresh", new_callable=AsyncMock):
         with patch.object(hass, "async_create_task") as mock_task:
             captured_callbacks[0](None)  # simulate the timer firing
 
-    assert coord._debounce_cancel is None
+    assert "unknown" not in coord._debounce_cancel_map
     mock_task.assert_called_once()
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -577,14 +577,23 @@ async def test_debounce_cancel_on_rapid_state_changes(
             "custom_components.entity_availability.coordinator.async_call_later",
             side_effect=[first_cancel, second_cancel],
         ):
+            entity_id = "binary_sensor.test"
+
+            def make_event(eid):
+                evt = MagicMock()
+                evt.data.get.side_effect = lambda key, default=None: (
+                    eid if key == "entity_id" else None
+                )
+                return evt
+
             # First state change — schedules debounce, no previous cancel
-            coord._handle_state_change(MagicMock())
-            assert coord._debounce_cancel is first_cancel
+            coord._handle_state_change(make_event(entity_id))
+            assert coord._debounce_cancel_map.get(entity_id) is first_cancel
             assert len(cancel_calls) == 0
 
             # Second rapid state change — cancels first, schedules new
-            coord._handle_state_change(MagicMock())
-            assert coord._debounce_cancel is second_cancel
+            coord._handle_state_change(make_event(entity_id))
+            assert coord._debounce_cancel_map.get(entity_id) is second_cancel
             assert len(cancel_calls) == 1  # first cancel was called
 
 
@@ -680,6 +689,60 @@ async def test_suppressed_entity_skips_availability_storage(
     assert record_offline_calls == [], (
         "suppressed entity should not record offline time"
     )
+
+
+async def test_async_shutdown_cancels_debounce_map(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """async_shutdown calls every cancel in _debounce_cancel_map and clears it."""
+    hass = mock_hass
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+        cancel_called = []
+
+        def fake_cancel():
+            cancel_called.append(True)
+
+        coord._debounce_cancel_map["binary_sensor.x"] = fake_cancel
+
+        await coord.async_shutdown()
+
+    assert len(cancel_called) == 1
+    assert coord._debounce_cancel_map == {}
+
+
+async def test_async_update_data_save_error_logs_warning(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """When _async_save_storage raises, a warning is logged and _update_count resets."""
+    hass = mock_hass
+
+    from custom_components.entity_availability.coordinator import _SAVE_INTERVAL_UPDATES
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ) as mock_save:
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+        # Prime the counter so the next update triggers the save path
+        coord._update_count = _SAVE_INTERVAL_UPDATES - 1
+        mock_save.side_effect = RuntimeError("disk full")
+
+        with patch(
+            "custom_components.entity_availability.coordinator._LOGGER"
+        ) as mock_logger:
+            await coord._async_update_data()
+
+        mock_logger.warning.assert_called_once()
+        assert coord._update_count == 0
 
 
 async def test_device_state_persistence_prevents_restart_retrigger(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1491,6 +1491,39 @@ async def test_shutdown_cancels_debounce(
 # ---------------------------------------------------------------------------
 
 
+async def test_load_storage_restores_naive_recently_offline_at(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Naive (no tzinfo) recently_offline_at within recovery window is restored."""
+    hass = mock_hass
+    # Naive isoformat — within default 5-minute window
+    naive_ts = (datetime.now(timezone.utc) - timedelta(minutes=2)).replace(tzinfo=None)
+
+    stored_data = {
+        "availability": {},
+        "suppressed": {},
+        "device_states": {
+            "binary_sensor.device_a": {
+                "is_offline": True,
+                "offline_since": None,
+                "cooldown_start": None,
+                "recently_offline_at": naive_ts.isoformat(),
+            }
+        },
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    device = coord._device_states["binary_sensor.device_a"]
+    assert device.recently_offline_at is not None
+    assert device.recently_offline_at.tzinfo is not None
+
+
 async def test_load_storage_restores_future_timed_suppression(
     mock_hass: HomeAssistant, mock_config_entry
 ) -> None:
@@ -1544,6 +1577,33 @@ async def test_load_storage_discards_expired_timed_suppression(
     await coord._async_load_storage()
 
     assert "binary_sensor.device_a" not in coord._suppressed
+
+
+async def test_load_storage_restores_naive_timed_suppression(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Naive (no tzinfo) suppress_until ISO string is treated as UTC and restored."""
+    hass = mock_hass
+
+    stored_data = {
+        "availability": {},
+        "suppressed": {
+            "binary_sensor.device_a": "2099-01-01T12:00:00",  # naive — far future
+        },
+        "device_states": {},
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    assert "binary_sensor.device_a" in coord._suppressed
+    restored = coord._suppressed["binary_sensor.device_a"]
+    assert restored is not None
+    assert restored.tzinfo is not None
 
 
 async def test_load_storage_ignores_invalid_suppression_timestamp(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -540,6 +540,48 @@ async def test_register_lovelace_resource_fallback_data_append(
     assert appended[0]["type"] == "module"
 
 
+async def test_async_install_card_clears_sentinel_on_register_failure(
+    mock_hass: HomeAssistant,
+) -> None:
+    """_async_install_card clears _CARD_INSTALLED_KEY when _async_register_lovelace_resource raises."""
+    from custom_components.entity_availability import (
+        _CARD_INSTALLED_KEY,
+        _async_install_card,
+    )
+
+    hass = mock_hass
+    hass.data.setdefault(DOMAIN, {})
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch.object(
+            hass,
+            "async_add_executor_job",
+            new_callable=AsyncMock,
+            return_value="1.0.0",
+        ),
+        patch(
+            "custom_components.entity_availability._async_register_lovelace_resource",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("lovelace exploded"),
+        ),
+        patch(
+            "custom_components.entity_availability.hass",
+            create=True,
+        ),
+        patch(
+            "homeassistant.components.http.StaticPathConfig",
+            autospec=False,
+        ),
+    ):
+        mock_http = MagicMock()
+        mock_http.async_register_static_paths = AsyncMock()
+        hass.http = mock_http
+        await _async_install_card(hass)
+
+    assert _CARD_INSTALLED_KEY not in hass.data.get(DOMAIN, {})
+
+
 async def test_register_lovelace_resource_non_storage_first_url_update(
     mock_hass: HomeAssistant,
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -497,6 +497,7 @@ class TestRecentlyOfflineSensor:
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
         )
         sensor.hass = mock_hass
+        sensor.native_value
         attrs = sensor.extra_state_attributes
         assert "binary_sensor.device_b" in attrs["entities"]
         assert attrs["count"] == 1
@@ -565,6 +566,7 @@ class TestRecentlyRecoveredSensor:
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
         )
         sensor.hass = mock_hass
+        sensor.native_value
         attrs = sensor.extra_state_attributes
         assert "binary_sensor.device_a" in attrs["entities"]
         assert attrs["count"] == 1
@@ -1069,3 +1071,40 @@ async def test_sensor_setup_entry_slug_sanitizes_slash_in_group_name(
         assert "/" not in entity.entity_id, (
             f"entity_id '{entity.entity_id}' contains forward slash"
         )
+
+
+async def test_sensor_setup_entry_slug_fallback(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """All-special-char group name falls back to entry_id[:8] for sensor slug."""
+    hass = mock_hass
+    config = dict(mock_config_data)
+    config[CONF_GROUP_NAME] = "!!!"
+
+    entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="!!!",
+        data=config,
+        entry_id="abcdef1234567890",
+        unique_id=f"{DOMAIN}_fallback_slug_sensor",
+    )
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, entry)
+    hass.data[DOMAIN][entry.entry_id] = coord
+
+    added = []
+
+    def capture(entities):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, capture)
+
+    assert len(added) > 0
+    for entity in added:
+        assert "abcdef12" in entity.entity_id

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -509,3 +509,73 @@ async def test_find_coordinator_skips_non_coordinator_values(setup_services) -> 
     for entity_id in coord.monitored_entities:
         if entity_id in coord.device_states:
             assert coord.device_states[entity_id].is_suppressed is True
+
+
+async def test_suppress_updates_all_coordinators_sharing_entity(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """Suppress service calls suppress_entity on ALL coordinators that monitor the entity."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.entity_availability.const import CONF_ENTITIES
+
+    hass = mock_hass
+
+    config_a = dict(mock_config_data)
+    config_a[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_a = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group A",
+        data=config_a,
+        entry_id="entry_multi_a",
+        unique_id=f"{DOMAIN}_entry_multi_a",
+    )
+
+    config_b = dict(mock_config_data)
+    config_b[CONF_ENTITIES] = ["binary_sensor.device_a", "binary_sensor.device_b"]
+    entry_b = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group B",
+        data=config_b,
+        entry_id="entry_multi_b",
+        unique_id=f"{DOMAIN}_entry_multi_b",
+    )
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord_a = EntityAvailabilityCoordinator(hass, entry_a)
+        coord_a._device_states = {
+            "binary_sensor.device_a": DeviceState(
+                entity_id="binary_sensor.device_a", is_offline=False
+            )
+        }
+        coord_a.data = None
+
+        coord_b = EntityAvailabilityCoordinator(hass, entry_b)
+        coord_b._device_states = {
+            "binary_sensor.device_a": DeviceState(
+                entity_id="binary_sensor.device_a", is_offline=False
+            ),
+            "binary_sensor.device_b": DeviceState(
+                entity_id="binary_sensor.device_b", is_offline=False
+            ),
+        }
+        coord_b.data = None
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["entry_multi_a"] = coord_a
+    hass.data[DOMAIN]["entry_multi_b"] = coord_b
+
+    await async_setup_services(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SUPPRESS,
+        {ATTR_ENTITY_ID: "binary_sensor.device_a", ATTR_DURATION: 10},
+        blocking=True,
+    )
+
+    assert coord_a.device_states["binary_sensor.device_a"].is_suppressed is True
+    assert coord_b.device_states["binary_sensor.device_a"].is_suppressed is True

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -390,3 +390,15 @@ class TestFromDictOuterTypeError:
         """from_dict skips entity when buckets_data is an integer."""
         storage = AvailabilityStorage.from_dict({"sensor.test": 42})
         assert "sensor.test" not in storage._buckets
+
+    def test_from_dict_naive_interval_start_gets_utc(self) -> None:
+        """from_dict normalizes naive interval_start to UTC-aware."""
+        from datetime import timezone
+
+        storage = AvailabilityStorage.from_dict(
+            {"sensor.test": [{"s": "2024-01-01T12:00:00", "o": 100.0}]}
+        )
+        assert "sensor.test" in storage._buckets
+        bucket = storage._buckets["sensor.test"][0]
+        assert bucket.interval_start.tzinfo is not None
+        assert bucket.interval_start.tzinfo == timezone.utc

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -371,3 +371,22 @@ class TestGetAvailabilityEdgeCases:
 
         result = storage.get_availability("sensor.test", "today", now)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# from_dict — outer TypeError when buckets_data is not iterable (lines 168-169)
+# ---------------------------------------------------------------------------
+
+
+class TestFromDictOuterTypeError:
+    """Test from_dict outer except TypeError branch."""
+
+    def test_from_dict_non_iterable_buckets_data_skipped(self) -> None:
+        """from_dict skips entity when buckets_data is not iterable (e.g. None)."""
+        storage = AvailabilityStorage.from_dict({"sensor.test": None})
+        assert "sensor.test" not in storage._buckets
+
+    def test_from_dict_integer_buckets_data_skipped(self) -> None:
+        """from_dict skips entity when buckets_data is an integer."""
+        storage = AvailabilityStorage.from_dict({"sensor.test": 42})
+        assert "sensor.test" not in storage._buckets


### PR DESCRIPTION
## Summary

Full fix pass following 35-agent audit of 0.3.6. Resolves 10 HIGH and 8 MEDIUM findings across 9 files.

### `__init__.py`
- **Fix TOCTOU race** in `_async_install_card`: set `_CARD_INSTALLED_KEY` sentinel *before* first `await` — prevents double Lovelace registration on concurrent entry setups (confirmed in logs)
- **Fix COMBINED unload path**: run card-key cleanup + service teardown for all entry types; previously COMBINED returned early, leaving a stale guard that prevented card re-registration on next startup

### `coordinator.py`
- **Immutable snapshot**: pass `dict()` copies to `EntityAvailabilityData` instead of live dict references
- **Double record fix**: skip `record_offline` when device is still inside cooldown window (was recording both online and offline in same tick)
- **Persist `recently_offline_at`** for recovered devices so `RecentlyOfflineSensor` survives restarts within the recovery window
- **Set `_dirty=True`** when timed suppression expires mid-update
- **Clear `is_degraded`/`is_stale`** on suppressed entities
- **Naive datetime fix**: normalize naive timestamps to UTC on storage load

### `storage.py`
- **Crash fix**: wrap bucket loop in outer `try/except TypeError` — non-iterable `buckets_data` (None, int, corrupted file) no longer crashes coordinator load
- **Data integrity**: clamp `online_seconds <= BUCKET_INTERVAL` on deserialization

### `services.py`
- **Overlapping groups**: suppress/unsuppress now updates *all* coordinators monitoring an entity, not just the first match

### `combined_binary_sensor.py`
- Add `_attr_should_poll = False` (was registering a 30s polling loop)
- Add `available` property returning `False` when all source coordinators are gone
- Type-safe `_active_coordinators()` using `isinstance()` check

### `combined_sensor.py`
- `isinstance()` check in `_active_coordinators()`
- `super()` calls in lifecycle hooks
- Key `groups` dict by `entry_id` instead of `group_name` to prevent silent overwrite on duplicate names

### `config_flow.py`
- Strip whitespace from `group_name` before saving
- Namespace GROUP unique-ids as `entity_availability_group_*` (eliminates collision with `combined_*`)
- Filter stale entry_ids from combined options flow default selector

### `sensor.py`
- `battery_powered` and `low_battery_entities` now iterate `monitored_entities` for correct counts

### `frontend/entity-availability-card.js`
- Bump `CARD_VERSION` to `0.3.6` for cache-busting
- Fix pluralisation (`"entity"/"entities"`, not `"entity"/"entityies"`)
- Fix `_handleUnsuppressAll` for combined groups (wrong entity prefix)

## Test plan
- [x] 374 tests pass (`python3 -m pytest`)
- [x] 100% coverage across all 12 source modules
- [x] `ruff format` + `ruff check` — clean