### PR TITLE
fix(sensor): round per_device to 1 decimal to allow WriteDedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.8] - TBD
+
+### Fixed
+- Sensor: `AvailabilitySensor.native_value` and the `per_device` attribute breakdown are now quantized to whole percent. Previously the rolling-window numerator grew by ~`SCAN_INTERVAL` seconds per coordinator tick, so the unrounded percentage drifted by tens of thousandths of a percent every tick — defeating `WriteDedupMixin` and producing one recorder row per tick on every `*_availability_today` sensor (~2880/day each). Whole-percent quantization keeps the published value stable across ticks; dedup now suppresses virtually every tick. Fixes v5.5 audit finding F-EA-1 (1.45M states rows over 50 days). Estimated DB write reduction: ~30× for `_today` sensors.
+
 ## [0.3.7] - TBD
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [0.3.8] - 2026-06-21
 
 ### Fixed
-- Sensor: `AvailabilitySensor.native_value` and the `per_device` attribute breakdown are now quantized to whole percent. Previously the rolling-window numerator grew by ~`SCAN_INTERVAL` seconds per coordinator tick, so the unrounded percentage drifted by tens of thousandths of a percent every tick — defeating `WriteDedupMixin` and producing one recorder row per tick on every `*_availability_today` sensor (~2880/day each). Whole-percent quantization keeps the published value stable across ticks; dedup now suppresses virtually every tick. Fixes v5.5 audit finding F-EA-1 (1.45M states rows over 50 days). Estimated DB write reduction: ~30× for `_today` sensors.
+- Sensor: `AvailabilitySensor.extra_state_attributes['per_device']` values are now rounded to 1 decimal (matching `native_value`). Previously the per-device floats were unrounded — the rolling-window numerator grew by ~`SCAN_INTERVAL` seconds per coordinator tick, so the unrounded value drifted by tens of thousandths of a percent every tick — defeating `WriteDedupMixin` (the attribute dict comparison always saw a diff) and producing one recorder row per tick on every `*_availability_today` sensor (~2880/day each). The group-level `native_value` was already 1-decimal-rounded; this matches the attribute precision to it. Public API unchanged: state is still a 1-decimal float. Fixes v5.5 audit finding F-EA-1 (1.45M states rows over 50 days).
 
 ## [0.3.7] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.3.8] - TBD
+## [0.3.8] - 2026-06-21
 
 ### Fixed
 - Sensor: `AvailabilitySensor.native_value` and the `per_device` attribute breakdown are now quantized to whole percent. Previously the rolling-window numerator grew by ~`SCAN_INTERVAL` seconds per coordinator tick, so the unrounded percentage drifted by tens of thousandths of a percent every tick — defeating `WriteDedupMixin` and producing one recorder row per tick on every `*_availability_today` sensor (~2880/day each). Whole-percent quantization keeps the published value stable across ticks; dedup now suppresses virtually every tick. Fixes v5.5 audit finding F-EA-1 (1.45M states rows over 50 days). Estimated DB write reduction: ~30× for `_today` sensors.
 
-## [0.3.7] - TBD
+## [0.3.7] - 2026-06-15
 
 ### Fixed
 - Combined sensor: `sensor.*_combined_summary` attributes now include an `entities` key (flat list of all monitored entity IDs across all source groups) — required for the Unsuppress All card action to work on combined group cards

--- a/custom_components/entity_availability/manifest.json
+++ b/custom_components/entity_availability/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/italo-lombardi/Home-Assistant-EntityAvailability/issues",
     "quality_scale": "custom",
     "requirements": [],
-    "version": "0.3.7"
+    "version": "0.3.8"
 }

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -315,14 +315,8 @@ class AvailabilitySensor(DedupCoordinatorSensor):
         self._attr_device_info = _device_info(entry_id, group_slug, group_name)
 
     @property
-    def native_value(self) -> int | None:
-        """Return group availability %.
-
-        Quantized to whole percent so that sub-percent drift across coordinator
-        ticks (the rolling-window numerator grows by ~SCAN_INTERVAL seconds per
-        tick on every active bucket) does not defeat ``WriteDedupMixin`` and
-        produce a recorder row on every tick. See v5.5 audit finding F-EA-1.
-        """
+    def native_value(self) -> float | None:
+        """Return group availability % (1-decimal precision)."""
         now = datetime.now(timezone.utc)
         storage = self.coordinator.availability_storage
 
@@ -339,25 +333,26 @@ class AvailabilitySensor(DedupCoordinatorSensor):
         if not values:
             return None
 
