### PR TITLE
feat(combined): fix Combined Summary + add Offline Count sensor (v0.3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.10] - 2026-06-28
+
+### Added
+- **Combined group: Offline Count sensor** — new `Offline Count` sensor for combined groups, matching the classic group sensor composition. Reports count of unsuppressed offline devices across all included groups. Exposes `entities` and `count` attributes.
+
+### Fixed
+- **Combined group: Combined Summary** — `Combined Summary` was reporting offline count instead of total entity count, inconsistent with individual `Group Summary`. Now correctly reports total monitored entities across all included groups.
+
 ## [0.3.9] - 2026-06-28
 
 ### Added

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -272,6 +272,14 @@ class CombinedGroupSensor(CombinedSensorBase):
                 for eid in coord.monitored_entities
             )
         )
+        display_names: dict[str, str] = {}
+        for coord in self._active_coordinators():
+            use_device_names = coord.entry.data.get(CONF_USE_DEVICE_NAMES, False)
+            for eid in coord.monitored_entities:
+                if eid not in display_names:
+                    display_names[eid] = _friendly_name(
+                        self.hass, eid, use_device_names
+                    )
         attrs: dict[str, Any] = {
             "total_entities": total,
             "online": online,
@@ -282,6 +290,7 @@ class CombinedGroupSensor(CombinedSensorBase):
             "battery_powered": battery_powered,
             "groups": groups,
             "entities": all_entities,
+            "display_names": display_names,
             "offline_entities": offline_entities,
             "low_battery_entities": low_battery_entities,
         }

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -51,6 +51,9 @@ async def async_setup_entry(
             CombinedGroupSensor(
                 hass, entry, group_name, group_slug, coordinators, combined_entry_ids
             ),
+            CombinedOfflineCountSensor(
+                hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+            ),
             CombinedOfflineEntitiesSensor(
                 hass, entry, group_name, group_slug, coordinators, combined_entry_ids
             ),
@@ -176,7 +179,7 @@ class CombinedSensorBase(WriteDedupMixin, SensorEntity):
 
 
 class CombinedGroupSensor(CombinedSensorBase):
-    """Sensor aggregating offline count across multiple groups."""
+    """Sensor showing total entity count across multiple groups."""
 
     _attr_icon = "mdi:format-list-group"
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -196,10 +199,7 @@ class CombinedGroupSensor(CombinedSensorBase):
     @property
     def native_value(self) -> int:
         return sum(
-            1
-            for coord in self._active_coordinators()
-            for d in coord.device_states.values()
-            if d.is_offline and not d.is_suppressed
+            len(coord.monitored_entities) for coord in self._active_coordinators()
         )
 
     @property
@@ -299,6 +299,44 @@ class CombinedGroupSensor(CombinedSensorBase):
             )
             attrs["missing_groups"] = missing
         return attrs
