### PR TITLE
fix: sensor cache consistency, combined available, missing_groups isinstance

### DIFF
--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -133,13 +133,32 @@ class CombinedSensorBase(WriteDedupMixin, SensorEntity):
 
     def _active_coordinators(self) -> list[EntityAvailabilityCoordinator]:
         domain_data = self.hass.data.get(DOMAIN, {})
-        return [
+        active = [
             c
             for c in self._coordinators
             if isinstance(
                 domain_data.get(c.entry.entry_id), EntityAvailabilityCoordinator
             )
         ]
+        if len(active) != len(self._coordinators):
+            _LOGGER.debug(
+                "[%s] _active_coordinators: %d/%d active",
+                self.entity_id,
+                len(active),
+                len(self._coordinators),
+            )
+        return active
+
+    @property
+    def available(self) -> bool:
+        """Return False when all source coordinators have been unloaded."""
+        is_available = len(self._active_coordinators()) > 0
+        if not is_available:
+            _LOGGER.debug(
+                "[%s] unavailable: all source coordinators unloaded",
+                self.entity_id,
+            )
+        return is_available
 
 
 class CombinedGroupSensor(CombinedSensorBase):
@@ -252,12 +271,18 @@ class CombinedGroupSensor(CombinedSensorBase):
             "offline_entities": offline_entities,
             "low_battery_entities": low_battery_entities,
         }
+        domain_data = self.hass.data.get(DOMAIN, {})
         missing = [
             eid
             for eid in self._combined_entry_ids
-            if eid not in self.hass.data.get(DOMAIN, {})
+            if not isinstance(domain_data.get(eid), EntityAvailabilityCoordinator)
         ]
         if missing:
+            _LOGGER.debug(
+                "[%s] missing_groups detected: %s",
+                self.entity_id,
+                missing,
+            )
             attrs["missing_groups"] = missing
         return attrs
 

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -483,6 +483,12 @@ class RecentlyOfflineSensor(DedupCoordinatorSensor):
             and d.recently_offline_at is not None
             and (now - d.recently_offline_at).total_seconds() <= cutoff
         ]
+        _LOGGER.debug(
+            "[%s] RecentlyOfflineSensor cache refreshed: %d device(s) within %ss window",
+            self.entity_id,
+            len(self._cached_devices),
+            cutoff,
+        )
         return self._cached_devices
 
     def _friendly_name(self, entity_id: str) -> str:
@@ -505,7 +511,7 @@ class RecentlyOfflineSensor(DedupCoordinatorSensor):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return list of entity IDs that recently went offline."""
-        devices = self._refresh_cache()
+        devices = self._cached_devices
         return {
             "entities": [d.entity_id for d in devices],
             "count": len(devices),
@@ -549,6 +555,12 @@ class RecentlyRecoveredSensor(DedupCoordinatorSensor):
             and d.last_recovery is not None
             and (now - d.last_recovery).total_seconds() <= cutoff
         ]
+        _LOGGER.debug(
+            "[%s] RecentlyRecoveredSensor cache refreshed: %d device(s) within %ss window",
+            self.entity_id,
+            len(self._cached_devices),
+            cutoff,
+        )
         return self._cached_devices
 
     def _friendly_name(self, entity_id: str) -> str:
@@ -571,7 +583,7 @@ class RecentlyRecoveredSensor(DedupCoordinatorSensor):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return list of entity IDs that recently recovered."""
-        devices = self._refresh_cache()
+        devices = self._cached_devices
         return {
             "entities": [d.entity_id for d in devices],
             "count": len(devices),

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -224,6 +224,52 @@ class TestCombinedSensorBase:
         sensor = self._make_sensor(mock_hass, combined_entry, coordinators)
         assert len(sensor._active_coordinators()) == 2
 
+    def test_available_true_when_at_least_one_coordinator_loaded(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """available returns True when at least one coordinator is active."""
+        mock_hass.data[DOMAIN] = {"entry_a": coordinators[0]}
+        sensor = self._make_sensor(mock_hass, combined_entry, coordinators)
+        assert sensor.available is True
+
+    def test_available_false_when_all_coordinators_unloaded(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """available returns False when no coordinator is in hass.data."""
+        mock_hass.data[DOMAIN] = {}
+        sensor = self._make_sensor(mock_hass, combined_entry, coordinators)
+        assert sensor.available is False
+
+    def test_available_false_when_hass_data_has_non_coordinator_value(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """available returns False when hass.data entry is not an EntityAvailabilityCoordinator."""
+        mock_hass.data[DOMAIN] = {"entry_a": "not_a_coordinator", "entry_b": object()}
+        sensor = self._make_sensor(mock_hass, combined_entry, coordinators)
+        assert sensor.available is False
+
+    def test_missing_groups_uses_isinstance_check(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """missing_groups flags entries whose hass.data value is not a coordinator."""
+        # entry_a has a non-coordinator value — should be flagged as missing
+        mock_hass.data[DOMAIN] = {
+            "entry_a": "not_a_coordinator",
+            "entry_b": coordinators[1],
+        }
+        sensor = CombinedGroupSensor(
+            mock_hass,
+            combined_entry,
+            "Combined",
+            "combined",
+            coordinators,
+            ["entry_a", "entry_b"],
+        )
+        attrs = sensor.extra_state_attributes
+        assert "missing_groups" in attrs
+        assert "entry_a" in attrs["missing_groups"]
+        assert "entry_b" not in attrs["missing_groups"]
+
 
 # ---------------------------------------------------------------------------
 # CombinedGroupSensor

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -510,6 +510,28 @@ class TestRecentlyOfflineSensor:
         )
         assert sensor.unique_id == "test_entry_id_recently_offline"
 
+    def test_extra_state_attributes_reuses_cached_devices_not_recomputed(
+        self, mock_coordinator, mock_hass
+    ):
+        """extra_state_attributes reads _cached_devices set by native_value, not a second _refresh_cache."""
+        mock_coordinator._device_states[
+            "binary_sensor.device_b"
+        ].recently_offline_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        sensor = RecentlyOfflineSensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        # Drive native_value to populate _cached_devices
+        sensor.native_value
+        cached_before = sensor._cached_devices
+        # Poison the underlying data so a re-computation would return different results
+        for d in mock_coordinator._device_states.values():
+            d.recently_offline_at = None
+        # extra_state_attributes must reflect the already-cached result, not the poisoned state
+        attrs = sensor.extra_state_attributes
+        assert attrs["count"] == len(cached_before)
+        assert attrs["entities"] == [d.entity_id for d in cached_before]
+
 
 class TestRecentlyRecoveredSensor:
     """Tests for RecentlyRecoveredSensor."""
@@ -590,6 +612,28 @@ class TestRecentlyRecoveredSensor:
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
         )
         assert sensor.unique_id == "test_entry_id_recently_recovered"
+
+    def test_extra_state_attributes_reuses_cached_devices_not_recomputed(
+        self, mock_coordinator, mock_hass
+    ):
+        """extra_state_attributes reads _cached_devices set by native_value, not a second _refresh_cache."""
+        mock_coordinator._device_states["binary_sensor.device_a"].last_recovery = (
+            datetime.now(timezone.utc) - timedelta(minutes=2)
+        )
+        sensor = RecentlyRecoveredSensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        # Drive native_value to populate _cached_devices
+        sensor.native_value
+        cached_before = sensor._cached_devices
+        # Poison the underlying data so a re-computation would return different results
+        for d in mock_coordinator._device_states.values():
+            d.last_recovery = None
+        # extra_state_attributes must reflect the already-cached result, not the poisoned state
+        attrs = sensor.extra_state_attributes
+        assert attrs["count"] == len(cached_before)
+        assert attrs["entities"] == [d.entity_id for d in cached_before]
 
     def test_native_value_at_exactly_window_boundary(self, mock_coordinator, mock_hass):
         """Device recovered at exactly window_minutes*60 seconds ago should still show."""


### PR DESCRIPTION
## Summary

- **Bug 1** — `RecentlyOfflineSensor` / `RecentlyRecoveredSensor`: `extra_state_attributes` was calling `_refresh_cache()` again instead of reading `self._cached_devices` set by `native_value`. If an entity crossed a window cutoff between the two HA property accesses, `native_value` count and `attributes.count` could disagree by 1.
- **Bug 2** — `CombinedSensorBase`: all 6 combined sensors were missing an `available` property, reporting `available=True` even when every source coordinator had been unloaded. The binary sensor already handled this correctly; base class now does too.
- **Bug 3** — `CombinedGroupSensor.extra_state_attributes`: `missing_groups` used a raw key presence check (`eid not in hass.data[DOMAIN]`), inconsistent with `_active_coordinators` which uses `isinstance(..., EntityAvailabilityCoordinator)`. A non-coordinator value in `hass.data` would be silently treated as present.

Added debug logging to `_refresh_cache`, `_active_coordinators`, `available`, and `missing_groups` paths.

## Test plan

- [ ] 6 new targeted tests: cache reuse correctness (poison test), `available` True/False, `available` with non-coordinator value, `missing_groups` isinstance path
- [ ] 393 passed, 100% coverage across all changed files
- [ ] Deployed to local HA Docker container for manual verification