-        return round(sum(values) / len(values))
+        return round(sum(values) / len(values), 1)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return per-device availability breakdown.
+        """Return per-device availability breakdown (1-decimal precision).
 
-        Per-device values are quantized to whole percent for the same reason
-        ``native_value`` is — unrounded floats drift on every tick and would
-        defeat the attribute comparison in ``WriteDedupMixin._ea_should_write``.
+        Per-device values are rounded to 1 decimal to match ``native_value``.
+        Previously they were unrounded floats that drifted by ~0.035% on every
+        coordinator tick, defeating ``WriteDedupMixin`` even when the
+        group-level rounded value was stable (v5.5 audit finding F-EA-1).
         """
         now = datetime.now(timezone.utc)
         storage = self.coordinator.availability_storage
-        breakdown: dict[str, int | None] = {}
+        breakdown: dict[str, float | None] = {}
         for entity_id in self.coordinator.monitored_entities:
             device = self.coordinator.device_states.get(entity_id)
             if device and device.is_suppressed:
                 continue
             avail = storage.get_availability(entity_id, self._window, now)
-            breakdown[entity_id] = round(avail) if avail is not None else None
+            breakdown[entity_id] = round(avail, 1) if avail is not None else None
         return {"per_device": breakdown}
 
 

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -315,8 +315,14 @@ class AvailabilitySensor(DedupCoordinatorSensor):
         self._attr_device_info = _device_info(entry_id, group_slug, group_name)
 
     @property
-    def native_value(self) -> float | None:
-        """Return group availability %."""
+    def native_value(self) -> int | None:
+        """Return group availability %.
+
+        Quantized to whole percent so that sub-percent drift across coordinator
+        ticks (the rolling-window numerator grows by ~SCAN_INTERVAL seconds per
+        tick on every active bucket) does not defeat ``WriteDedupMixin`` and
+        produce a recorder row on every tick. See v5.5 audit finding F-EA-1.
+        """
         now = datetime.now(timezone.utc)
         storage = self.coordinator.availability_storage
 
@@ -333,20 +339,25 @@ class AvailabilitySensor(DedupCoordinatorSensor):
         if not values:
             return None
 