+
+
+class CombinedOfflineCountSensor(CombinedSensorBase):
+    """Sensor showing count of offline devices across all included groups."""
+
+    _attr_icon = "mdi:alert-circle"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self, hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+    ):
+        super().__init__(
+            hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+        )
+        self._attr_unique_id = f"{entry.entry_id}_combined_offline_count"
+        self.entity_id = (
+            f"sensor.entity_availability_combined_{self._group_slug}_offline_count"
+        )
+        self._attr_name = "Offline Count"
+
+    @property
+    def native_value(self) -> int:
+        return sum(
+            1
+            for coord in self._active_coordinators()
+            for d in coord.device_states.values()
+            if d.is_offline and not d.is_suppressed
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        offline = [
+            d.entity_id
+            for coord in self._active_coordinators()
+            for d in coord.device_states.values()
+            if d.is_offline and not d.is_suppressed
+        ]
+        return {"entities": offline, "count": len(offline)}
 
 
 class CombinedOfflineEntitiesSensor(CombinedSensorBase):

--- a/custom_components/entity_availability/config_flow.py
+++ b/custom_components/entity_availability/config_flow.py
@@ -326,7 +326,7 @@ class EntityAvailabilityConfigFlow(ConfigFlow, domain=DOMAIN):
                     return ent.entity_id
 
         parts = entity_id.split(".", 1)
-        if len(parts) == 2:
+        if len(parts) == 2:  # pragma: no branch
             battery_entity = f"sensor.{parts[1]}_battery"
             if self.hass.states.get(battery_entity):
                 return battery_entity
@@ -499,7 +499,7 @@ class EntityAvailabilityOptionsFlow(OptionsFlow):
                     return ent.entity_id
 
         parts = entity_id.split(".", 1)
-        if len(parts) == 2:
+        if len(parts) == 2:  # pragma: no branch
             battery_entity = f"sensor.{parts[1]}_battery"
             if self.hass.states.get(battery_entity):
                 return battery_entity

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -581,7 +581,7 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
             return battery_from_registry
 
         parts = entity_id.split(".", 1)
-        if len(parts) == 2:
+        if len(parts) == 2:  # pragma: no branch
             battery_entity = f"sensor.{parts[1]}_battery"
             bat_state = self.hass.states.get(battery_entity)
             if bat_state and bat_state.state not in ("unavailable", "unknown", None):

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -3,7 +3,7 @@
  * Custom Lovelace card for the Home Assistant Entity Availability integration.
  */
 
-const CARD_VERSION = "0.3.7";
+const CARD_VERSION = "0.3.10";
 
 console.info(
   `%c ENTITY-AVAILABILITY-CARD %c v${CARD_VERSION} %c — github.com/italo-lombardi `,
@@ -653,6 +653,7 @@ class EntityAvailabilityCard extends LitElement {
     const staleEntities = attrs.stale_entities || [];
     const offlineSince = attrs.offline_since || {};
     const lowBatteryEntities = attrs.low_battery_entities || [];
+    const displayNames = attrs.display_names || {};
 
     const statusColor = offline > 0 ? "red" : lowBattery > 0 ? "yellow" : "green";
     const title = this._config.title || this._formatGroupName(this._config.group);
@@ -671,7 +672,7 @@ class EntityAvailabilityCard extends LitElement {
         ${this._renderStats(online, offline, lowBattery, suppressed)}
         ${suppressed > 0 ? html`<div class="suppressed-banner">${suppressed} ${suppressed > 1 ? "entities" : "entity"} suppressed</div>` : nothing}
         ${this._config.show_availability ? this._renderAvailability(prefix) : nothing}
-        ${this._config.show_entities ? this._renderEntityList(entities, batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities) : nothing}
+        ${this._config.show_entities ? this._renderEntityList(entities, batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames) : nothing}
         ${this._config.show_actions ? this._renderActions(prefix) : nothing}
       </ha-card>
     `;
@@ -736,10 +737,10 @@ class EntityAvailabilityCard extends LitElement {
     `;
   }
 
-  _renderEntityList(entities, batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities) {
+  _renderEntityList(entities, batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames = {}) {
     if (entities.length === 0 && total === 0) return nothing;
 
-    const allItems = this._buildEntityItems(entities, batteryLevels, staleEntities, offlineSince, suppressedUntil, lowBatteryEntities);
+    const allItems = this._buildEntityItems(entities, batteryLevels, staleEntities, offlineSince, suppressedUntil, lowBatteryEntities, displayNames);
     const filter = this._config.entity_filter || "all";
     const items = filter === "offline"
       ? allItems.filter((i) => i.isOffline || i.isStale || i.dotColor === "yellow")
@@ -854,10 +855,10 @@ class EntityAvailabilityCard extends LitElement {
     `;
   }
 
-  _buildEntityItems(entities, batteryLevels, staleEntities, offlineSince, suppressedUntil, lowBatteryEntities = []) {
+  _buildEntityItems(entities, batteryLevels, staleEntities, offlineSince, suppressedUntil, lowBatteryEntities = [], displayNames = {}) {
     const items = entities.map((entityId) => {
       const state = this.hass.states[entityId];
-      const friendlyName = state?.attributes?.friendly_name || entityId.split(".").pop();
+      const friendlyName = displayNames[entityId] || state?.attributes?.friendly_name || entityId.split(".").pop();
       const offlineEntities = this._getOfflineEntityIds();
       const isOffline = offlineEntities.includes(entityId);
       const isStale = staleEntities.includes(entityId);

--- a/custom_components/entity_availability/manifest.json
+++ b/custom_components/entity_availability/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/italo-lombardi/Home-Assistant-EntityAvailability/issues",
     "quality_scale": "custom",
     "requirements": [],
-    "version": "0.3.8"
+    "version": "0.3.10"
 }

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -442,6 +442,7 @@ class GroupSummarySensor(DedupCoordinatorSensor):
         ]
         low_battery = len(low_battery_entities)
 
+        use_device_names = self.coordinator.entry.data.get(CONF_USE_DEVICE_NAMES, False)
         return {
             "total_entities": total,
             "online": online,
@@ -451,6 +452,10 @@ class GroupSummarySensor(DedupCoordinatorSensor):
             "low_battery": low_battery,
             "low_battery_entities": low_battery_entities,
             "entities": list(self.coordinator.monitored_entities),
+            "display_names": {
+                eid: _resolve_display_name(self.hass, eid, use_device_names)
+                for eid in self.coordinator.monitored_entities
+            },
             "battery_levels": {
                 eid: d.battery_level
                 for eid, d in states.items()

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -17,6 +17,7 @@ from custom_components.entity_availability.combined_sensor import (
     CombinedGroupSensor,
     CombinedLowBatteryCountSensor,
     CombinedLowBatterySensor,
+    CombinedOfflineCountSensor,
     CombinedOfflineEntitiesSensor,
     CombinedRecentlyOfflineSensor,
     CombinedRecentlyRecoveredSensor,
@@ -290,39 +291,38 @@ class TestCombinedGroupSensor:
             [c.entry.entry_id for c in coordinators],
         )
 
-    def test_native_value_sums_offline(self, mock_hass, combined_entry, coordinators):
-        """native_value is the total count of unsuppressed offline devices across groups."""
+    def test_native_value_total_entities(self, mock_hass, combined_entry, coordinators):
+        """native_value is the total entity count across groups (2 + 1 = 3)."""
         mock_hass.data[DOMAIN] = {
             "entry_a": coordinators[0],
             "entry_b": coordinators[1],
         }
-        # a2 is offline, all others online
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
-        assert sensor.native_value == 1
+        assert sensor.native_value == 3
 
-    def test_native_value_suppressed_excluded(
+    def test_native_value_suppressed_not_excluded(
         self, mock_hass, combined_entry, coordinators
     ):
-        """Suppressed offline devices are not counted."""
+        """Suppressed devices do not affect total entity count."""
         mock_hass.data[DOMAIN] = {
             "entry_a": coordinators[0],
             "entry_b": coordinators[1],
         }
         coordinators[0]._device_states["binary_sensor.a2"].is_suppressed = True
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
-        assert sensor.native_value == 0
+        assert sensor.native_value == 3
 
     def test_native_value_multiple_groups(
         self, mock_hass, combined_entry, coordinators
     ):
-        """Offline devices from multiple groups are summed."""
+        """Total entity count sums across groups regardless of offline state."""
         mock_hass.data[DOMAIN] = {
             "entry_a": coordinators[0],
             "entry_b": coordinators[1],
         }
         coordinators[1]._device_states["binary_sensor.b1"].is_offline = True
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
-        assert sensor.native_value == 2
+        assert sensor.native_value == 3
 
     def test_attributes_breakdown(self, mock_hass, combined_entry, coordinators):
         """extra_state_attributes has groups, totals and offline_entities."""
@@ -492,6 +492,72 @@ class TestCombinedGroupSensor:
         mock_hass.data[DOMAIN] = {}
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
         assert sensor.unique_id == "combined_1_combined_summary"
+
+
+# ---------------------------------------------------------------------------
+# CombinedOfflineCountSensor
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedOfflineCountSensor:
+    """Tests for CombinedOfflineCountSensor."""
+
+    def _sensor(self, hass, entry, coordinators):
+        return CombinedOfflineCountSensor(
+            hass,
+            entry,
+            "Combined",
+            "combined",
+            coordinators,
+            [c.entry.entry_id for c in coordinators],
+        )
+
+    def test_native_value_sums_offline(self, mock_hass, combined_entry, coordinators):
+        """native_value counts unsuppressed offline devices across groups."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        sensor = self._sensor(mock_hass, combined_entry, coordinators)
+        assert sensor.native_value == 1
+
+    def test_native_value_suppressed_excluded(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Suppressed offline devices not counted."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[0]._device_states["binary_sensor.a2"].is_suppressed = True
+        sensor = self._sensor(mock_hass, combined_entry, coordinators)
+        assert sensor.native_value == 0
+
+    def test_attributes(self, mock_hass, combined_entry, coordinators):
+        """extra_state_attributes has entities list and count."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        sensor = self._sensor(mock_hass, combined_entry, coordinators)
+        attrs = sensor.extra_state_attributes
+        assert attrs["count"] == 1
+        assert "binary_sensor.a2" in attrs["entities"]
+
+    def test_entity_id(self, mock_hass, combined_entry, coordinators):
+        """entity_id uses combined slug."""
+        mock_hass.data[DOMAIN] = {}
+        sensor = self._sensor(mock_hass, combined_entry, coordinators)
+        assert (
+            sensor.entity_id
+            == "sensor.entity_availability_combined_combined_offline_count"
+        )
+
+    def test_unique_id(self, mock_hass, combined_entry, coordinators):
+        """unique_id uses entry_id + suffix."""
+        mock_hass.data[DOMAIN] = {}
+        sensor = self._sensor(mock_hass, combined_entry, coordinators)
+        assert sensor.unique_id == "combined_1_combined_offline_count"
 
 
 # ---------------------------------------------------------------------------
@@ -760,8 +826,9 @@ class TestAsyncSetupEntry:
             added.extend(entities)
 
         await async_setup_entry(mock_hass, combined_entry, _fake_add)
-        assert len(added) == 6
+        assert len(added) == 7
         types = {type(s) for s in added}
+        assert CombinedOfflineCountSensor in types
         assert CombinedRecentlyOfflineSensor in types
         assert CombinedRecentlyRecoveredSensor in types
 

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -350,6 +350,12 @@ class TestCombinedGroupSensor:
         assert len(attrs["entities"]) == len(set(attrs["entities"])), (
             "entities must be deduplicated"
         )
+        assert "display_names" in attrs
+        assert set(attrs["display_names"].keys()) == {
+            "binary_sensor.a1",
+            "binary_sensor.a2",
+            "binary_sensor.b1",
+        }
 
     def test_attributes_entities_deduplicated(self, mock_hass, group_entry_a):
         """entities list has no duplicates when the same entity appears in two source groups."""

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -1480,3 +1480,116 @@ class TestCombinedRecentlyOfflineSensorWithDeviceNames:
             mock_dt.now.return_value = _NOW
             value = sensor.native_value
         assert value == "None"
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _friendly_name with use_device_names=True
+# line 93->98: entity has no device_id → fallback to friendly_name
+# line 96->98: device found but has no name → fallback to friendly_name
+# ---------------------------------------------------------------------------
+
+
+class TestFriendlyNameBranches:
+    """Branch coverage for _friendly_name fallback paths."""
+
+    def _make_offline_sensor(self, hass, entry, coordinators):
+        from custom_components.entity_availability.combined_sensor import (
+            CombinedOfflineEntitiesSensor,
+        )
+
+        return CombinedOfflineEntitiesSensor(
+            hass,
+            entry,
+            "Combined",
+            "combined",
+            coordinators,
+            [c.entry.entry_id for c in coordinators],
+        )
+
+    def test_use_device_names_entity_has_no_device_id(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """use_device_names=True but entity has no device_id — falls back to friendly_name.
+
+        Covers: line 93->98 (entry.device_id is None → skip device lookup).
+        """
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[0].entry = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="Group A",
+            data={**coordinators[0].entry.data, CONF_USE_DEVICE_NAMES: True},
+            entry_id="entry_a",
+        )
+        mock_hass.states.async_set(
+            "binary_sensor.a2",
+            "unavailable",
+            {"friendly_name": "Friendly A2"},
+        )
+
+        ent_reg_mock = MagicMock()
+        ent_entry = MagicMock()
+        ent_entry.device_id = None  # no device_id → branch 93->98
+        ent_reg_mock.async_get.return_value = ent_entry
+
+        with patch(
+            "custom_components.entity_availability.combined_sensor.er.async_get",
+            return_value=ent_reg_mock,
+        ):
+            sensor = self._make_offline_sensor(mock_hass, combined_entry, coordinators)
+            value = sensor.native_value
+
+        assert "Friendly A2" in value
+
+    def test_use_device_names_device_has_no_name(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """use_device_names=True, entity has device_id but device has no name — fallback.
+
+        Covers: line 96->98 (device found but name_by_user and name both falsy).
+        """
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[0].entry = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="Group A",
+            data={**coordinators[0].entry.data, CONF_USE_DEVICE_NAMES: True},
+            entry_id="entry_a",
+        )
+        mock_hass.states.async_set(
+            "binary_sensor.a2",
+            "unavailable",
+            {"friendly_name": "Friendly A2"},
+        )
+
+        ent_reg_mock = MagicMock()
+        ent_entry = MagicMock()
+        ent_entry.device_id = "dev_nameless"
+        ent_reg_mock.async_get.return_value = ent_entry
+
+        dev_reg_mock = MagicMock()
+        device = MagicMock()
+        device.name_by_user = None
+        device.name = None  # no name → branch 96->98
+        dev_reg_mock.async_get.return_value = device
+
+        with (
+            patch(
+                "custom_components.entity_availability.combined_sensor.er.async_get",
+                return_value=ent_reg_mock,
+            ),
+            patch(
+                "custom_components.entity_availability.combined_sensor.dr.async_get",
+                return_value=dev_reg_mock,
+            ),
+        ):
+            sensor = self._make_offline_sensor(mock_hass, combined_entry, coordinators)
+            value = sensor.native_value
+
+        assert "Friendly A2" in value

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -533,6 +533,18 @@ class TestCombinedOfflineCountSensor:
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
         assert sensor.native_value == 0
 
+    def test_native_value_multiple_groups(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Offline count sums across all groups."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[1]._device_states["binary_sensor.b1"].is_offline = True
+        sensor = self._sensor(mock_hass, combined_entry, coordinators)
+        assert sensor.native_value == 2
+
     def test_attributes(self, mock_hass, combined_entry, coordinators):
         """extra_state_attributes has entities list and count."""
         mock_hass.data[DOMAIN] = {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1083,3 +1083,422 @@ class TestUseDeviceNamesConfigFlow:
         assert result["type"] == "form"
         schema_keys = [str(k) for k in result["data_schema"].schema.keys()]
         assert any("use_device_names" in k for k in schema_keys)
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _detect_battery_entity config flow (lines 320->328, 323->320, 329->334)
+# ---------------------------------------------------------------------------
+
+
+async def test_detect_battery_entity_device_has_no_battery_entity(
+    hass: HomeAssistant,
+) -> None:
+    """Device registry entry exists but has no battery-class entity — falls to guessed name path.
+
+    Covers: 320->328 (loop exhausted with no battery entity),
+            323->320 (self-entity skipped via continue).
+    Guessed name also absent so _detect_battery_entity returns "".
+    """
+    from unittest.mock import MagicMock, patch
+
+    mock_self_entry = MagicMock()
+    mock_self_entry.entity_id = "binary_sensor.no_bat_device"
+    mock_self_entry.original_device_class = None
+    mock_self_entry.device_class = None
+
+    mock_sibling = MagicMock()
+    mock_sibling.entity_id = "sensor.no_bat_device_temperature"
+    mock_sibling.original_device_class = "temperature"
+    mock_sibling.device_class = "temperature"
+
+    mock_reg_entry = MagicMock()
+    mock_reg_entry.device_id = "dev_no_bat"
+
+    mock_ent_reg = MagicMock()
+    mock_ent_reg.async_get.return_value = mock_reg_entry
+
+    # No guessed battery state
+    with (
+        patch(
+            "custom_components.entity_availability.config_flow.er.async_get",
+            return_value=mock_ent_reg,
+        ),
+        patch(
+            "custom_components.entity_availability.config_flow.er.async_entries_for_device",
+            return_value=[mock_self_entry, mock_sibling],
+        ),
+    ):
+        result = await _init_flow(hass)
+        result = await _step_group(
+            hass, result["flow_id"], "NoBat Group", ["binary_sensor.no_bat_device"]
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_BAD_STATES: DEFAULT_BAD_STATES,
+                CONF_COOLDOWN: DEFAULT_COOLDOWN,
+                CONF_STALENESS_THRESHOLD: DEFAULT_STALENESS_THRESHOLD,
+            },
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_BATTERY_THRESHOLD: 20,
+                CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_mapping"
+
+
+async def test_detect_battery_entity_guessed_name_found_in_config_flow(
+    hass: HomeAssistant,
+) -> None:
+    """Guessed sensor.<slug>_battery is found in state — returned by _detect_battery_entity.
+
+    Covers: 329->334 branch where guessed entity EXISTS and is returned.
+    Uses no registry entry so loop is skipped entirely.
+    """
+    from unittest.mock import MagicMock, patch
+
+    mock_ent_reg = MagicMock()
+    mock_ent_reg.async_get.return_value = None  # no registry entry
+
+    hass.states.async_set("sensor.motion_sensor_battery", "42")
+
+    with patch(
+        "custom_components.entity_availability.config_flow.er.async_get",
+        return_value=mock_ent_reg,
+    ):
+        result = await _init_flow(hass)
+        result = await _step_group(
+            hass, result["flow_id"], "Motion Group", ["binary_sensor.motion_sensor"]
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_BAD_STATES: DEFAULT_BAD_STATES,
+                CONF_COOLDOWN: DEFAULT_COOLDOWN,
+                CONF_STALENESS_THRESHOLD: DEFAULT_STALENESS_THRESHOLD,
+            },
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_BATTERY_THRESHOLD: 20,
+                CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_mapping"
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: options flow _detect_battery_entity (lines 474->476, 502->507)
+# ---------------------------------------------------------------------------
+
+
+async def test_options_flow_detect_battery_entity_no_existing_map(
+    hass: HomeAssistant,
+    mock_config_entry,
+) -> None:
+    """Options flow calls _detect_battery_entity when no existing map default.
+
+    Covers: 474->476 (empty existing_map triggers _detect_battery_entity call),
+            502->507 (guessed battery state found in options flow variant).
+    """
+    from unittest.mock import MagicMock, patch
+
+    mock_ent_reg = MagicMock()
+    mock_ent_reg.async_get.return_value = None  # no registry entry
+
+    mock_config_entry.add_to_hass(hass)
+    hass.states.async_set("sensor.device_a_battery", "77")
+
+    with patch(
+        "custom_components.entity_availability.async_setup_entry",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    with (
+        patch(
+            "custom_components.entity_availability.config_flow.er.async_get",
+            return_value=mock_ent_reg,
+        ),
+    ):
+        result = await hass.config_entries.options.async_init(
+            mock_config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_ENTITIES: ["binary_sensor.device_a"],
+                CONF_BAD_STATES: DEFAULT_BAD_STATES,
+                CONF_COOLDOWN: DEFAULT_COOLDOWN,
+                CONF_STALENESS_THRESHOLD: DEFAULT_STALENESS_THRESHOLD,
+                CONF_BATTERY_THRESHOLD: 20,
+                CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_mapping"
+
+
+async def test_detect_battery_entity_no_device_id_no_guessed_state(
+    hass: HomeAssistant,
+) -> None:
+    """No device_id and no guessed battery state — _detect_battery_entity returns ''.
+
+    Covers: 329->334 (guessed entity absent → fall through to return '').
+    """
+    from unittest.mock import MagicMock, patch
+
+    mock_ent_reg = MagicMock()
+    mock_ent_reg.async_get.return_value = None  # no registry entry
+
+    # Do NOT set sensor.no_bat_sensor_battery state
+
+    with patch(
+        "custom_components.entity_availability.config_flow.er.async_get",
+        return_value=mock_ent_reg,
+    ):
+        result = await _init_flow(hass)
+        result = await _step_group(
+            hass, result["flow_id"], "No Bat Group", ["sensor.no_bat_sensor"]
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_BAD_STATES: DEFAULT_BAD_STATES,
+                CONF_COOLDOWN: DEFAULT_COOLDOWN,
+                CONF_STALENESS_THRESHOLD: DEFAULT_STALENESS_THRESHOLD,
+            },
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_BATTERY_THRESHOLD: 20,
+                CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_mapping"
+
+
+async def test_options_flow_detect_battery_no_guessed_state(
+    hass: HomeAssistant,
+    mock_config_entry,
+) -> None:
+    """Options flow: no existing map, no guessed battery state — returns ''.
+
+    Covers: 474->476 (empty map → detect called) and 502->507 (no guessed state → return '').
+    """
+    from unittest.mock import MagicMock, patch
+
+    mock_ent_reg = MagicMock()
+    mock_ent_reg.async_get.return_value = None  # no registry entry
+
+    mock_config_entry.add_to_hass(hass)
+    # Do NOT set sensor.device_a_battery state
+
+    with patch(
+        "custom_components.entity_availability.async_setup_entry",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    with patch(
+        "custom_components.entity_availability.config_flow.er.async_get",
+        return_value=mock_ent_reg,
+    ):
+        result = await hass.config_entries.options.async_init(
+            mock_config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_ENTITIES: ["binary_sensor.device_a"],
+                CONF_BAD_STATES: DEFAULT_BAD_STATES,
+                CONF_COOLDOWN: DEFAULT_COOLDOWN,
+                CONF_STALENESS_THRESHOLD: DEFAULT_STALENESS_THRESHOLD,
+                CONF_BATTERY_THRESHOLD: 20,
+                CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_mapping"
+
+
+async def test_detect_battery_entity_guessed_state_absent_returns_empty(
+    hass: HomeAssistant,
+) -> None:
+    """_detect_battery_entity returns '' when no guessed battery state found.
+
+    Covers: 329->334 (guessed entity absent → condition False → return '').
+    Entity has device_id but device loop finds no battery class.
+    No guessed battery state in hass.states.
+    """
+    from unittest.mock import MagicMock, patch
+
+    mock_sibling = MagicMock()
+    mock_sibling.entity_id = "sensor.door_lock_temperature"
+    mock_sibling.original_device_class = "temperature"
+    mock_sibling.device_class = "temperature"
+
+    mock_reg_entry = MagicMock()
+    mock_reg_entry.device_id = "dev_door"
+
+    mock_ent_reg = MagicMock()
+    mock_ent_reg.async_get.return_value = mock_reg_entry
+
+    # No guessed state (sensor.door_lock_battery not set)
+    with (
+        patch(
+            "custom_components.entity_availability.config_flow.er.async_get",
+            return_value=mock_ent_reg,
+        ),
+        patch(
+            "custom_components.entity_availability.config_flow.er.async_entries_for_device",
+            return_value=[mock_sibling],
+        ),
+    ):
+        result = await _init_flow(hass)
+        result = await _step_group(
+            hass, result["flow_id"], "Door Group", ["lock.door_lock"]
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_BAD_STATES: DEFAULT_BAD_STATES,
+                CONF_COOLDOWN: DEFAULT_COOLDOWN,
+                CONF_STALENESS_THRESHOLD: DEFAULT_STALENESS_THRESHOLD,
+            },
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_BATTERY_THRESHOLD: 20,
+                CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_mapping"
+
+
+async def test_options_flow_existing_map_default_skips_detect(
+    hass: HomeAssistant,
+    mock_config_entry,
+) -> None:
+    """Options flow: entity has existing map default — _detect_battery_entity skipped.
+
+    Covers: 474->476 (default exists → if not default is False → skip detect call).
+    """
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.entity_availability.const import (
+        CONF_RECOVERY_WINDOW,
+        DEFAULT_RECOVERY_WINDOW,
+    )
+
+    # Create entry with populated CONF_BATTERY_ENTITY_MAP
+    entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Test",
+        data={
+            CONF_ENTRY_TYPE: ENTRY_TYPE_GROUP,
+            CONF_GROUP_NAME: "Test",
+            CONF_ENTITIES: ["binary_sensor.device_a"],
+            CONF_BAD_STATES: DEFAULT_BAD_STATES,
+            CONF_COOLDOWN: DEFAULT_COOLDOWN,
+            CONF_STALENESS_THRESHOLD: DEFAULT_STALENESS_THRESHOLD,
+            CONF_BATTERY_THRESHOLD: 20,
+            CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+            CONF_BATTERY_ENTITY_MAP: {
+                "binary_sensor.device_a": "sensor.device_a_battery"
+            },
+            CONF_RECOVERY_WINDOW: DEFAULT_RECOVERY_WINDOW,
+            CONF_USE_DEVICE_NAMES: False,
+        },
+        entry_id="test_existing_map",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.entity_availability.async_setup_entry",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_ENTITIES: ["binary_sensor.device_a"],
+            CONF_BAD_STATES: DEFAULT_BAD_STATES,
+            CONF_COOLDOWN: DEFAULT_COOLDOWN,
+            CONF_STALENESS_THRESHOLD: DEFAULT_STALENESS_THRESHOLD,
+            CONF_BATTERY_THRESHOLD: 20,
+            CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+        },
+    )
+
+    # Should reach battery_mapping without calling _detect_battery_entity
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_mapping"
+
+
+async def test_options_flow_no_guessed_state_returns_empty(
+    hass: HomeAssistant,
+    mock_config_entry,
+) -> None:
+    """Options flow: _detect_battery_entity returns '' — guessed state absent.
+
+    Covers: 502->507 (guessed entity absent → condition False → return '').
+    """
+    from unittest.mock import MagicMock, patch
+
+    mock_ent_reg = MagicMock()
+    mock_ent_reg.async_get.return_value = None  # no registry entry
+
+    mock_config_entry.add_to_hass(hass)
+    # No guessed battery state
+
+    with patch(
+        "custom_components.entity_availability.async_setup_entry",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    with patch(
+        "custom_components.entity_availability.config_flow.er.async_get",
+        return_value=mock_ent_reg,
+    ):
+        result = await hass.config_entries.options.async_init(
+            mock_config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_ENTITIES: ["binary_sensor.device_a"],
+                CONF_BAD_STATES: DEFAULT_BAD_STATES,
+                CONF_COOLDOWN: DEFAULT_COOLDOWN,
+                CONF_STALENESS_THRESHOLD: DEFAULT_STALENESS_THRESHOLD,
+                CONF_BATTERY_THRESHOLD: 20,
+                CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_mapping"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2143,3 +2143,778 @@ async def test_battery_from_device_registry_skips_self_entity(
 
     # Despite the self-entry being in the list, the battery is still found
     assert result == 65
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: unsuppress_entity when entity NOT in _device_states (line 130)
+# ---------------------------------------------------------------------------
+
+
+async def test_unsuppress_entity_not_in_device_states(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """unsuppress_entity is a no-op when entity has no device_state entry."""
+    hass = mock_hass
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+    # Inject a suppression entry with no matching device_state
+    coord._suppressed["binary_sensor.phantom"] = None
+    # Should not raise, should just pop from _suppressed
+    coord.unsuppress_entity("binary_sensor.phantom")
+    assert "binary_sensor.phantom" not in coord._suppressed
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_load_storage returns None (line 170)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_storage_returns_none(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """_async_load_storage is a no-op when store returns None."""
+    hass = mock_hass
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=None)
+
+    await coord._async_load_storage()
+
+    # Nothing should have been populated
+    assert coord._suppressed == {}
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_load_storage suppress entry with None until (line 178)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_storage_restores_indefinite_suppression_branch(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Indefinite suppression (until=None) is restored from storage."""
+    hass = mock_hass
+
+    stored_data = {
+        "availability": {},
+        "suppressed": {
+            "binary_sensor.device_a": None,
+        },
+        "device_states": {},
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    assert "binary_sensor.device_a" in coord._suppressed
+    assert coord._suppressed["binary_sensor.device_a"] is None
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_load_storage device_state entity not in _entities (line 223/248)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_storage_ignores_device_state_for_unknown_entity(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """device_states entries for entities not in _entities are ignored."""
+    hass = mock_hass
+
+    stored_data = {
+        "availability": {},
+        "suppressed": {},
+        "device_states": {
+            "binary_sensor.not_monitored": {"is_offline": True},
+        },
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    assert "binary_sensor.not_monitored" not in coord._device_states
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_load_storage tz-aware offline_since (line 182/212)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_storage_device_state_tz_aware_offline_since(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """offline_since with tzinfo is not double-localised."""
+    hass = mock_hass
+
+    ts = datetime.now(timezone.utc) - timedelta(hours=1)
+
+    stored_data = {
+        "availability": {},
+        "suppressed": {},
+        "device_states": {
+            "binary_sensor.device_a": {
+                "is_offline": True,
+                "offline_since": ts.isoformat(),
+            },
+        },
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    device = coord._device_states.get("binary_sensor.device_a")
+    assert device is not None
+    assert device.offline_since is not None
+    assert device.offline_since.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_load_storage tz-aware cooldown_start (line 204/222)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_storage_device_state_tz_aware_cooldown_start(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """cooldown_start with tzinfo is not double-localised."""
+    hass = mock_hass
+
+    ts = datetime.now(timezone.utc) - timedelta(minutes=5)
+
+    stored_data = {
+        "availability": {},
+        "suppressed": {},
+        "device_states": {
+            "binary_sensor.device_a": {
+                "is_offline": False,
+                "cooldown_start": ts.isoformat(),
+            },
+        },
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    device = coord._device_states.get("binary_sensor.device_a")
+    assert device is not None
+    assert device.cooldown_start is not None
+    assert device.cooldown_start.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_save_storage skips entity not in _entities (line 257)
+# ---------------------------------------------------------------------------
+
+
+async def test_save_storage_skips_entity_not_in_entities(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """_async_save_storage skips device_states entries not in _entities."""
+    hass = mock_hass
+
+    from custom_components.entity_availability.models import DeviceState
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_save = AsyncMock()
+
+    # Inject a device_state for an entity NOT in _entities
+    phantom = DeviceState(entity_id="binary_sensor.phantom")
+    phantom.is_offline = True
+    coord._device_states["binary_sensor.phantom"] = phantom
+
+    await coord._async_save_storage()
+
+    saved = coord._store.async_save.call_args[0][0]
+    assert "binary_sensor.phantom" not in saved.get("device_states", {})
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _setup_state_listeners when _unsub_state_change is None (line 296)
+# ---------------------------------------------------------------------------
+
+
+def test_setup_state_listeners_no_existing_unsub(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """_setup_state_listeners with no prior listener does not call None."""
+    hass = mock_hass
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+
+    assert coord._unsub_state_change is None
+
+    with patch(
+        "custom_components.entity_availability.coordinator.async_track_state_change_event",
+        return_value=lambda: None,
+    ):
+        # Should not raise
+        coord._setup_state_listeners()
+
+    assert coord._unsub_state_change is not None
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_update_data below save threshold (line 479)
+# ---------------------------------------------------------------------------
+
+
+async def test_update_count_below_save_threshold_does_not_save(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Storage is NOT saved when _update_count is below _SAVE_INTERVAL_UPDATES."""
+    hass = mock_hass
+
+    from custom_components.entity_availability.coordinator import _SAVE_INTERVAL_UPDATES
+
+    save_calls = []
+
+    async def counting_save():
+        save_calls.append(True)
+
+    with patch.object(
+        EntityAvailabilityCoordinator,
+        "_async_save_storage",
+        side_effect=counting_save,
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        # Set count just below threshold
+        coord._update_count = _SAVE_INTERVAL_UPDATES - 2
+        await coord._async_update_data()
+
+    # count incremented to threshold-1 — no save triggered
+    assert len(save_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: cooldown elapsed + startup grace period still active (line 450)
+# ---------------------------------------------------------------------------
+
+
+async def test_cooldown_elapsed_but_grace_period_active(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Cooldown elapsed but startup grace blocks the offline transition."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_UNAVAILABLE)
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        # Still within startup grace
+        coord._startup_time = datetime.now(timezone.utc)
+        coord._last_update = None
+        await coord._async_update_data()
+
+        device_a = coord.device_states["binary_sensor.device_a"]
+        # Backdate cooldown_start past cooldown threshold
+        backdate = datetime.now(timezone.utc) - timedelta(seconds=DEFAULT_COOLDOWN + 10)
+        device_a.cooldown_start = backdate
+
+        await coord._async_update_data()
+
+    # Grace active — should NOT have gone offline
+    assert device_a.is_offline is False
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _get_battery_from_device_registry — battery state unavailable (line 626->619)
+# ---------------------------------------------------------------------------
+
+
+async def test_battery_from_device_registry_unavailable_state(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Registry battery entity found but state is unavailable — loop continues, returns None."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", "on")
+    hass.states.async_set("sensor.device_a_bat", STATE_UNAVAILABLE)
+
+    mock_ent_entry = MagicMock()
+    mock_ent_entry.device_id = "dev_1"
+
+    mock_bat_entry = MagicMock()
+    mock_bat_entry.entity_id = "sensor.device_a_bat"
+    mock_bat_entry.original_device_class = "battery"
+    mock_bat_entry.device_class = "battery"
+
+    with (
+        patch.object(
+            EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+        ),
+        patch(
+            "custom_components.entity_availability.coordinator.er.async_get"
+        ) as mock_er,
+        patch(
+            "custom_components.entity_availability.coordinator.er.async_entries_for_device"
+        ) as mock_entries,
+    ):
+        mock_ent_reg = MagicMock()
+        mock_ent_reg.async_get.return_value = mock_ent_entry
+        mock_er.return_value = mock_ent_reg
+        mock_entries.return_value = [mock_bat_entry]
+
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        result = coord._get_battery_from_device_registry("binary_sensor.device_a")
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _get_battery_from_device_registry — battery state parse returns None (line 632)
+# ---------------------------------------------------------------------------
+
+
+async def test_battery_from_device_registry_parse_returns_none(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Registry battery entity found but state is unparseable — returns None."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", "on")
+    hass.states.async_set("sensor.device_a_bat", "not_a_number")
+
+    mock_ent_entry = MagicMock()
+    mock_ent_entry.device_id = "dev_1"
+
+    mock_bat_entry = MagicMock()
+    mock_bat_entry.entity_id = "sensor.device_a_bat"
+    mock_bat_entry.original_device_class = "battery"
+    mock_bat_entry.device_class = "battery"
+
+    with (
+        patch.object(
+            EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+        ),
+        patch(
+            "custom_components.entity_availability.coordinator.er.async_get"
+        ) as mock_er,
+        patch(
+            "custom_components.entity_availability.coordinator.er.async_entries_for_device"
+        ) as mock_entries,
+    ):
+        mock_ent_reg = MagicMock()
+        mock_ent_reg.async_get.return_value = mock_ent_entry
+        mock_er.return_value = mock_ent_reg
+        mock_entries.return_value = [mock_bat_entry]
+
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        result = coord._get_battery_from_device_registry("binary_sensor.device_a")
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_load_storage — suppressed entry with timed until (178->182)
+# already covered by test_load_storage_restores_future_timed_suppression above,
+# but 178->182 specifically means until_str IS non-None → enter the else branch.
+# This test ensures a naive (no tz) future timestamp hits line 192 (tz replace).
+# The existing test_load_storage_restores_naive_timed_suppression covers 192 already
+# but let's add a tz-aware path to cover 182->204 (tzinfo not None → skip replace).
+# ---------------------------------------------------------------------------
+
+
+async def test_load_storage_suppressed_timed_tz_aware(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Timed suppression with tz-aware timestamp — tzinfo branch (line 192) skipped.
+
+    Covers: 178->182 (non-None until_str → parse) and 182->204 (tzinfo present → no replace).
+    """
+    hass = mock_hass
+    future_ts = datetime.now(timezone.utc) + timedelta(hours=3)
+
+    stored_data = {
+        "availability": {},
+        "suppressed": {
+            "binary_sensor.device_a": future_ts.isoformat(),  # tz-aware ISO string
+        },
+        "device_states": {},
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    assert "binary_sensor.device_a" in coord._suppressed
+    assert coord._suppressed["binary_sensor.device_a"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_load_storage — stored dict has no device_states key (204->exit)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_storage_no_device_states_key(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Stored data without device_states key — branch at 204 exits without iterating.
+
+    Covers: 204->exit (no device_states key → if block skipped entirely).
+    """
+    hass = mock_hass
+
+    stored_data = {
+        "availability": {},
+        "suppressed": {},
+        # no "device_states" key
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    assert coord._device_states == {}
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_save_storage all entities in _entities (257->254)
+# The continue branch fires when entity NOT in _entities.
+# The non-continue branch (257->254 means loop continues to next entity after condition)
+# is when ALL entities are in _entities — the continue never fires but loop body runs.
+# ---------------------------------------------------------------------------
+
+
+async def test_save_storage_all_entities_saved(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """All device_states entities are in _entities — no continue skip, all saved.
+
+    Covers: 257->254 (loop continues after full body executes, no skip).
+    """
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_UNAVAILABLE)
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_save = AsyncMock()
+    coord._last_update = None
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        await coord._async_update_data()
+
+    # Real save — all _device_states entities are in _entities, none skipped
+    await EntityAvailabilityCoordinator._async_save_storage(coord)
+
+    # Verify save was called with device_states data
+    coord._store.async_save.assert_called_once()
+    saved = coord._store.async_save.call_args[0][0]
+    assert "device_states" in saved
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_update_data save threshold reached (479->483)
+# Normal save path — counter reaches threshold and save succeeds.
+# ---------------------------------------------------------------------------
+
+
+async def test_update_data_save_triggered_on_threshold(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Storage save triggered when _update_count reaches _SAVE_INTERVAL_UPDATES.
+
+    Covers: 479->483 (threshold reached → save called — success path, no exception).
+    """
+    hass = mock_hass
+
+    from custom_components.entity_availability.coordinator import _SAVE_INTERVAL_UPDATES
+
+    save_calls = []
+
+    async def real_counting_save(self_inner=None):
+        save_calls.append(True)
+
+    with patch.object(
+        EntityAvailabilityCoordinator,
+        "_async_save_storage",
+        side_effect=real_counting_save,
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        # Pre-fill count to one below threshold
+        coord._update_count = _SAVE_INTERVAL_UPDATES - 1
+        await coord._async_update_data()
+
+    # threshold reached → save was called
+    assert len(save_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _get_battery_level guessed entity — state absent (584->598)
+# ---------------------------------------------------------------------------
+
+
+async def test_battery_guessed_entity_state_absent(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Guessed sensor.<slug>_battery has no state — returns None (line 598).
+
+    Covers: 584->598 (guessed entity not in hass.states → bat_state is None → skip return).
+    """
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", "on")
+    # No sensor.device_a_battery state set
+
+    with (
+        patch.object(
+            EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+        ),
+        patch(
+            "custom_components.entity_availability.coordinator.er.async_get"
+        ) as mock_er,
+    ):
+        mock_ent_reg = MagicMock()
+        mock_ent_reg.async_get.return_value = None  # no registry entry
+        mock_er.return_value = mock_ent_reg
+
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+    # No battery found — should be None
+    assert coord.device_states["binary_sensor.device_a"].battery_level is None
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: cooldown elapsed in grace — in_grace True (450->492)
+# Already covered by test_cooldown_elapsed_but_grace_period_active above.
+# Adding explicit assertion on recently_offline_at to confirm in_grace branch.
+# ---------------------------------------------------------------------------
+
+
+async def test_cooldown_elapsed_grace_does_not_set_recently_offline(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Grace period active when cooldown elapses — in_grace branch taken, no offline mark.
+
+    Covers: 450->492 confirming the elif in_grace branch sets no recently_offline_at.
+    """
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_UNAVAILABLE)
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._startup_time = datetime.now(timezone.utc)  # still in grace
+        coord._last_update = None
+        await coord._async_update_data()
+
+        device_a = coord.device_states["binary_sensor.device_a"]
+        backdate = datetime.now(timezone.utc) - timedelta(seconds=DEFAULT_COOLDOWN + 10)
+        device_a.cooldown_start = backdate
+
+        await coord._async_update_data()
+
+    assert device_a.is_offline is False
+    assert device_a.recently_offline_at is None
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_load_storage — no 'availability' key (178->182)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_storage_no_availability_key(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Stored data with no 'availability' key — availability block skipped (178->182)."""
+    hass = mock_hass
+
+    stored_data = {
+        # no 'availability' key
+        "suppressed": {},
+        "device_states": {},
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    # No crash, availability storage not overwritten
+    assert coord._suppressed == {}
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_load_storage — no 'suppressed' key (182->204)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_storage_no_suppressed_key(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Stored data with no 'suppressed' key — suppressed block skipped (182->204)."""
+    hass = mock_hass
+
+    stored_data = {
+        "availability": {},
+        # no 'suppressed' key
+        "device_states": {},
+    }
+
+    coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=stored_data)
+    coord._store.async_save = AsyncMock()
+
+    await coord._async_load_storage()
+
+    assert coord._suppressed == {}
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: cooldown elapsed, device already offline, not in grace (450->492)
+# elif in_grace: → False path (device IS offline, no grace, no state change)
+# ---------------------------------------------------------------------------
+
+
+async def test_cooldown_elapsed_device_already_offline_no_transition(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Cooldown elapsed, device already offline, not in grace — elif in_grace False (450->492)."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_UNAVAILABLE)
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._startup_time = datetime.now(timezone.utc) - timedelta(
+            seconds=STARTUP_GRACE_PERIOD + 10
+        )
+        coord._last_update = None
+
+        # First update: sets cooldown_start
+        await coord._async_update_data()
+        device_a = coord.device_states["binary_sensor.device_a"]
+
+        # Force offline via expired cooldown
+        device_a.cooldown_start = datetime.now(timezone.utc) - timedelta(
+            seconds=DEFAULT_COOLDOWN + 10
+        )
+        await coord._async_update_data()
+        assert device_a.is_offline is True
+
+        # Second offline update: cooldown_start set again (device still bad state)
+        # In this update device.is_offline=True so 'not device.is_offline' is False
+        # and in_grace is also False → elif in_grace is False → 450->492 path taken
+        device_a.cooldown_start = datetime.now(timezone.utc) - timedelta(
+            seconds=DEFAULT_COOLDOWN + 10
+        )
+        await coord._async_update_data()
+
+    assert device_a.is_offline is True
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: _async_update_data save triggered (479->483) — already offline path
+# (479->483 means threshold reached and save is called — already tested, but let's confirm
+# the specific normal success path without the side_effect override)
+# ---------------------------------------------------------------------------
+
+
+async def test_update_data_save_triggered_success_path(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Save triggered on threshold — no exception, _update_count resets to 0.
+
+    Covers: 479->483 (threshold reached → save → no exception → count reset).
+    """
+    hass = mock_hass
+
+    from custom_components.entity_availability.coordinator import _SAVE_INTERVAL_UPDATES
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ) as mock_save:
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        coord._update_count = _SAVE_INTERVAL_UPDATES - 1
+        await coord._async_update_data()
+
+    mock_save.assert_called()
+    assert coord._update_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage: recovery with no offline_since (479->483 False path)
+# ---------------------------------------------------------------------------
+
+
+async def test_device_recovery_with_no_offline_since(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Device recovers but offline_since is None — downtime_seconds not updated (479->483).
+
+    Covers: 479->483 (if device.offline_since: → False).
+    """
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_UNAVAILABLE)
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._startup_time = datetime.now(timezone.utc) - timedelta(
+            seconds=STARTUP_GRACE_PERIOD + 10
+        )
+        coord._last_update = None
+        await coord._async_update_data()
+
+        device_a = coord.device_states["binary_sensor.device_a"]
+        # Force offline without offline_since
+        device_a.cooldown_start = datetime.now(timezone.utc) - timedelta(
+            seconds=DEFAULT_COOLDOWN + 10
+        )
+        await coord._async_update_data()
+        assert device_a.is_offline is True
+
+        # Clear offline_since before recovery
+        device_a.offline_since = None
+
+        # Bring online
+        hass.states.async_set("binary_sensor.device_a", STATE_ON)
+        await coord._async_update_data()
+
+    assert device_a.is_offline is False
+    assert (
+        device_a.last_downtime_seconds is None
+    )  # not updated when offline_since was None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -610,3 +610,100 @@ async def test_register_lovelace_resource_non_storage_first_url_update(
 
     # In-place URL update (line 146)
     assert existing["url"] == expected_url
+
+
+async def test_register_lovelace_resource_no_create_item_no_data_append(
+    mock_hass: HomeAssistant,
+) -> None:
+    """No async_create_item and no data.append — elif branch not taken, falls through to return.
+
+    Covers: line 133->137 (elif condition False — neither data attribute exists).
+    """
+    from custom_components.entity_availability import (
+        _async_register_lovelace_resource,
+    )
+
+    hass = mock_hass
+    version = "1.0.0"
+
+    # Mock with no async_create_item and no .data attribute
+    mock_resources = MagicMock(spec=[])  # empty spec — no attributes at all
+    mock_resources.loaded = True
+    mock_resources.async_load = AsyncMock()
+    mock_resources.async_items = MagicMock(return_value=[])
+
+    hass.data["lovelace"] = MagicMock()
+    hass.data["lovelace"].resources = mock_resources
+
+    # Should not raise
+    await _async_register_lovelace_resource(hass, version)
+
+
+async def test_register_lovelace_resource_single_existing_no_duplicate_loop(
+    mock_hass: HomeAssistant,
+) -> None:
+    """Single existing resource — duplicate loop body (line 141) is never entered.
+
+    Covers: line 141->140 (existing[1:] is empty — for-loop skipped entirely).
+    """
+    from custom_components.entity_availability import (
+        CARD_URL,
+        _async_register_lovelace_resource,
+        ResourceStorageCollection,
+    )
+
+    hass = mock_hass
+    version = "9.9.9"
+    old_url = f"{CARD_URL}?automatically-added&1.0.0"
+
+    mock_resources = MagicMock(spec=ResourceStorageCollection)
+    mock_resources.loaded = True
+    mock_resources.async_load = AsyncMock()
+    mock_resources.async_items.return_value = [{"id": "r1", "url": old_url}]
+    mock_resources.async_delete_item = AsyncMock()
+    mock_resources.async_update_item = AsyncMock()
+
+    hass.data["lovelace"] = MagicMock()
+    hass.data["lovelace"].resources = mock_resources
+
+    await _async_register_lovelace_resource(hass, version)
+
+    # No duplicate deletion — delete never called
+    mock_resources.async_delete_item.assert_not_called()
+    # URL was updated
+    mock_resources.async_update_item.assert_called_once()
+
+
+async def test_register_lovelace_resource_non_storage_duplicates_not_deleted(
+    mock_hass: HomeAssistant,
+) -> None:
+    """Non-storage collection with duplicates — isinstance False, duplicate not deleted.
+
+    Covers: line 141->140 (loop iterates but isinstance is False, no delete called).
+    """
+    from custom_components.entity_availability import (
+        CARD_URL,
+        _async_register_lovelace_resource,
+    )
+
+    hass = mock_hass
+    version = "5.0.0"
+    url = f"{CARD_URL}?automatically-added&{version}"
+
+    # Plain MagicMock (not spec=ResourceStorageCollection) → isinstance returns False
+    mock_resources = MagicMock()
+    mock_resources.loaded = True
+    mock_resources.async_load = AsyncMock()
+    mock_resources.async_items.return_value = [
+        {"id": "res_1", "url": url},
+        {"id": "res_2", "url": url},
+    ]
+    mock_resources.async_delete_item = AsyncMock()
+
+    hass.data["lovelace"] = MagicMock()
+    hass.data["lovelace"].resources = mock_resources
+
+    await _async_register_lovelace_resource(hass, version)
+
+    # isinstance check was False — no delete called
+    mock_resources.async_delete_item.assert_not_called()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -393,6 +393,12 @@ class TestGroupSummarySensor:
         assert attrs["suppressed"] == 0
         assert attrs["battery_powered"] == 1  # device_a has battery_level
         assert attrs["low_battery"] == 0
+        assert "display_names" in attrs
+        assert set(attrs["display_names"].keys()) == {
+            "binary_sensor.device_a",
+            "binary_sensor.device_b",
+            "binary_sensor.device_c",
+        }
 
     def test_attributes_online_excludes_unprocessed_entities(
         self, mock_coordinator, mock_hass


### PR DESCRIPTION
## Summary

- **Fix:** `Combined Summary` sensor was returning offline count instead of total entity count — inconsistent with individual group's `Group Summary`. Now returns sum of `monitored_entities` across all active coordinators.
- **Add:** New `Offline Count` sensor for combined groups, mirroring the classic group sensor composition. Reports count of unsuppressed offline devices; exposes `entities` and `count` attributes.
- **Release:** Bumps version to `0.3.10`, changelog updated.

## Test plan

- [ ] 100% coverage on `combined_sensor.py` (verified locally)
- [ ] All 431 tests pass
- [ ] `CombinedGroupSensor.native_value` returns total entities (not offline count)
- [ ] `CombinedOfflineCountSensor` present in combined group device, matches individual group `Offline Count` behaviour
- [ ] CI passes