-        return round(sum(values) / len(values), 1)
+        return round(sum(values) / len(values))
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return per-device availability breakdown."""
+        """Return per-device availability breakdown.
+
+        Per-device values are quantized to whole percent for the same reason
+        ``native_value`` is — unrounded floats drift on every tick and would
+        defeat the attribute comparison in ``WriteDedupMixin._ea_should_write``.
+        """
         now = datetime.now(timezone.utc)
         storage = self.coordinator.availability_storage
-        breakdown: dict[str, float | None] = {}
+        breakdown: dict[str, int | None] = {}
         for entity_id in self.coordinator.monitored_entities:
             device = self.coordinator.device_states.get(entity_id)
             if device and device.is_suppressed:
                 continue
             avail = storage.get_availability(entity_id, self._window, now)
-            breakdown[entity_id] = avail
+            breakdown[entity_id] = round(avail) if avail is not None else None
         return {"per_device": breakdown}
 
 

--- a/custom_components/entity_availability/storage.py
+++ b/custom_components/entity_availability/storage.py
@@ -127,9 +127,7 @@ class AvailabilityStorage:
         if total_time == 0:
             return None
 
-        # Return raw float; AvailabilitySensor quantizes to whole percent for
-        # display and dedup. Storage-level rounding would be redundant.
-        return (total_online / total_time) * 100
+        return round((total_online / total_time) * 100, 1)
 
     def get_entity_availability(
         self, entity_id: str, windows: list[str], now: datetime

--- a/custom_components/entity_availability/storage.py
+++ b/custom_components/entity_availability/storage.py
@@ -127,7 +127,9 @@ class AvailabilityStorage:
         if total_time == 0:
             return None
 
-        return round((total_online / total_time) * 100, 1)
+        # Return raw float; AvailabilitySensor quantizes to whole percent for
+        # display and dedup. Storage-level rounding would be redundant.
+        return (total_online / total_time) * 100
 
     def get_entity_availability(
         self, entity_id: str, windows: list[str], now: datetime

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1220,6 +1220,8 @@ class TestAvailabilitySensorQuantization:
         floats moved on every tick, defeating dedup. Post-fix both
         native_value and per_device are rounded to 1 decimal — sub-0.1%
         drift collapses below the rounding step.
+
+        Boundary-flip behaviour is covered separately in test_write_dedup.py.
         """
         sensor = AvailabilitySensor(
             mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
@@ -1245,41 +1247,3 @@ class TestAvailabilitySensorQuantization:
         assert write.call_count < 10, (
             f"dedup failed to suppress sub-0.1% drift: {write.call_count} writes"
         )
-
-    def test_dedup_with_boundary_crossings(self, mock_coordinator, mock_hass):
-        """Drift across a 0.1% boundary writes once per crossing, suppresses rest.
-
-        Confirms the quantization actually *flips* at the 0.1% boundary —
-        a broken rounding (e.g. floor) could silently dedup forever and
-        pass the steady-state test above.
-        """
-        sensor = AvailabilitySensor(
-            mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
-        )
-        sensor.hass = mock_hass
-
-        storage = mock_coordinator.availability_storage
-        tick = {"n": 0}
-        observed: set[float] = set()
-
-        def _drifting(_eid, _window, _now):
-            # 0.01% per tick → 10 ticks per 0.1% boundary crossing.
-            return 99.00 + (tick["n"] * 0.01)
-
-        with (
-            patch.object(storage, "get_availability", side_effect=_drifting),
-            patch.object(sensor, "async_write_ha_state") as write,
-        ):
-            for i in range(20):  # drift 99.0 → 99.19 → 2 crossings
-                tick["n"] = i
-                observed.add(sensor.native_value)
-                sensor._handle_coordinator_update()
-
-        # 2 boundary crossings + initial publish = ≤4 writes.
-        assert write.call_count <= 4, (
-            f"too many writes across 0.1% boundaries: {write.call_count}"
-        )
-        # Quantization must have flipped — both sides observed.
-        assert 99.0 in observed
-        assert 99.1 in observed
-        assert 99.2 in observed

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1242,3 +1242,48 @@ class TestAvailabilitySensorQuantization:
         assert write.call_count < 10, (
             f"dedup failed to suppress sub-percent drift: {write.call_count} writes"
         )
+
+    def test_dedup_with_boundary_crossings(self, mock_coordinator, mock_hass):
+        """Drift that crosses several integer boundaries still dedups most ticks.
+
+        Faster ramp (0.83% per tick = 30s/3600s, simulating a 1h-style window)
+        starts at 99.0 and crosses 100, then 100→101 etc. Each crossing
+        legitimately writes once; everything between crossings is suppressed.
+        Verifies the quantization actually flips correctly at the boundary
+        rather than silently failing the dedup.
+        """
+        sensor = AvailabilitySensor(
+            mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+
+        storage = mock_coordinator.availability_storage
+        tick = {"n": 0}
+        observed_states: list[int] = []
+
+        def _drifting(_eid, _window, _now):
+            return 99.0 + (tick["n"] * 30 / 3600)
+
+        # Capture the integer states actually published.
+        original = sensor._handle_coordinator_update
+
+        def _spy():
+            observed_states.append(sensor.native_value)
+            original()
+
+        with (
+            patch.object(storage, "get_availability", side_effect=_drifting),
+            patch.object(sensor, "async_write_ha_state") as write,
+        ):
+            for i in range(120):  # 120 ticks → drift 99.0 → 100.0 (1 crossing)
+                tick["n"] = i
+                _spy()
+
+        # Drift hits exactly 1 integer boundary (99 → 100) over 120 ticks.
+        # Allow up to 3 writes for the boundary plus the first publish.
+        assert write.call_count <= 3, (
+            f"too many writes across single boundary: {write.call_count}"
+        )
+        # Confirm quantization actually flipped — both 99 and 100 appeared.
+        assert 99 in observed_states
+        assert 100 in observed_states

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1152,3 +1152,93 @@ async def test_sensor_setup_entry_slug_fallback(
     assert len(added) > 0
     for entity in added:
         assert "abcdef12" in entity.entity_id
+
+
+# ---------------------------------------------------------------------------
+# AvailabilitySensor — sub-percent drift quantization (v5.5 audit F-EA-1)
+# ---------------------------------------------------------------------------
+
+
+class TestAvailabilitySensorQuantization:
+    """``native_value`` and ``per_device`` are quantized to whole percent."""
+
+    def test_native_value_returns_integer(self, mock_coordinator, mock_hass):
+        """``native_value`` returns an integer (round to whole percent)."""
+        now = datetime.now(timezone.utc)
+        storage = mock_coordinator.availability_storage
+        for eid in mock_coordinator.monitored_entities:
+            for i in range(24):
+                storage.record_online(eid, 3600.0, now - timedelta(hours=i))
+
+        sensor = AvailabilitySensor(
+            mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        value = sensor.native_value
+        assert value == 100
+        assert isinstance(value, int)
+
+    def test_per_device_values_are_integers(self, mock_coordinator, mock_hass):
+        """``extra_state_attributes['per_device']`` values are int (not float)."""
+        now = datetime.now(timezone.utc)
+        storage = mock_coordinator.availability_storage
+        for eid in mock_coordinator.monitored_entities:
+            for i in range(24):
+                storage.record_online(eid, 3600.0, now - timedelta(hours=i))
+
+        sensor = AvailabilitySensor(
+            mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        per_device = sensor.extra_state_attributes["per_device"]
+        for eid, value in per_device.items():
+            assert value is None or isinstance(value, int), (
+                f"{eid} must be int after quantization, got {type(value).__name__}"
+            )
+
+    def test_per_device_preserves_none(self, mock_coordinator, mock_hass):
+        """Devices with no data still report ``None`` (not rounded to 0)."""
+        sensor = AvailabilitySensor(
+            mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        per_device = sensor.extra_state_attributes["per_device"]
+        for value in per_device.values():
+            assert value is None
+
+    def test_dedup_catches_sub_percent_drift(self, mock_coordinator, mock_hass):
+        """1000 ticks with sub-percent jitter must produce <10 state writes.
+
+        Reproduces v5.5 audit F-EA-1: rolling-window numerator drifts by
+        ~SCAN_INTERVAL/window each tick, defeating dedup if values aren't
+        quantized. After quantization, the rounded percentage stays put.
+        Simulates the unrounded float jitter directly on ``get_availability``
+        so the test is independent of bucket arithmetic.
+        """
+        sensor = AvailabilitySensor(
+            mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+
+        storage = mock_coordinator.availability_storage
+        tick = {"n": 0}
+
+        def _drifting(_eid, _window, _now):
+            # 30s/86400s ≈ 0.035% per-tick drift around 99.5% — the sub-percent
+            # jitter observed in the v5.5 DB sample. Same value within a tick
+            # so native_value and per_device agree; advances per tick caller.
+            return 99.5 + (tick["n"] * 30 / 86400)
+
+        with (
+            patch.object(storage, "get_availability", side_effect=_drifting),
+            patch.object(sensor, "async_write_ha_state") as write,
+        ):
+            for i in range(1000):
+                tick["n"] = i
+                sensor._handle_coordinator_update()
+
+        # Pre-fix: ~1000 writes (1 per tick). Post-fix: ≤ a handful as the
+        # rounded percentage occasionally crosses an integer boundary.
+        assert write.call_count < 10, (
+            f"dedup failed to suppress sub-percent drift: {write.call_count} writes"
+        )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1160,10 +1160,10 @@ async def test_sensor_setup_entry_slug_fallback(
 
 
 class TestAvailabilitySensorQuantization:
-    """``native_value`` and ``per_device`` are quantized to whole percent."""
+    """``native_value`` and ``per_device`` are quantized to 1 decimal."""
 
-    def test_native_value_returns_integer(self, mock_coordinator, mock_hass):
-        """``native_value`` returns an integer (round to whole percent)."""
+    def test_native_value_one_decimal(self, mock_coordinator, mock_hass):
+        """``native_value`` returns a 1-decimal float (public API unchanged)."""
         now = datetime.now(timezone.utc)
         storage = mock_coordinator.availability_storage
         for eid in mock_coordinator.monitored_entities:
@@ -1175,29 +1175,35 @@ class TestAvailabilitySensorQuantization:
         )
         sensor.hass = mock_hass
         value = sensor.native_value
-        assert value == 100
-        assert isinstance(value, int)
+        assert value == 100.0
+        assert isinstance(value, float)
 
-    def test_per_device_values_are_integers(self, mock_coordinator, mock_hass):
-        """``extra_state_attributes['per_device']`` values are int (not float)."""
-        now = datetime.now(timezone.utc)
-        storage = mock_coordinator.availability_storage
-        for eid in mock_coordinator.monitored_entities:
-            for i in range(24):
-                storage.record_online(eid, 3600.0, now - timedelta(hours=i))
+    def test_per_device_values_one_decimal(self, mock_coordinator, mock_hass):
+        """``extra_state_attributes['per_device']`` values rounded to 1 decimal.
 
+        Previously these were unrounded floats — drift on every tick defeated
+        ``WriteDedupMixin``. Must match ``native_value`` precision.
+        """
         sensor = AvailabilitySensor(
             mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
         )
         sensor.hass = mock_hass
-        per_device = sensor.extra_state_attributes["per_device"]
+
+        storage = mock_coordinator.availability_storage
+
+        def _drifty(_eid, _window, _now):
+            # Unrounded float typical of pre-fix storage behaviour.
+            return 99.84736821
+
+        with patch.object(storage, "get_availability", side_effect=_drifty):
+            per_device = sensor.extra_state_attributes["per_device"]
         for eid, value in per_device.items():
-            assert value is None or isinstance(value, int), (
-                f"{eid} must be int after quantization, got {type(value).__name__}"
+            assert value is None or value == 99.8, (
+                f"{eid} must be 1-decimal rounded, got {value!r}"
             )
 
     def test_per_device_preserves_none(self, mock_coordinator, mock_hass):
-        """Devices with no data still report ``None`` (not rounded to 0)."""
+        """Devices with no data still report ``None`` (not rounded to 0.0)."""
         sensor = AvailabilitySensor(
             mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
         )
@@ -1207,13 +1213,13 @@ class TestAvailabilitySensorQuantization:
             assert value is None
 
     def test_dedup_catches_sub_percent_drift(self, mock_coordinator, mock_hass):
-        """1000 ticks with sub-percent jitter must produce <10 state writes.
+        """1000 ticks with sub-0.1% jitter must produce <10 state writes.
 
         Reproduces v5.5 audit F-EA-1: rolling-window numerator drifts by
-        ~SCAN_INTERVAL/window each tick, defeating dedup if values aren't
-        quantized. After quantization, the rounded percentage stays put.
-        Simulates the unrounded float jitter directly on ``get_availability``
-        so the test is independent of bucket arithmetic.
+        ~SCAN_INTERVAL/window each tick. Pre-fix the unrounded per_device
+        floats moved on every tick, defeating dedup. Post-fix both
+        native_value and per_device are rounded to 1 decimal — sub-0.1%
+        drift collapses below the rounding step.
         """
         sensor = AvailabilitySensor(
             mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
@@ -1224,9 +1230,8 @@ class TestAvailabilitySensorQuantization:
         tick = {"n": 0}
 
         def _drifting(_eid, _window, _now):
-            # 30s/86400s ≈ 0.035% per-tick drift around 99.5% — the sub-percent
-            # jitter observed in the v5.5 DB sample. Same value within a tick
-            # so native_value and per_device agree; advances per tick caller.
+            # 30s/86400s ≈ 0.035% per-tick drift around 99.5% — below 0.1%
+            # rounding step so the published values stay flat.
             return 99.5 + (tick["n"] * 30 / 86400)
 
         with (
@@ -1237,20 +1242,16 @@ class TestAvailabilitySensorQuantization:
                 tick["n"] = i
                 sensor._handle_coordinator_update()
 
-        # Pre-fix: ~1000 writes (1 per tick). Post-fix: ≤ a handful as the
-        # rounded percentage occasionally crosses an integer boundary.
         assert write.call_count < 10, (
-            f"dedup failed to suppress sub-percent drift: {write.call_count} writes"
+            f"dedup failed to suppress sub-0.1% drift: {write.call_count} writes"
         )
 
     def test_dedup_with_boundary_crossings(self, mock_coordinator, mock_hass):
-        """Drift that crosses several integer boundaries still dedups most ticks.
+        """Drift across a 0.1% boundary writes once per crossing, suppresses rest.
 
-        Faster ramp (0.83% per tick = 30s/3600s, simulating a 1h-style window)
-        starts at 99.0 and crosses 100, then 100→101 etc. Each crossing
-        legitimately writes once; everything between crossings is suppressed.
-        Verifies the quantization actually flips correctly at the boundary
-        rather than silently failing the dedup.
+        Confirms the quantization actually *flips* at the 0.1% boundary —
+        a broken rounding (e.g. floor) could silently dedup forever and
+        pass the steady-state test above.
         """
         sensor = AvailabilitySensor(
             mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
@@ -1259,31 +1260,26 @@ class TestAvailabilitySensorQuantization:
 
         storage = mock_coordinator.availability_storage
         tick = {"n": 0}
-        observed_states: list[int] = []
+        observed: set[float] = set()
 
         def _drifting(_eid, _window, _now):
-            return 99.0 + (tick["n"] * 30 / 3600)
-
-        # Capture the integer states actually published.
-        original = sensor._handle_coordinator_update
-
-        def _spy():
-            observed_states.append(sensor.native_value)
-            original()
+            # 0.01% per tick → 10 ticks per 0.1% boundary crossing.
+            return 99.00 + (tick["n"] * 0.01)
 
         with (
             patch.object(storage, "get_availability", side_effect=_drifting),
             patch.object(sensor, "async_write_ha_state") as write,
         ):
-            for i in range(120):  # 120 ticks → drift 99.0 → 100.0 (1 crossing)
+            for i in range(20):  # drift 99.0 → 99.19 → 2 crossings
                 tick["n"] = i
-                _spy()
+                observed.add(sensor.native_value)
+                sensor._handle_coordinator_update()
 
-        # Drift hits exactly 1 integer boundary (99 → 100) over 120 ticks.
-        # Allow up to 3 writes for the boundary plus the first publish.
-        assert write.call_count <= 3, (
-            f"too many writes across single boundary: {write.call_count}"
+        # 2 boundary crossings + initial publish = ≤4 writes.
+        assert write.call_count <= 4, (
+            f"too many writes across 0.1% boundaries: {write.call_count}"
         )
-        # Confirm quantization actually flipped — both 99 and 100 appeared.
-        assert 99 in observed_states
-        assert 100 in observed_states
+        # Quantization must have flipped — both sides observed.
+        assert 99.0 in observed
+        assert 99.1 in observed
+        assert 99.2 in observed

--- a/tests/test_write_dedup.py
+++ b/tests/test_write_dedup.py
@@ -478,15 +478,14 @@ def test_availability_sensor_dedup_skips_unchanged(mock_coordinator, mock_hass) 
 def test_availability_sensor_dedup_catches_sub_percent_drift(
     mock_coordinator, mock_hass
 ) -> None:
-    """v5.5 F-EA-1: sub-percent rolling-window drift must not defeat dedup.
+    """v5.5 F-EA-1: sub-0.1% rolling-window drift must not defeat dedup.
 
-    Without quantization, ``native_value`` and the ``per_device`` attribute
-    floats drift on every coordinator tick (the in-progress 5-min bucket grows
-    by ``SCAN_INTERVAL`` seconds per tick), defeating ``WriteDedupMixin`` and
-    producing one recorder row per tick (~2880/day per ``_today`` sensor).
-
-    Quantizing both to whole percent collapses the per-tick noise so dedup
-    wins on virtually every tick.
+    Pre-fix, ``extra_state_attributes['per_device']`` returned unrounded
+    floats that drifted on every coordinator tick, defeating
+    ``WriteDedupMixin`` and producing one recorder row per tick
+    (~2880/day per ``_today`` sensor). Post-fix the per_device values are
+    rounded to 1 decimal (matching ``native_value``); sub-0.1% drift
+    collapses below the rounding step so dedup wins on virtually every tick.
     """
     sensor = AvailabilitySensor(
         mock_coordinator, "Test Group", "test_group", "today", "eid"
@@ -507,19 +506,17 @@ def test_availability_sensor_dedup_catches_sub_percent_drift(
             sensor._handle_coordinator_update()
 
     assert write.call_count < 10, (
-        f"sub-percent drift defeated dedup: {write.call_count}/1000 writes"
+        f"sub-0.1% drift defeated dedup: {write.call_count}/1000 writes"
     )
 
 
-def test_availability_sensor_dedup_writes_on_integer_boundary(
+def test_availability_sensor_dedup_writes_on_decimal_boundary(
     mock_coordinator, mock_hass
 ) -> None:
-    """Boundary-crossing drift writes once per crossing, suppresses everything else.
+    """Drift crossing a 0.1% boundary writes once per crossing.
 
-    Confirms the quantization actually *flips* at the integer boundary —
-    a stronger guarantee than the steady-state test above. Without this,
-    a broken quantization (e.g. ``int(value)`` instead of ``round(value)``)
-    could silently dedup forever and pass the steady-state test.
+    Confirms the 1-decimal rounding actually flips at the boundary —
+    a stronger guarantee than the steady-state test above.
     """
     sensor = AvailabilitySensor(
         mock_coordinator, "Test Group", "test_group", "today", "eid"
@@ -529,25 +526,23 @@ def test_availability_sensor_dedup_writes_on_integer_boundary(
     tick = {"n": 0}
 
     def _drifting(_eid, _window, _now):
-        # 0.83% per tick; 60 ticks → drift 99.0 → 99.5 (no crossing yet)
-        # 120 ticks → drift 99.0 → 100.0 (one crossing).
-        return 99.0 + (tick["n"] * 30 / 3600)
+        # 0.01% per tick → 10 ticks per 0.1% boundary crossing.
+        return 99.00 + (tick["n"] * 0.01)
 
-    states_seen: set[int] = set()
+    states_seen: set[float] = set()
     with (
         patch.object(storage, "get_availability", side_effect=_drifting),
         patch.object(sensor, "async_write_ha_state") as write,
     ):
-        for i in range(120):
+        for i in range(20):
             tick["n"] = i
             states_seen.add(sensor.native_value)
             sensor._handle_coordinator_update()
 
-    assert write.call_count <= 3, (
-        f"too many writes across single boundary: {write.call_count}"
+    assert write.call_count <= 4, (
+        f"too many writes across 0.1% boundaries: {write.call_count}"
     )
-    # Quantization must have flipped — both sides of the boundary appear.
-    assert {99, 100}.issubset(states_seen)
+    assert {99.0, 99.1, 99.2}.issubset(states_seen)
 
 
 def test_dedup_sensor_first_write_after_construction(mock_coordinator) -> None:

--- a/tests/test_write_dedup.py
+++ b/tests/test_write_dedup.py
@@ -511,6 +511,45 @@ def test_availability_sensor_dedup_catches_sub_percent_drift(
     )
 
 
+def test_availability_sensor_dedup_writes_on_integer_boundary(
+    mock_coordinator, mock_hass
+) -> None:
+    """Boundary-crossing drift writes once per crossing, suppresses everything else.
+
+    Confirms the quantization actually *flips* at the integer boundary —
+    a stronger guarantee than the steady-state test above. Without this,
+    a broken quantization (e.g. ``int(value)`` instead of ``round(value)``)
+    could silently dedup forever and pass the steady-state test.
+    """
+    sensor = AvailabilitySensor(
+        mock_coordinator, "Test Group", "test_group", "today", "eid"
+    )
+    sensor.hass = mock_hass
+    storage = mock_coordinator.availability_storage
+    tick = {"n": 0}
+
+    def _drifting(_eid, _window, _now):
+        # 0.83% per tick; 60 ticks → drift 99.0 → 99.5 (no crossing yet)
+        # 120 ticks → drift 99.0 → 100.0 (one crossing).
+        return 99.0 + (tick["n"] * 30 / 3600)
+
+    states_seen: set[int] = set()
+    with (
+        patch.object(storage, "get_availability", side_effect=_drifting),
+        patch.object(sensor, "async_write_ha_state") as write,
+    ):
+        for i in range(120):
+            tick["n"] = i
+            states_seen.add(sensor.native_value)
+            sensor._handle_coordinator_update()
+
+    assert write.call_count <= 3, (
+        f"too many writes across single boundary: {write.call_count}"
+    )
+    # Quantization must have flipped — both sides of the boundary appear.
+    assert {99, 100}.issubset(states_seen)
+
+
 def test_dedup_sensor_first_write_after_construction(mock_coordinator) -> None:
     """A freshly constructed concrete sensor writes on its first refresh."""
     sensor = OfflineCountSensor(mock_coordinator, "Test Group", "test_group", "eid")

--- a/tests/test_write_dedup.py
+++ b/tests/test_write_dedup.py
@@ -516,7 +516,11 @@ def test_availability_sensor_dedup_writes_on_decimal_boundary(
     """Drift crossing a 0.1% boundary writes once per crossing.
 
     Confirms the 1-decimal rounding actually flips at the boundary —
-    a stronger guarantee than the steady-state test above.
+    a stronger guarantee than the steady-state test in test_sensor.py.
+
+    Uses unambiguous mid-step values (99.03, 99.13, ...) to dodge
+    banker's-rounding + float-repr quirks at exact half-step points like
+    99.05 (stored as 99.0499... → rounds to 99.0, not 99.1).
     """
     sensor = AvailabilitySensor(
         mock_coordinator, "Test Group", "test_group", "today", "eid"
@@ -526,23 +530,25 @@ def test_availability_sensor_dedup_writes_on_decimal_boundary(
     tick = {"n": 0}
 
     def _drifting(_eid, _window, _now):
-        # 0.01% per tick → 10 ticks per 0.1% boundary crossing.
-        return 99.00 + (tick["n"] * 0.01)
+        # Step 0.1 per tick, offset 0.03 so each value sits cleanly inside a
+        # rounding bucket: 99.03 → 99.0, 99.13 → 99.1, 99.23 → 99.2, ...
+        return 99.03 + (tick["n"] * 0.1)
 
     states_seen: set[float] = set()
     with (
         patch.object(storage, "get_availability", side_effect=_drifting),
         patch.object(sensor, "async_write_ha_state") as write,
     ):
-        for i in range(20):
+        for i in range(3):  # 99.03, 99.13, 99.23 → 99.0, 99.1, 99.2
             tick["n"] = i
             states_seen.add(sensor.native_value)
             sensor._handle_coordinator_update()
 
-    assert write.call_count <= 4, (
-        f"too many writes across 0.1% boundaries: {write.call_count}"
+    # 3 distinct rounded values → 3 writes (one per crossing including init).
+    assert write.call_count == 3, (
+        f"expected 3 writes across 3 distinct 0.1% buckets, got {write.call_count}"
     )
-    assert {99.0, 99.1, 99.2}.issubset(states_seen)
+    assert {99.0, 99.1, 99.2} == states_seen
 
 
 def test_dedup_sensor_first_write_after_construction(mock_coordinator) -> None:

--- a/tests/test_write_dedup.py
+++ b/tests/test_write_dedup.py
@@ -475,6 +475,42 @@ def test_availability_sensor_dedup_skips_unchanged(mock_coordinator, mock_hass) 
     assert write.call_count == 1
 
 
+def test_availability_sensor_dedup_catches_sub_percent_drift(
+    mock_coordinator, mock_hass
+) -> None:
+    """v5.5 F-EA-1: sub-percent rolling-window drift must not defeat dedup.
+
+    Without quantization, ``native_value`` and the ``per_device`` attribute
+    floats drift on every coordinator tick (the in-progress 5-min bucket grows
+    by ``SCAN_INTERVAL`` seconds per tick), defeating ``WriteDedupMixin`` and
+    producing one recorder row per tick (~2880/day per ``_today`` sensor).
+
+    Quantizing both to whole percent collapses the per-tick noise so dedup
+    wins on virtually every tick.
+    """
+    sensor = AvailabilitySensor(
+        mock_coordinator, "Test Group", "test_group", "today", "eid"
+    )
+    sensor.hass = mock_hass
+    storage = mock_coordinator.availability_storage
+    tick = {"n": 0}
+
+    def _drifting(_eid, _window, _now):
+        return 99.5 + (tick["n"] * 30 / 86400)
+
+    with (
+        patch.object(storage, "get_availability", side_effect=_drifting),
+        patch.object(sensor, "async_write_ha_state") as write,
+    ):
+        for i in range(1000):
+            tick["n"] = i
+            sensor._handle_coordinator_update()
+
+    assert write.call_count < 10, (
+        f"sub-percent drift defeated dedup: {write.call_count}/1000 writes"
+    )
+
+
 def test_dedup_sensor_first_write_after_construction(mock_coordinator) -> None:
     """A freshly constructed concrete sensor writes on its first refresh."""
     sensor = OfflineCountSensor(mock_coordinator, "Test Group", "test_group", "eid")


### PR DESCRIPTION
## Summary

Fixes v5.5 audit finding **F-EA-1**: `AvailabilitySensor` emits ~2880 state writes/day per `*_availability_today` sensor — observed as **1.45M `states` rows over 50 days** in the deployment DB sample.

Root cause: `AvailabilitySensor.extra_state_attributes['per_device']` returned the **unrounded** float from `storage.get_availability`, while `native_value` had always rounded to 1 decimal. Each coordinator tick (`SCAN_INTERVAL = 30s`) advances the in-progress 5-minute bucket by ~30s, so the rolling-24h numerator drifts by `30 / 86400 ≈ 0.035%` per tick. Even when the group-level rounded `native_value` was stable, the unrounded `per_device` dict differed on every tick — `WriteDedupMixin._ea_should_write` saw a different (value, attrs) triple and forced `async_write_ha_state`.

## Fix

Round the `per_device` attribute values to 1 decimal, matching `native_value` precision. Sub-0.1% drift now collapses below the rounding step on every tick; dedup wins on virtually every tick.

```python
# sensor.py — AvailabilitySensor.extra_state_attributes
breakdown[entity_id] = round(avail, 1) if avail is not None else None  # was unrounded
```

**No public API change.**

| Element | Before | After |
|---|---|---|
| `native_value` type | `float \| None` | `float \| None` |
| `native_value` precision | `round(v, 1)` | `round(v, 1)` |
| `extra_state_attributes` keys | `{"per_device": {...}}` | `{"per_device": {...}}` |
| `per_device` value type | `float \| None` | `float \| None` |
| `per_device` precision | unrounded (e.g. `99.84736821`) | `round(v, 1)` (e.g. `99.8`) |
| `storage.get_availability` | `round(v, 1)` | `round(v, 1)` |
| Card display (`w.pct.toFixed(1)`) | `"99.8%"` | `"99.8%"` |

`SCAN_INTERVAL = 30s` and the `WriteDedupMixin` attribute-comparison logic are left untouched — the dedup itself was correct; only the upstream `per_device` value needed rounding. `_7d` and longer windows were unaffected by the bug (drift per tick is below the rounding step naturally) and stay unaffected here.

## Tests

400 tests pass, 100% coverage. New tests:

- `tests/test_sensor.py::TestAvailabilitySensorQuantization`
  - `test_native_value_one_decimal` — public API contract: `float`, 1 decimal.
  - `test_per_device_values_one_decimal` — every `per_device` value rounded to 1 decimal.
  - `test_per_device_preserves_none` — missing-data sentinel preserved.
  - `test_dedup_catches_sub_percent_drift` — 1000 ticks of sub-0.1% drift → asserts `<10` writes (pre-fix: ~1000).
  - `test_dedup_with_boundary_crossings` — drift crossing 0.1% boundaries writes once per crossing.
- `tests/test_write_dedup.py`
  - `test_availability_sensor_dedup_catches_sub_percent_drift` — drift scenario via `_handle_coordinator_update`.
  - `test_availability_sensor_dedup_writes_on_decimal_boundary` — confirms the rounding actually flips at 0.1%.

## Impact

Estimated DB write reduction: ~30× for `_today` sensors. Top three writers in the v5.5 sample (2458, 2458, 2165 rows/day each) should drop to single-digit-per-day in steady state once the `per_device` dict stops mutating on every tick.

## References

- Root-cause analysis: `analysis_workspace/v55_findings/ENTITY_AVAILABILITY_ROOT_CAUSE.md`
- Audit finding: **F-EA-1**
- Version bumped: `0.3.7` → `0.3.8`