### PR TITLE
feat(sensor): add affected areas sensors (v0.3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.3.11] - 2026-06-28
+## [0.3.11] - 2026-06-29
 
 ### Added
 - **Area sensors** — four new sensors per group and combined group exposing which physical areas are affected by offline entities:
-  - **Affected Areas Count** (`affected_areas_count`) — integer count of unique HA areas containing ≥1 offline, unsuppressed entity.
-  - **Affected Areas** (`affected_areas`) — comma-separated sorted list of area names. Attributes: `areas` (list), `count`, `unassigned_entities` (entity IDs with no area assigned).
+  - **Affected Areas Count** (`affected_areas_count`) — integer count of unique HA areas containing ≥1 offline, unsuppressed entity. Entities with no area assigned contribute under the reserved sentinel `(No Area)` so `offline_count > 0` always implies `affected_areas_count ≥ 1`.
+  - **Affected Areas** (`affected_areas`) — comma-separated sorted list of area names (including `(No Area)` when unassigned entities are offline). Attributes: `areas` (list), `count`, `unassigned_entities` (entity IDs with no area assigned).
   - **Areas Recently Offline** (`affected_areas_recently_offline`) — areas where ≥1 entity went offline within the group's `recovery_window_minutes`. Attributes: `areas`, `count`, `window_minutes`.
   - **Areas Recently Recovered** (`affected_areas_recently_recovered`) — areas where ALL non-suppressed entities are back online and the most recent recovery happened within `recovery_window_minutes`. Attributes: `areas`, `count`, `window_minutes`.
   - All four sensors appear on combined groups as well, with area deduplication across source groups.
-  - Area resolution: entity `area_id` → device `area_id` → excluded. Entities without an area assignment are silently excluded from area sensors; the `unassigned_entities` attribute on `Affected Areas` lists them for diagnostics.
+  - Area resolution: entity `area_id` → device `area_id` → `(No Area)` sentinel. The `unassigned_entities` attribute on `Affected Areas` lists entity IDs with no area for diagnostics.
   - No new configuration required — sensors appear automatically on update and reuse the group's existing `recovery_window_minutes` setting.
   - Entities are excluded if suppressed, consistent with all other sensors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.11] - 2026-06-28
+
+### Added
+- **Area sensors** — four new sensors per group and combined group exposing which physical areas are affected by offline entities:
+  - **Affected Areas Count** (`affected_areas_count`) — integer count of unique HA areas containing ≥1 offline, unsuppressed entity.
+  - **Affected Areas** (`affected_areas`) — comma-separated sorted list of area names. Attributes: `areas` (list), `count`, `unassigned_entities` (entity IDs with no area assigned).
+  - **Areas Recently Offline** (`affected_areas_recently_offline`) — areas where ≥1 entity went offline within the group's `recovery_window_minutes`. Attributes: `areas`, `count`, `window_minutes`.
+  - **Areas Recently Recovered** (`affected_areas_recently_recovered`) — areas where ALL non-suppressed entities are back online and the most recent recovery happened within `recovery_window_minutes`. Attributes: `areas`, `count`, `window_minutes`.
+  - All four sensors appear on combined groups as well, with area deduplication across source groups.
+  - Area resolution: entity `area_id` → device `area_id` → excluded. Entities without an area assignment are silently excluded from area sensors; the `unassigned_entities` attribute on `Affected Areas` lists them for diagnostics.
+  - No new configuration required — sensors appear automatically on update and reuse the group's existing `recovery_window_minutes` setting.
+  - Entities are excluded if suppressed, consistent with all other sensors.
+
 ## [0.3.10] - 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ For example, a group named "Security Devices" produces the slug `security_device
 | `sensor..._availability_5d` | Sensor | Group availability % over 5 days | Per-entity availability breakdown |
 | `sensor..._availability_7d` | Sensor | Group availability % over 7 days | Per-entity availability breakdown |
 | `binary_sensor..._any_offline` | Binary Sensor (Problem) | ON when at least one entity is offline | offline_entities, offline_count |
+| `sensor..._affected_areas_count` | Sensor | Number of unique HA areas containing ≥1 offline, unsuppressed entity | — |
+| `sensor..._affected_areas` | Sensor | Comma-separated sorted list of affected area names (`"None"` when none) | `areas` (list), `count`, `unassigned_entities` (entity IDs with no area) |
+| `sensor..._affected_areas_recently_offline` | Sensor | Areas where ≥1 entity went offline within the recovery window (`"None"` when none) | `areas` (list), `count`, `window_minutes` |
+| `sensor..._affected_areas_recently_recovered` | Sensor | Areas where all entities are back online and most recent recovery is within the recovery window (`"None"` when none) | `areas` (list), `count`, `window_minutes` |
 
 > **Note:** The Low Battery and Low Battery Count sensors are only created when battery threshold > 0. Availability window sensors are only created for windows selected during configuration. The recently-offline and recently-recovered sensors are always created regardless of battery threshold.
 
@@ -223,6 +227,10 @@ For example, a combined group named "All Devices" produces the slug `all_devices
 | `sensor..._low_battery` | Sensor | Comma-separated names of low battery entities (`"None"` when all OK) | Attributes: `devices` (dict of entity ID → battery level), `count` |
 | `sensor..._low_battery_count` | Sensor | Number of entities with low battery across all groups | — |
 | `binary_sensor..._any_offline` | Binary Sensor (Problem) | ON when any entity across all groups is offline | Attributes: `offline_entities`, `offline_count` |
+| `sensor..._affected_areas_count` | Sensor | Number of unique HA areas containing ≥1 offline, unsuppressed entity across all groups | — |
+| `sensor..._affected_areas` | Sensor | Comma-separated sorted list of affected area names (`"None"` when none) | `areas` (list), `count`, `unassigned_entities` (entity IDs with no area) |
+| `sensor..._affected_areas_recently_offline` | Sensor | Areas where ≥1 entity went offline within the relevant source group's recovery window (`"None"` when none) | `areas` (list), `count` |
+| `sensor..._affected_areas_recently_recovered` | Sensor | Areas where all entities are back online and most recent recovery is within the relevant source group's recovery window (`"None"` when none) | `areas` (list), `count` |
 
 Suppressed entities are excluded from all combined sensor states, consistent with per-group behaviour.
 

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -11,7 +11,6 @@ from typing import Any
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr, entity_registry as er  # noqa: F401
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -594,6 +593,7 @@ class CombinedAffectedAreasCountSensor(CombinedSensorBase):
 
     _attr_icon = "mdi:home-alert"
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_has_entity_name = True
 
     def __init__(
         self, hass, entry, group_name, group_slug, coordinators, combined_entry_ids
@@ -620,6 +620,7 @@ class CombinedAffectedAreasSensor(CombinedSensorBase):
     """Sensor showing sorted comma-separated areas with offline entities across all groups."""
 
     _attr_icon = "mdi:home-group"
+    _attr_has_entity_name = True
 
     def __init__(
         self, hass, entry, group_name, group_slug, coordinators, combined_entry_ids

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_GROUP_NAME,
     CONF_USE_DEVICE_NAMES,
     DOMAIN,
+    NO_AREA_SENTINEL,
 )
 from .coordinator import EntityAvailabilityCoordinator
 from .helpers import resolve_area_name, resolve_display_name
@@ -611,8 +612,7 @@ class CombinedAffectedAreasCountSensor(CombinedSensorBase):
             for d in coord.device_states.values():
                 if d.is_offline and not d.is_suppressed:
                     area = resolve_area_name(self.hass, d.entity_id)
-                    if area:
-                        areas.add(area)
+                    areas.add(area if area else NO_AREA_SENTINEL)
         return len(areas)
 
 
@@ -645,6 +645,7 @@ class CombinedAffectedAreasSensor(CombinedSensorBase):
                     if area:
                         areas.add(area)
                     else:
+                        areas.add(NO_AREA_SENTINEL)
                         unassigned.append(d.entity_id)
         self._cached_areas = sorted(areas)
         self._cached_unassigned = unassigned
@@ -702,8 +703,7 @@ class CombinedAffectedAreasRecentlyOfflineSensor(CombinedSensorBase):
                     and (now - d.recently_offline_at).total_seconds() <= cutoff
                 ):
                     area = resolve_area_name(self.hass, d.entity_id)
-                    if area:
-                        areas.add(area)
+                    areas.add(area if area else NO_AREA_SENTINEL)
         return sorted(areas)
 
     @property
@@ -751,9 +751,7 @@ class CombinedAffectedAreasRecentlyRecoveredSensor(CombinedSensorBase):
             for d in coord.device_states.values():
                 if d.is_suppressed:
                     continue
-                area = resolve_area_name(self.hass, d.entity_id)
-                if not area:
-                    continue
+                area = resolve_area_name(self.hass, d.entity_id) or NO_AREA_SENTINEL
                 area_pairs.setdefault(area, []).append((coord, d))
 
         recovered: list[str] = []

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -11,7 +11,7 @@ from typing import Any
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er  # noqa: F401
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -23,6 +23,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import EntityAvailabilityCoordinator
+from .helpers import resolve_area_name, resolve_display_name
 from .write_dedup import WriteDedupMixin
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,6 +70,18 @@ async def async_setup_entry(
             CombinedRecentlyRecoveredSensor(
                 hass, entry, group_name, group_slug, coordinators, combined_entry_ids
             ),
+            CombinedAffectedAreasCountSensor(
+                hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+            ),
+            CombinedAffectedAreasSensor(
+                hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+            ),
+            CombinedAffectedAreasRecentlyOfflineSensor(
+                hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+            ),
+            CombinedAffectedAreasRecentlyRecoveredSensor(
+                hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+            ),
         ]
     )
 
@@ -85,20 +98,7 @@ def _device_info(entry_id: str, group_name: str) -> DeviceInfo:
 def _friendly_name(
     hass: HomeAssistant, entity_id: str, use_device_names: bool = False
 ) -> str:
-    # ponytail: duplicate of _resolve_display_name in sensor.py — module-level
-    # circular import prevents sharing (sensor.py imports combined_sensor.py).
-    if use_device_names:
-        ent_reg = er.async_get(hass)
-        entry = ent_reg.async_get(entity_id)
-        if entry and entry.device_id:
-            dev_reg = dr.async_get(hass)
-            device = dev_reg.async_get(entry.device_id)
-            if device and (device.name_by_user or device.name):
-                return device.name_by_user or device.name
-    state = hass.states.get(entity_id)
-    if state and state.attributes.get("friendly_name"):
-        return state.attributes["friendly_name"]
-    return entity_id.split(".")[-1].replace("_", " ").title()
+    return resolve_display_name(hass, entity_id, use_device_names)
 
 
 class CombinedSensorBase(WriteDedupMixin, SensorEntity):
@@ -586,3 +586,203 @@ class CombinedRecentlyRecoveredSensor(CombinedSensorBase):
     def extra_state_attributes(self) -> dict[str, Any]:
         pairs = self._matching_devices()
         return {"entities": [d.entity_id for _, d in pairs], "count": len(pairs)}
+
+
+class CombinedAffectedAreasCountSensor(CombinedSensorBase):
+    """Sensor showing count of unique areas with offline entities across all groups."""
+
+    _attr_icon = "mdi:home-alert"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self, hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+    ):
+        super().__init__(
+            hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+        )
+        self._attr_unique_id = f"{entry.entry_id}_combined_affected_areas_count"
+        self.entity_id = f"sensor.entity_availability_combined_{self._group_slug}_affected_areas_count"
+        self._attr_name = "Affected Areas Count"
+
+    @property
+    def native_value(self) -> int:
+        areas: set[str] = set()
+        for coord in self._active_coordinators():
+            for d in coord.device_states.values():
+                if d.is_offline and not d.is_suppressed:
+                    area = resolve_area_name(self.hass, d.entity_id)
+                    if area:
+                        areas.add(area)
+        return len(areas)
+
+
+class CombinedAffectedAreasSensor(CombinedSensorBase):
+    """Sensor showing sorted comma-separated areas with offline entities across all groups."""
+
+    _attr_icon = "mdi:home-group"
+
+    def __init__(
+        self, hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+    ):
+        super().__init__(
+            hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+        )
+        self._attr_unique_id = f"{entry.entry_id}_combined_affected_areas"
+        self.entity_id = (
+            f"sensor.entity_availability_combined_{self._group_slug}_affected_areas"
+        )
+        self._attr_name = "Affected Areas"
+        self._cached_areas: list[str] = []
+        self._cached_unassigned: list[str] = []
+
+    def _refresh_cache(self) -> list[str]:
+        areas: set[str] = set()
+        unassigned: list[str] = []
+        for coord in self._active_coordinators():
+            for d in coord.device_states.values():
+                if d.is_offline and not d.is_suppressed:
+                    area = resolve_area_name(self.hass, d.entity_id)
+                    if area:
+                        areas.add(area)
+                    else:
+                        unassigned.append(d.entity_id)
+        self._cached_areas = sorted(areas)
+        self._cached_unassigned = unassigned
+        return self._cached_areas
+
+    @property
+    def native_value(self) -> str:
+        areas = self._refresh_cache()
+        if not areas:
+            return "None"
+        result = ", ".join(areas)
+        return (
+            result[: MAX_STATE_LENGTH - 3] + "..."
+            if len(result) > MAX_STATE_LENGTH - 3
+            else result
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "areas": self._cached_areas,
+            "count": len(self._cached_areas),
+            "unassigned_entities": self._cached_unassigned,
+        }
+
+
+class CombinedAffectedAreasRecentlyOfflineSensor(CombinedSensorBase):
+    """Sensor showing areas where an entity went offline within the window across all groups."""
+
+    _attr_icon = "mdi:home-clock"
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+    ):
+        super().__init__(
+            hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+        )
+        self._attr_unique_id = (
+            f"{entry.entry_id}_combined_affected_areas_recently_offline"
+        )
+        self.entity_id = f"sensor.entity_availability_combined_{self._group_slug}_affected_areas_recently_offline"
+        self._attr_name = "Areas Recently Offline"
+
+    def _matching_areas(self) -> list[str]:
+        now = datetime.now(timezone.utc)
+        areas: set[str] = set()
+        for coord in self._active_coordinators():
+            cutoff = coord.recovery_window_minutes * 60
+            for d in coord.device_states.values():
+                if (
+                    d.is_offline
+                    and not d.is_suppressed
+                    and d.recently_offline_at is not None
+                    and (now - d.recently_offline_at).total_seconds() <= cutoff
+                ):
+                    area = resolve_area_name(self.hass, d.entity_id)
+                    if area:
+                        areas.add(area)
+        return sorted(areas)
+
+    @property
+    def native_value(self) -> str:
+        areas = self._matching_areas()
+        if not areas:
+            return "None"
+        result = ", ".join(areas)
+        return (
+            result[: MAX_STATE_LENGTH - 3] + "..."
+            if len(result) > MAX_STATE_LENGTH - 3
+            else result
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        areas = self._matching_areas()
+        return {"areas": areas, "count": len(areas)}
+
+
+class CombinedAffectedAreasRecentlyRecoveredSensor(CombinedSensorBase):
+    """Sensor showing areas fully recovered within the window across all groups."""
+
+    _attr_icon = "mdi:home-heart"
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+    ):
+        super().__init__(
+            hass, entry, group_name, group_slug, coordinators, combined_entry_ids
+        )
+        self._attr_unique_id = (
+            f"{entry.entry_id}_combined_affected_areas_recently_recovered"
+        )
+        self.entity_id = f"sensor.entity_availability_combined_{self._group_slug}_affected_areas_recently_recovered"
+        self._attr_name = "Areas Recently Recovered"
+
+    def _matching_areas(self) -> list[str]:
+        now = datetime.now(timezone.utc)
+
+        # Build combined area → [(coord, device)] across all active coordinators
+        area_pairs: dict[str, list] = {}
+        for coord in self._active_coordinators():
+            for d in coord.device_states.values():
+                if d.is_suppressed:
+                    continue
+                area = resolve_area_name(self.hass, d.entity_id)
+                if not area:
+                    continue
+                area_pairs.setdefault(area, []).append((coord, d))
+
+        recovered: list[str] = []
+        for area, pairs in area_pairs.items():
+            if any(d.is_offline for _, d in pairs):
+                continue
+            if any(
+                d.last_recovery is not None
+                and (now - d.last_recovery).total_seconds()
+                <= coord.recovery_window_minutes * 60
+                for coord, d in pairs
+            ):
+                recovered.append(area)
+
+        return sorted(recovered)
+
+    @property
+    def native_value(self) -> str:
+        areas = self._matching_areas()
+        if not areas:
+            return "None"
+        result = ", ".join(areas)
+        return (
+            result[: MAX_STATE_LENGTH - 3] + "..."
+            if len(result) > MAX_STATE_LENGTH - 3
+            else result
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        areas = self._matching_areas()
+        return {"areas": areas, "count": len(areas)}

--- a/custom_components/entity_availability/const.py
+++ b/custom_components/entity_availability/const.py
@@ -44,3 +44,7 @@ STARTUP_GRACE_PERIOD = 60  # seconds
 # Recovery window for recently_recovered / recently_offline sensors
 CONF_RECOVERY_WINDOW = "recovery_window"
 DEFAULT_RECOVERY_WINDOW = 5  # minutes
+
+# Sentinel area name for entities with no HA area assigned.
+# Parentheses signal "not a real area" and avoid colliding with user-created area names.
+NO_AREA_SENTINEL = "(No Area)"

--- a/custom_components/entity_availability/helpers.py
+++ b/custom_components/entity_availability/helpers.py
@@ -19,7 +19,7 @@ def resolve_area_name(hass: HomeAssistant, entity_id: str) -> str | None:
     entry = ent_reg.async_get(entity_id)
     if not entry:
         return None
-    area_id = entry.area_id or None
+    area_id = entry.area_id
     if not area_id and entry.device_id:
         dev_reg = dr.async_get(hass)
         device = dev_reg.async_get(entry.device_id)

--- a/custom_components/entity_availability/helpers.py
+++ b/custom_components/entity_availability/helpers.py
@@ -1,0 +1,53 @@
+"""Shared helpers for Entity Availability."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    entity_registry as er,
+)
+
+
+def resolve_area_name(hass: HomeAssistant, entity_id: str) -> str | None:
+    """Return the area name for entity_id, or None if unassigned.
+
+    Priority: entity area_id → device area_id → None.
+    """
+    ent_reg = er.async_get(hass)
+    entry = ent_reg.async_get(entity_id)
+    if not entry:
+        return None
+    area_id = entry.area_id or None
+    if not area_id and entry.device_id:
+        dev_reg = dr.async_get(hass)
+        device = dev_reg.async_get(entry.device_id)
+        area_id = device.area_id if device else None
+    if not area_id:
+        return None
+    area_reg = ar.async_get(hass)
+    area = area_reg.async_get_area(area_id)
+    return area.name if area else None
+
+
+def resolve_display_name(
+    hass: HomeAssistant, entity_id: str, use_device_names: bool = False
+) -> str:
+    """Return a display name for entity_id.
+
+    If use_device_names is True, prefer the device name from the device registry.
+    Falls back to friendly_name state attribute, then to an entity_id slug.
+    """
+    if use_device_names:
+        ent_reg = er.async_get(hass)
+        entry = ent_reg.async_get(entity_id)
+        if entry and entry.device_id:
+            dev_reg = dr.async_get(hass)
+            device = dev_reg.async_get(entry.device_id)
+            if device and (device.name_by_user or device.name):
+                return device.name_by_user or device.name
+    state = hass.states.get(entity_id)
+    if state and state.attributes.get("friendly_name"):
+        return state.attributes["friendly_name"]
+    return entity_id.split(".")[-1].replace("_", " ").title()

--- a/custom_components/entity_availability/manifest.json
+++ b/custom_components/entity_availability/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/italo-lombardi/Home-Assistant-EntityAvailability/issues",
     "quality_scale": "custom",
     "requirements": [],
-    "version": "0.3.10"
+    "version": "0.3.11"
 }

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -26,6 +26,7 @@ from .const import (
     DEFAULT_BATTERY_THRESHOLD,
     DOMAIN,
     ENTRY_TYPE_COMBINED,
+    NO_AREA_SENTINEL,
 )
 from .coordinator import EntityAvailabilityCoordinator
 from .helpers import resolve_area_name, resolve_display_name
@@ -643,11 +644,10 @@ class AffectedAreasCountSensor(DedupCoordinatorSensor):
     @property
     def native_value(self) -> int:
         areas = {
-            resolve_area_name(self.hass, d.entity_id)
+            resolve_area_name(self.hass, d.entity_id) or NO_AREA_SENTINEL
             for d in self.coordinator.device_states.values()
             if d.is_offline and not d.is_suppressed
         }
-        areas.discard(None)
         return len(areas)
 
 
@@ -681,6 +681,7 @@ class AffectedAreasSensor(DedupCoordinatorSensor):
                 if area:
                     areas.add(area)
                 else:
+                    areas.add(NO_AREA_SENTINEL)
                     unassigned.append(d.entity_id)
         self._cached_areas = sorted(areas)
         self._cached_unassigned = unassigned
@@ -739,8 +740,7 @@ class AffectedAreasRecentlyOfflineSensor(DedupCoordinatorSensor):
                 and (now - d.recently_offline_at).total_seconds() <= cutoff
             ):
                 area = resolve_area_name(self.hass, d.entity_id)
-                if area:
-                    areas.add(area)
+                areas.add(area if area else NO_AREA_SENTINEL)
         self._cached_areas = sorted(areas)
         return self._cached_areas
 
@@ -789,14 +789,12 @@ class AffectedAreasRecentlyRecoveredSensor(DedupCoordinatorSensor):
         now = datetime.now(timezone.utc)
         cutoff = self.coordinator.recovery_window_minutes * 60
 
-        # Build area → list[DeviceState] for non-suppressed devices with an assigned area
+        # Build area → list[DeviceState] for non-suppressed devices
         area_devices: dict[str, list] = {}
         for d in self.coordinator.device_states.values():
             if d.is_suppressed:
                 continue
-            area = resolve_area_name(self.hass, d.entity_id)
-            if not area:
-                continue
+            area = resolve_area_name(self.hass, d.entity_id) or NO_AREA_SENTINEL
             area_devices.setdefault(area, []).append(d)
 
         recovered: list[str] = []

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -12,8 +12,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers import device_registry as dr, entity_registry as er  # noqa: F401
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
-from homeassistant.helpers import entity_registry as er, device_registry as dr
 
 from .const import (
     CONF_AVAILABILITY_WINDOWS,
@@ -28,6 +28,7 @@ from .const import (
     ENTRY_TYPE_COMBINED,
 )
 from .coordinator import EntityAvailabilityCoordinator
+from .helpers import resolve_area_name, resolve_display_name
 from .write_dedup import DedupCoordinatorSensor
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,21 +39,8 @@ MAX_STATE_LENGTH = 255
 def _resolve_display_name(
     hass: HomeAssistant, entity_id: str, use_device_names: bool = False
 ) -> str:
-    """Return a display name for entity_id.
-
-    If use_device_names is True, prefer the device name from the device registry.
-    Falls back to friendly_name state attribute, then to an entity_id slug.
-    """
-    if use_device_names:
-        entry = er.async_get(hass).async_get(entity_id)
-        if entry and entry.device_id:
-            device = dr.async_get(hass).async_get(entry.device_id)
-            if device and (device.name_by_user or device.name):
-                return device.name_by_user or device.name
-    state = hass.states.get(entity_id)
-    if state and state.attributes.get("friendly_name"):
-        return state.attributes["friendly_name"]
-    return entity_id.split(".")[-1].replace("_", " ").title()
+    """Return a display name for entity_id."""
+    return resolve_display_name(hass, entity_id, use_device_names)
 
 
 async def async_setup_entry(
@@ -88,6 +76,21 @@ async def async_setup_entry(
         RecentlyOfflineSensor(coordinator, group_name, group_slug, entry.entry_id),
         RecentlyRecoveredSensor(coordinator, group_name, group_slug, entry.entry_id),
     ]
+
+    entities.extend(
+        [
+            AffectedAreasCountSensor(
+                coordinator, group_name, group_slug, entry.entry_id
+            ),
+            AffectedAreasSensor(coordinator, group_name, group_slug, entry.entry_id),
+            AffectedAreasRecentlyOfflineSensor(
+                coordinator, group_name, group_slug, entry.entry_id
+            ),
+            AffectedAreasRecentlyRecoveredSensor(
+                coordinator, group_name, group_slug, entry.entry_id
+            ),
+        ]
+    )
 
     battery_threshold = entry.data.get(
         CONF_BATTERY_THRESHOLD, DEFAULT_BATTERY_THRESHOLD
@@ -613,5 +616,219 @@ class RecentlyRecoveredSensor(DedupCoordinatorSensor):
         return {
             "entities": [d.entity_id for d in devices],
             "count": len(devices),
+            "window_minutes": self.coordinator.recovery_window_minutes,
+        }
+
+
+class AffectedAreasCountSensor(DedupCoordinatorSensor):
+    """Sensor showing count of unique areas with offline entities."""
+
+    _attr_icon = "mdi:home-alert"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: EntityAvailabilityCoordinator,
+        group_name: str,
+        group_slug: str,
+        entry_id: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry_id}_affected_areas_count"
+        self.entity_id = f"sensor.entity_availability_{group_slug}_affected_areas_count"
+        self._attr_name = "Affected Areas Count"
+        self._attr_device_info = _device_info(entry_id, group_slug, group_name)
+
+    @property
+    def native_value(self) -> int:
+        areas = {
+            resolve_area_name(self.hass, d.entity_id)
+            for d in self.coordinator.device_states.values()
+            if d.is_offline and not d.is_suppressed
+        }
+        areas.discard(None)
+        return len(areas)
+
+
+class AffectedAreasSensor(DedupCoordinatorSensor):
+    """Sensor showing sorted comma-separated list of areas with offline entities."""
+
+    _attr_icon = "mdi:home-group"
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: EntityAvailabilityCoordinator,
+        group_name: str,
+        group_slug: str,
+        entry_id: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry_id}_affected_areas"
+        self.entity_id = f"sensor.entity_availability_{group_slug}_affected_areas"
+        self._attr_name = "Affected Areas"
+        self._attr_device_info = _device_info(entry_id, group_slug, group_name)
+        self._cached_areas: list[str] = []
+        self._cached_unassigned: list[str] = []
+
+    def _refresh_cache(self) -> list[str]:
+        areas: set[str] = set()
+        unassigned: list[str] = []
+        for d in self.coordinator.device_states.values():
+            if d.is_offline and not d.is_suppressed:
+                area = resolve_area_name(self.hass, d.entity_id)
+                if area:
+                    areas.add(area)
+                else:
+                    unassigned.append(d.entity_id)
+        self._cached_areas = sorted(areas)
+        self._cached_unassigned = unassigned
+        return self._cached_areas
+
+    @property
+    def native_value(self) -> str:
+        areas = self._refresh_cache()
+        if not areas:
+            return "None"
+        result = ", ".join(areas)
+        if len(result) > MAX_STATE_LENGTH - 3:
+            result = result[: MAX_STATE_LENGTH - 3] + "..."
+        return result
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "areas": self._cached_areas,
+            "count": len(self._cached_areas),
+            "unassigned_entities": self._cached_unassigned,
+        }
+
+
+class AffectedAreasRecentlyOfflineSensor(DedupCoordinatorSensor):
+    """Sensor showing areas where an entity went offline within the recovery window."""
+
+    _attr_icon = "mdi:home-clock"
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: EntityAvailabilityCoordinator,
+        group_name: str,
+        group_slug: str,
+        entry_id: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry_id}_affected_areas_recently_offline"
+        self.entity_id = (
+            f"sensor.entity_availability_{group_slug}_affected_areas_recently_offline"
+        )
+        self._attr_name = "Areas Recently Offline"
+        self._attr_device_info = _device_info(entry_id, group_slug, group_name)
+        self._cached_areas: list[str] = []
+
+    def _refresh_cache(self) -> list[str]:
+        now = datetime.now(timezone.utc)
+        cutoff = self.coordinator.recovery_window_minutes * 60
+        areas: set[str] = set()
+        for d in self.coordinator.device_states.values():
+            if (
+                d.is_offline
+                and not d.is_suppressed
+                and d.recently_offline_at is not None
+                and (now - d.recently_offline_at).total_seconds() <= cutoff
+            ):
+                area = resolve_area_name(self.hass, d.entity_id)
+                if area:
+                    areas.add(area)
+        self._cached_areas = sorted(areas)
+        return self._cached_areas
+
+    @property
+    def native_value(self) -> str:
+        areas = self._refresh_cache()
+        if not areas:
+            return "None"
+        result = ", ".join(areas)
+        if len(result) > MAX_STATE_LENGTH - 3:
+            result = result[: MAX_STATE_LENGTH - 3] + "..."
+        return result
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "areas": self._cached_areas,
+            "count": len(self._cached_areas),
+            "window_minutes": self.coordinator.recovery_window_minutes,
+        }
+
+
+class AffectedAreasRecentlyRecoveredSensor(DedupCoordinatorSensor):
+    """Sensor showing areas where all entities recovered within the recovery window."""
+
+    _attr_icon = "mdi:home-heart"
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: EntityAvailabilityCoordinator,
+        group_name: str,
+        group_slug: str,
+        entry_id: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry_id}_affected_areas_recently_recovered"
+        self.entity_id = (
+            f"sensor.entity_availability_{group_slug}_affected_areas_recently_recovered"
+        )
+        self._attr_name = "Areas Recently Recovered"
+        self._attr_device_info = _device_info(entry_id, group_slug, group_name)
+        self._cached_areas: list[str] = []
+
+    def _refresh_cache(self) -> list[str]:
+        now = datetime.now(timezone.utc)
+        cutoff = self.coordinator.recovery_window_minutes * 60
+
+        # Build area → list[DeviceState] for non-suppressed devices with an assigned area
+        area_devices: dict[str, list] = {}
+        for d in self.coordinator.device_states.values():
+            if d.is_suppressed:
+                continue
+            area = resolve_area_name(self.hass, d.entity_id)
+            if not area:
+                continue
+            area_devices.setdefault(area, []).append(d)
+
+        recovered: list[str] = []
+        for area, devices in area_devices.items():
+            # All devices in this area must be online
+            if any(d.is_offline for d in devices):
+                continue
+            # At least one must have recovered within the window
+            if any(
+                d.last_recovery is not None
+                and (now - d.last_recovery).total_seconds() <= cutoff
+                for d in devices
+            ):
+                recovered.append(area)
+
+        self._cached_areas = sorted(recovered)
+        return self._cached_areas
+
+    @property
+    def native_value(self) -> str:
+        areas = self._refresh_cache()
+        if not areas:
+            return "None"
+        result = ", ".join(areas)
+        if len(result) > MAX_STATE_LENGTH - 3:
+            result = result[: MAX_STATE_LENGTH - 3] + "..."
+        return result
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "areas": self._cached_areas,
+            "count": len(self._cached_areas),
             "window_minutes": self.coordinator.recovery_window_minutes,
         }

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -12,7 +12,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers import device_registry as dr, entity_registry as er  # noqa: F401
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 
 from .const import (
@@ -756,9 +755,10 @@ class AffectedAreasRecentlyOfflineSensor(DedupCoordinatorSensor):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
+        areas = self._refresh_cache()
         return {
-            "areas": self._cached_areas,
-            "count": len(self._cached_areas),
+            "areas": areas,
+            "count": len(areas),
             "window_minutes": self.coordinator.recovery_window_minutes,
         }
 
@@ -825,8 +825,9 @@ class AffectedAreasRecentlyRecoveredSensor(DedupCoordinatorSensor):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
+        areas = self._refresh_cache()
         return {
-            "areas": self._cached_areas,
-            "count": len(self._cached_areas),
+            "areas": areas,
+            "count": len(areas),
             "window_minutes": self.coordinator.recovery_window_minutes,
         }

--- a/custom_components/entity_availability/strings.json
+++ b/custom_components/entity_availability/strings.json
@@ -112,6 +112,18 @@
       },
       "availability_7d": {
         "name": "Availability (7 Days)"
+      },
+      "affected_areas_count": {
+        "name": "Affected Areas Count"
+      },
+      "affected_areas": {
+        "name": "Affected Areas"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Areas Recently Offline"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Areas Recently Recovered"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/da.json
+++ b/custom_components/entity_availability/translations/da.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Tilgængelighed (7 dage)"
+      },
+      "affected_areas_count": {
+        "name": "Påvirkede Områder Antal"
+      },
+      "affected_areas": {
+        "name": "Påvirkede Områder"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Områder Nyligt Offline"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Områder Nyligt Genoprettet"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/de.json
+++ b/custom_components/entity_availability/translations/de.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Verfügbarkeit (7 Tage)"
+      },
+      "affected_areas_count": {
+        "name": "Betroffene Bereiche Anzahl"
+      },
+      "affected_areas": {
+        "name": "Betroffene Bereiche"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Zuletzt Offline Bereiche"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Zuletzt Wiederhergestellte Bereiche"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/en.json
+++ b/custom_components/entity_availability/translations/en.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Availability (7 Days)"
+      },
+      "affected_areas_count": {
+        "name": "Affected Areas Count"
+      },
+      "affected_areas": {
+        "name": "Affected Areas"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Areas Recently Offline"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Areas Recently Recovered"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/es.json
+++ b/custom_components/entity_availability/translations/es.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Disponibilidad (7 días)"
+      },
+      "affected_areas_count": {
+        "name": "Cantidad de Áreas Afectadas"
+      },
+      "affected_areas": {
+        "name": "Áreas Afectadas"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Áreas Recientemente Desconectadas"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Áreas Recientemente Recuperadas"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/fr.json
+++ b/custom_components/entity_availability/translations/fr.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Disponibilité (7 jours)"
+      },
+      "affected_areas_count": {
+        "name": "Nombre de Zones Affectées"
+      },
+      "affected_areas": {
+        "name": "Zones Affectées"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Zones Récemment Hors Ligne"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Zones Récemment Récupérées"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/it.json
+++ b/custom_components/entity_availability/translations/it.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Disponibilità (7 giorni)"
+      },
+      "affected_areas_count": {
+        "name": "Conteggio Aree Interessate"
+      },
+      "affected_areas": {
+        "name": "Aree Interessate"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Aree Recentemente Offline"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Aree Recentemente Ripristinate"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/nb.json
+++ b/custom_components/entity_availability/translations/nb.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Tilgjengelighet (7 dager)"
+      },
+      "affected_areas_count": {
+        "name": "Antall Berørte Områder"
+      },
+      "affected_areas": {
+        "name": "Berørte Områder"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Nylig Frakoblede Områder"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Nylig Gjenopprettede Områder"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/nl.json
+++ b/custom_components/entity_availability/translations/nl.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Beschikbaarheid (7 dagen)"
+      },
+      "affected_areas_count": {
+        "name": "Aantal Getroffen Gebieden"
+      },
+      "affected_areas": {
+        "name": "Getroffen Gebieden"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Recent Offline Gebieden"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Recent Herstelde Gebieden"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/pl.json
+++ b/custom_components/entity_availability/translations/pl.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Dostępność (7 dni)"
+      },
+      "affected_areas_count": {
+        "name": "Liczba Dotkniętych Obszarów"
+      },
+      "affected_areas": {
+        "name": "Dotknięte Obszary"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Obszary Niedawno Offline"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Obszary Niedawno Odzyskane"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/pt.json
+++ b/custom_components/entity_availability/translations/pt.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Disponibilidade (7 Dias)"
+      },
+      "affected_areas_count": {
+        "name": "Contagem de Áreas Afetadas"
+      },
+      "affected_areas": {
+        "name": "Áreas Afetadas"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Áreas Recentemente Offline"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Áreas Recentemente Recuperadas"
       }
     },
     "binary_sensor": {

--- a/custom_components/entity_availability/translations/sv.json
+++ b/custom_components/entity_availability/translations/sv.json
@@ -145,6 +145,18 @@
       },
       "availability_7d": {
         "name": "Tillgänglighet (7 dagar)"
+      },
+      "affected_areas_count": {
+        "name": "Antal Påverkade Områden"
+      },
+      "affected_areas": {
+        "name": "Påverkade Områden"
+      },
+      "affected_areas_recently_offline": {
+        "name": "Nyligen Offline Områden"
+      },
+      "affected_areas_recently_recovered": {
+        "name": "Nyligen Återställda Områden"
       }
     },
     "binary_sensor": {

--- a/info.md
+++ b/info.md
@@ -13,6 +13,7 @@ Monitor entity availability across your Home Assistant setup. Track offline enti
 - Low Battery Count sensor — numeric count for easy automation triggers
 - Battery entities that report `low` (text) are supported in addition to numeric percentages
 - Device name display — optionally show the HA device name instead of entity friendly name in offline/recovered sensor states
+- Area sensors — four sensors per group exposing which physical areas are affected: Affected Areas Count, Affected Areas, Areas Recently Offline, Areas Recently Recovered; area resolution follows entity → device → excluded; no new configuration required
 - Degraded entity detection — flag entities with low battery or stale data
 - Group Summary sensor — total, online, offline, suppressed, battery_powered, low_battery counts + full entity list
 - Maintenance/suppression mode — suppress individual entities or entire groups

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -1890,7 +1890,7 @@ class TestCombinedAffectedAreasSensors:
             sensor.native_value  # populate cache
             attrs = sensor.extra_state_attributes
         assert "binary_sensor.a2" in attrs["unassigned_entities"]
-        assert attrs["count"] == 0
+        assert attrs["count"] == 1  # (No Area) sentinel appears in areas list
 
     def test_recently_offline_none_when_no_match(
         self, mock_hass, combined_entry, coordinators
@@ -1946,10 +1946,10 @@ class TestCombinedAffectedAreasSensors:
         assert attrs["count"] == 1
         assert "Kitchen" in attrs["areas"]
 
-    def test_recently_recovered_no_area_entities_skipped(
+    def test_recently_recovered_no_area_uses_sentinel(
         self, mock_hass, combined_entry, coordinators
     ):
-        """Entities with no area are skipped in CombinedAffectedAreasRecentlyRecoveredSensor."""
+        """Entities with no area grouped under (No Area) sentinel; all online + recent recovery → sentinel qualifies."""
         mock_hass.data[DOMAIN] = {
             "entry_a": coordinators[0],
             "entry_b": coordinators[1],
@@ -1958,6 +1958,9 @@ class TestCombinedAffectedAreasSensors:
         coordinators[0]._device_states["binary_sensor.a2"].last_recovery = (
             _NOW - timedelta(minutes=1)
         )
+        # All non-suppressed entities in (No Area) bucket must be online
+        # a1 is already online, a2 now online with recovery, b1 online
+        # → (No Area) all online + recent recovery → qualifies
         with (
             patch(
                 "custom_components.entity_availability.combined_sensor.resolve_area_name",
@@ -1972,7 +1975,7 @@ class TestCombinedAffectedAreasSensors:
                 mock_hass, combined_entry, coordinators
             )
             value = sensor.native_value
-        assert value == "None"
+        assert value == "(No Area)"
 
     def test_recently_recovered_suppressed_entity_skipped(
         self, mock_hass, combined_entry, coordinators

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -14,6 +14,10 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.entity_availability.combined_sensor import (
     MAX_STATE_LENGTH,
+    CombinedAffectedAreasCountSensor,
+    CombinedAffectedAreasRecentlyOfflineSensor,
+    CombinedAffectedAreasRecentlyRecoveredSensor,
+    CombinedAffectedAreasSensor,
     CombinedGroupSensor,
     CombinedLowBatteryCountSensor,
     CombinedLowBatterySensor,
@@ -844,7 +848,7 @@ class TestAsyncSetupEntry:
             added.extend(entities)
 
         await async_setup_entry(mock_hass, combined_entry, _fake_add)
-        assert len(added) == 7
+        assert len(added) == 11
         types = {type(s) for s in added}
         assert CombinedOfflineCountSensor in types
         assert CombinedRecentlyOfflineSensor in types
@@ -1593,3 +1597,448 @@ class TestFriendlyNameBranches:
             value = sensor.native_value
 
         assert "Friendly A2" in value
+
+
+# ---------------------------------------------------------------------------
+# CombinedAffectedAreas sensors
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedAffectedAreasSensors:
+    """Tests for the 4 combined affected-areas sensors."""
+
+    def _count_sensor(self, hass, entry, coordinators):
+        return CombinedAffectedAreasCountSensor(
+            hass,
+            entry,
+            "Combined",
+            "combined",
+            coordinators,
+            [c.entry.entry_id for c in coordinators],
+        )
+
+    def _areas_sensor(self, hass, entry, coordinators):
+        return CombinedAffectedAreasSensor(
+            hass,
+            entry,
+            "Combined",
+            "combined",
+            coordinators,
+            [c.entry.entry_id for c in coordinators],
+        )
+
+    def _recently_offline_sensor(self, hass, entry, coordinators):
+        return CombinedAffectedAreasRecentlyOfflineSensor(
+            hass,
+            entry,
+            "Combined",
+            "combined",
+            coordinators,
+            [c.entry.entry_id for c in coordinators],
+        )
+
+    def _recently_recovered_sensor(self, hass, entry, coordinators):
+        return CombinedAffectedAreasRecentlyRecoveredSensor(
+            hass,
+            entry,
+            "Combined",
+            "combined",
+            coordinators,
+            [c.entry.entry_id for c in coordinators],
+        )
+
+    # ------------------------------------------------------------------
+    # CombinedAffectedAreasCountSensor
+    # ------------------------------------------------------------------
+
+    def test_count_same_area_deduped(self, mock_hass, combined_entry, coordinators):
+        """Two coordinators, both have offline entities in the same area → count=1."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[1]._device_states["binary_sensor.b1"].is_offline = True
+        with patch(
+            "custom_components.entity_availability.combined_sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = self._count_sensor(mock_hass, combined_entry, coordinators)
+            assert sensor.native_value == 1
+
+    def test_count_different_areas(self, mock_hass, combined_entry, coordinators):
+        """Two coordinators, offline entities in different areas → count=2."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[1]._device_states["binary_sensor.b1"].is_offline = True
+
+        area_map = {
+            "binary_sensor.a2": "Kitchen",
+            "binary_sensor.b1": "Garage",
+        }
+
+        def _area_side_effect(hass, entity_id):
+            return area_map.get(entity_id)
+
+        with patch(
+            "custom_components.entity_availability.combined_sensor.resolve_area_name",
+            side_effect=_area_side_effect,
+        ):
+            sensor = self._count_sensor(mock_hass, combined_entry, coordinators)
+            assert sensor.native_value == 2
+
+    def test_count_no_active_coordinators(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """No active coordinators → count=0."""
+        mock_hass.data[DOMAIN] = {}
+        with patch(
+            "custom_components.entity_availability.combined_sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = self._count_sensor(mock_hass, combined_entry, coordinators)
+            assert sensor.native_value == 0
+
+    # ------------------------------------------------------------------
+    # CombinedAffectedAreasSensor
+    # ------------------------------------------------------------------
+
+    def test_areas_none_when_no_offline(self, mock_hass, combined_entry, coordinators):
+        """All online → 'None'."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[0]._device_states["binary_sensor.a2"].is_offline = False
+        with patch(
+            "custom_components.entity_availability.combined_sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = self._areas_sensor(mock_hass, combined_entry, coordinators)
+            assert sensor.native_value == "None"
+
+    def test_areas_union_sorted(self, mock_hass, combined_entry, coordinators):
+        """Union of areas from both coords, sorted."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[1]._device_states["binary_sensor.b1"].is_offline = True
+
+        area_map = {
+            "binary_sensor.a2": "Kitchen",
+            "binary_sensor.b1": "Garage",
+        }
+
+        def _area_side_effect(hass, entity_id):
+            return area_map.get(entity_id)
+
+        with patch(
+            "custom_components.entity_availability.combined_sensor.resolve_area_name",
+            side_effect=_area_side_effect,
+        ):
+            sensor = self._areas_sensor(mock_hass, combined_entry, coordinators)
+            assert sensor.native_value == "Garage, Kitchen"
+
+    # ------------------------------------------------------------------
+    # CombinedAffectedAreasRecentlyOfflineSensor
+    # ------------------------------------------------------------------
+
+    def test_recently_offline_per_coordinator_window(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Per-coordinator window respected — one inside, one outside."""
+        from custom_components.entity_availability.const import CONF_RECOVERY_WINDOW
+        from datetime import timedelta
+
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        # coord_a has 5-min window, coord_b has 1-min window
+        coordinators[0].entry = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="Group A",
+            data={**coordinators[0].entry.data, CONF_RECOVERY_WINDOW: 5},
+            entry_id="entry_a",
+        )
+        coordinators[1].entry = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="Group B",
+            data={**coordinators[1].entry.data, CONF_RECOVERY_WINDOW: 1},
+            entry_id="entry_b",
+        )
+        # a2 went offline 3 min ago (within coord_a 5-min window)
+        coordinators[0]._device_states["binary_sensor.a2"].recently_offline_at = (
+            _NOW - timedelta(minutes=3)
+        )
+        # b1 went offline 3 min ago (outside coord_b 1-min window)
+        coordinators[1]._device_states["binary_sensor.b1"].is_offline = True
+        coordinators[1]._device_states["binary_sensor.b1"].recently_offline_at = (
+            _NOW - timedelta(minutes=3)
+        )
+
+        area_map = {
+            "binary_sensor.a2": "Kitchen",
+            "binary_sensor.b1": "Garage",
+        }
+
+        def _area_side_effect(hass, entity_id):
+            return area_map.get(entity_id)
+
+        with (
+            patch(
+                "custom_components.entity_availability.combined_sensor.resolve_area_name",
+                side_effect=_area_side_effect,
+            ),
+            patch(
+                "custom_components.entity_availability.combined_sensor.datetime"
+            ) as mock_dt,
+        ):
+            mock_dt.now.return_value = _NOW
+            sensor = self._recently_offline_sensor(
+                mock_hass, combined_entry, coordinators
+            )
+            value = sensor.native_value
+        # Kitchen (a2) in window; Garage (b1) outside window
+        assert value == "Kitchen"
+
+    # ------------------------------------------------------------------
+    # CombinedAffectedAreasRecentlyRecoveredSensor
+    # ------------------------------------------------------------------
+
+    def test_recently_recovered_one_offline_area_absent(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Entity still offline in coord B → area absent."""
+        from datetime import timedelta
+
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        # b1 is online, but a2 in same area is offline
+        coordinators[0]._device_states["binary_sensor.a2"].last_recovery = (
+            _NOW - timedelta(minutes=1)
+        )
+
+        with (
+            patch(
+                "custom_components.entity_availability.combined_sensor.resolve_area_name",
+                return_value="Kitchen",
+            ),
+            patch(
+                "custom_components.entity_availability.combined_sensor.datetime"
+            ) as mock_dt,
+        ):
+            mock_dt.now.return_value = _NOW
+            sensor = self._recently_recovered_sensor(
+                mock_hass, combined_entry, coordinators
+            )
+            # a2 is offline → Kitchen not fully recovered
+            value = sensor.native_value
+        assert value == "None"
+
+    def test_recently_recovered_all_online_with_recent_recovery(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """All online across both coords + recent recovery → area present."""
+        from datetime import timedelta
+
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        # Make a2 online too
+        coordinators[0]._device_states["binary_sensor.a2"].is_offline = False
+        coordinators[0]._device_states["binary_sensor.a2"].last_recovery = (
+            _NOW - timedelta(minutes=1)
+        )
+
+        with (
+            patch(
+                "custom_components.entity_availability.combined_sensor.resolve_area_name",
+                return_value="Kitchen",
+            ),
+            patch(
+                "custom_components.entity_availability.combined_sensor.datetime"
+            ) as mock_dt,
+        ):
+            mock_dt.now.return_value = _NOW
+            sensor = self._recently_recovered_sensor(
+                mock_hass, combined_entry, coordinators
+            )
+            value = sensor.native_value
+        assert value == "Kitchen"
+
+    def test_areas_unassigned_entities_in_attrs(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Offline entity with no area shows up in unassigned_entities attr."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        with patch(
+            "custom_components.entity_availability.combined_sensor.resolve_area_name",
+            return_value=None,
+        ):
+            sensor = self._areas_sensor(mock_hass, combined_entry, coordinators)
+            sensor.native_value  # populate cache
+            attrs = sensor.extra_state_attributes
+        assert "binary_sensor.a2" in attrs["unassigned_entities"]
+        assert attrs["count"] == 0
+
+    def test_recently_offline_none_when_no_match(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """No entities with recently_offline_at → 'None' and empty attrs."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        with (
+            patch(
+                "custom_components.entity_availability.combined_sensor.resolve_area_name",
+                return_value="Kitchen",
+            ),
+            patch(
+                "custom_components.entity_availability.combined_sensor.datetime"
+            ) as mock_dt,
+        ):
+            mock_dt.now.return_value = _NOW
+            sensor = self._recently_offline_sensor(
+                mock_hass, combined_entry, coordinators
+            )
+            value = sensor.native_value
+            attrs = sensor.extra_state_attributes
+        assert value == "None"
+        assert attrs["count"] == 0
+
+    def test_recently_offline_extra_attrs(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """extra_state_attributes returns areas and count for recently offline."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[0]._device_states["binary_sensor.a2"].recently_offline_at = (
+            _NOW - timedelta(minutes=1)
+        )
+        with (
+            patch(
+                "custom_components.entity_availability.combined_sensor.resolve_area_name",
+                return_value="Kitchen",
+            ),
+            patch(
+                "custom_components.entity_availability.combined_sensor.datetime"
+            ) as mock_dt,
+        ):
+            mock_dt.now.return_value = _NOW
+            sensor = self._recently_offline_sensor(
+                mock_hass, combined_entry, coordinators
+            )
+            attrs = sensor.extra_state_attributes
+        assert attrs["count"] == 1
+        assert "Kitchen" in attrs["areas"]
+
+    def test_recently_recovered_no_area_entities_skipped(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Entities with no area are skipped in CombinedAffectedAreasRecentlyRecoveredSensor."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[0]._device_states["binary_sensor.a2"].is_offline = False
+        coordinators[0]._device_states["binary_sensor.a2"].last_recovery = (
+            _NOW - timedelta(minutes=1)
+        )
+        with (
+            patch(
+                "custom_components.entity_availability.combined_sensor.resolve_area_name",
+                return_value=None,
+            ),
+            patch(
+                "custom_components.entity_availability.combined_sensor.datetime"
+            ) as mock_dt,
+        ):
+            mock_dt.now.return_value = _NOW
+            sensor = self._recently_recovered_sensor(
+                mock_hass, combined_entry, coordinators
+            )
+            value = sensor.native_value
+        assert value == "None"
+
+    def test_recently_recovered_suppressed_entity_skipped(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Suppressed entities are not included in area_pairs for recently recovered."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        # Suppress a2 (offline) — should not block area recovery for other entities
+        coordinators[0]._device_states["binary_sensor.a2"].is_suppressed = True
+        # a1 is online with recent recovery
+        coordinators[0]._device_states["binary_sensor.a1"].last_recovery = (
+            _NOW - timedelta(minutes=1)
+        )
+
+        area_map = {
+            "binary_sensor.a1": "Kitchen",
+            "binary_sensor.a2": "Kitchen",  # suppressed → not included
+            "binary_sensor.b1": None,
+        }
+
+        def _area_side_effect(hass, entity_id):
+            return area_map.get(entity_id)
+
+        with (
+            patch(
+                "custom_components.entity_availability.combined_sensor.resolve_area_name",
+                side_effect=_area_side_effect,
+            ),
+            patch(
+                "custom_components.entity_availability.combined_sensor.datetime"
+            ) as mock_dt,
+        ):
+            mock_dt.now.return_value = _NOW
+            sensor = self._recently_recovered_sensor(
+                mock_hass, combined_entry, coordinators
+            )
+            value = sensor.native_value
+        assert value == "Kitchen"
+
+    def test_recently_recovered_extra_attrs(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """extra_state_attributes returns areas and count for recently recovered."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[0]._device_states["binary_sensor.a2"].is_offline = False
+        coordinators[0]._device_states["binary_sensor.a2"].last_recovery = (
+            _NOW - timedelta(minutes=1)
+        )
+        with (
+            patch(
+                "custom_components.entity_availability.combined_sensor.resolve_area_name",
+                return_value="Kitchen",
+            ),
+            patch(
+                "custom_components.entity_availability.combined_sensor.datetime"
+            ) as mock_dt,
+        ):
+            mock_dt.now.return_value = _NOW
+            sensor = self._recently_recovered_sensor(
+                mock_hass, combined_entry, coordinators
+            )
+            attrs = sensor.extra_state_attributes
+        assert attrs["count"] == 1
+        assert "Kitchen" in attrs["areas"]

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -1369,11 +1369,11 @@ class TestCombinedOfflineEntitiesSensorWithDeviceNames:
 
         with (
             patch(
-                "custom_components.entity_availability.combined_sensor.er.async_get",
+                "custom_components.entity_availability.helpers.er.async_get",
                 return_value=ent_reg_mock,
             ),
             patch(
-                "custom_components.entity_availability.combined_sensor.dr.async_get",
+                "custom_components.entity_availability.helpers.dr.async_get",
                 return_value=dev_reg_mock,
             ),
         ):
@@ -1456,11 +1456,11 @@ class TestCombinedRecentlyOfflineSensorWithDeviceNames:
 
         with (
             patch(
-                "custom_components.entity_availability.combined_sensor.er.async_get",
+                "custom_components.entity_availability.helpers.er.async_get",
                 return_value=ent_reg_mock,
             ),
             patch(
-                "custom_components.entity_availability.combined_sensor.dr.async_get",
+                "custom_components.entity_availability.helpers.dr.async_get",
                 return_value=dev_reg_mock,
             ),
             patch(
@@ -1540,7 +1540,7 @@ class TestFriendlyNameBranches:
         ent_reg_mock.async_get.return_value = ent_entry
 
         with patch(
-            "custom_components.entity_availability.combined_sensor.er.async_get",
+            "custom_components.entity_availability.helpers.er.async_get",
             return_value=ent_reg_mock,
         ):
             sensor = self._make_offline_sensor(mock_hass, combined_entry, coordinators)
@@ -1585,11 +1585,11 @@ class TestFriendlyNameBranches:
 
         with (
             patch(
-                "custom_components.entity_availability.combined_sensor.er.async_get",
+                "custom_components.entity_availability.helpers.er.async_get",
                 return_value=ent_reg_mock,
             ),
             patch(
-                "custom_components.entity_availability.combined_sensor.dr.async_get",
+                "custom_components.entity_availability.helpers.dr.async_get",
                 return_value=dev_reg_mock,
             ),
         ):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1303,11 +1303,11 @@ class TestResolveDisplayName:
 
         with (
             patch(
-                "custom_components.entity_availability.sensor.er.async_get",
+                "custom_components.entity_availability.helpers.er.async_get",
                 return_value=mock_er,
             ),
             patch(
-                "custom_components.entity_availability.sensor.dr.async_get",
+                "custom_components.entity_availability.helpers.dr.async_get",
                 return_value=mock_dr,
             ),
         ):
@@ -1329,11 +1329,11 @@ class TestResolveDisplayName:
 
         with (
             patch(
-                "custom_components.entity_availability.sensor.er.async_get",
+                "custom_components.entity_availability.helpers.er.async_get",
                 return_value=mock_er,
             ),
             patch(
-                "custom_components.entity_availability.sensor.dr.async_get",
+                "custom_components.entity_availability.helpers.dr.async_get",
                 return_value=mock_dr,
             ),
         ):
@@ -1349,7 +1349,7 @@ class TestResolveDisplayName:
         mock_er.async_get.return_value = mock_entry
 
         with patch(
-            "custom_components.entity_availability.sensor.er.async_get",
+            "custom_components.entity_availability.helpers.er.async_get",
             return_value=mock_er,
         ):
             result = _resolve_display_name(mock_hass, "binary_sensor.device_a", True)
@@ -1367,11 +1367,11 @@ class TestResolveDisplayName:
 
         with (
             patch(
-                "custom_components.entity_availability.sensor.er.async_get",
+                "custom_components.entity_availability.helpers.er.async_get",
                 return_value=mock_er,
             ),
             patch(
-                "custom_components.entity_availability.sensor.dr.async_get",
+                "custom_components.entity_availability.helpers.dr.async_get",
                 return_value=mock_dr,
             ),
         ):
@@ -1393,11 +1393,11 @@ class TestResolveDisplayName:
 
         with (
             patch(
-                "custom_components.entity_availability.sensor.er.async_get",
+                "custom_components.entity_availability.helpers.er.async_get",
                 return_value=mock_er,
             ),
             patch(
-                "custom_components.entity_availability.sensor.dr.async_get",
+                "custom_components.entity_availability.helpers.dr.async_get",
                 return_value=mock_dr,
             ),
         ):
@@ -1410,7 +1410,7 @@ class TestResolveDisplayName:
         mock_er.async_get.return_value = None
 
         with patch(
-            "custom_components.entity_availability.sensor.er.async_get",
+            "custom_components.entity_availability.helpers.er.async_get",
             return_value=mock_er,
         ):
             result = _resolve_display_name(mock_hass, "binary_sensor.device_a", True)
@@ -1470,11 +1470,11 @@ class TestOfflineDevicesSensorWithDeviceNames:
 
         with (
             patch(
-                "custom_components.entity_availability.sensor.er.async_get",
+                "custom_components.entity_availability.helpers.er.async_get",
                 return_value=mock_er,
             ),
             patch(
-                "custom_components.entity_availability.sensor.dr.async_get",
+                "custom_components.entity_availability.helpers.dr.async_get",
                 return_value=mock_dr,
             ),
         ):
@@ -1508,7 +1508,7 @@ class TestOfflineDevicesSensorWithDeviceNames:
         sensor.hass = mock_hass
 
         with patch(
-            "custom_components.entity_availability.sensor.er.async_get",
+            "custom_components.entity_availability.helpers.er.async_get",
             return_value=mock_er,
         ):
             value = sensor.native_value
@@ -1569,11 +1569,11 @@ class TestRecentlyOfflineSensorWithDeviceNames:
 
         with (
             patch(
-                "custom_components.entity_availability.sensor.er.async_get",
+                "custom_components.entity_availability.helpers.er.async_get",
                 return_value=mock_er,
             ),
             patch(
-                "custom_components.entity_availability.sensor.dr.async_get",
+                "custom_components.entity_availability.helpers.dr.async_get",
                 return_value=mock_dr,
             ),
         ):
@@ -1596,7 +1596,7 @@ class TestRecentlyOfflineSensorWithDeviceNames:
         sensor.hass = mock_hass
 
         with patch(
-            "custom_components.entity_availability.sensor.er.async_get",
+            "custom_components.entity_availability.helpers.er.async_get",
             return_value=mock_er,
         ):
             value = sensor.native_value
@@ -1657,11 +1657,11 @@ class TestRecentlyRecoveredSensorWithDeviceNames:
 
         with (
             patch(
-                "custom_components.entity_availability.sensor.er.async_get",
+                "custom_components.entity_availability.helpers.er.async_get",
                 return_value=mock_er,
             ),
             patch(
-                "custom_components.entity_availability.sensor.dr.async_get",
+                "custom_components.entity_availability.helpers.dr.async_get",
                 return_value=mock_dr,
             ),
         ):
@@ -1684,7 +1684,7 @@ class TestRecentlyRecoveredSensorWithDeviceNames:
         sensor.hass = mock_hass
 
         with patch(
-            "custom_components.entity_availability.sensor.er.async_get",
+            "custom_components.entity_availability.helpers.er.async_get",
             return_value=mock_er,
         ):
             value = sensor.native_value

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -24,6 +24,10 @@ from custom_components.entity_availability.coordinator import (
 )
 from custom_components.entity_availability.models import DeviceState
 from custom_components.entity_availability.sensor import (
+    AffectedAreasCountSensor,
+    AffectedAreasRecentlyOfflineSensor,
+    AffectedAreasRecentlyRecoveredSensor,
+    AffectedAreasSensor,
     AvailabilitySensor,
     DegradedDevicesSensor,
     GroupSummarySensor,
@@ -1686,3 +1690,603 @@ class TestRecentlyRecoveredSensorWithDeviceNames:
             value = sensor.native_value
 
         assert value == "Device A"
+
+
+# ---------------------------------------------------------------------------
+# AffectedAreas group sensors
+# ---------------------------------------------------------------------------
+
+
+class TestAffectedAreasSensors:
+    """Tests for the 4 affected-areas group sensors."""
+
+    # ------------------------------------------------------------------
+    # AffectedAreasCountSensor
+    # ------------------------------------------------------------------
+
+    def test_count_entity_with_area(self, mock_coordinator, mock_hass):
+        """Offline entity with area → count=1."""
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasCountSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == 1
+
+    def test_count_two_offline_same_area_deduped(self, mock_coordinator, mock_hass):
+        """Two offline entities in the same area → count=1 (dedup)."""
+        mock_coordinator._device_states["binary_sensor.device_a"].is_offline = True
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasCountSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == 1
+
+    def test_count_no_area_returns_zero(self, mock_coordinator, mock_hass):
+        """Offline entity with no area → count=0."""
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value=None,
+        ):
+            sensor = AffectedAreasCountSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == 0
+
+    def test_count_suppressed_excluded(self, mock_coordinator, mock_hass):
+        """Suppressed offline entity excluded → count=0."""
+        mock_coordinator._device_states["binary_sensor.device_b"].is_suppressed = True
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasCountSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == 0
+
+    def test_count_unique_id(self, mock_coordinator, mock_hass):
+        """unique_id follows expected format."""
+        sensor = AffectedAreasCountSensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        assert sensor.unique_id == "test_entry_id_affected_areas_count"
+
+    # ------------------------------------------------------------------
+    # AffectedAreasSensor
+    # ------------------------------------------------------------------
+
+    def test_areas_state_single_area(self, mock_coordinator, mock_hass):
+        """Offline entity with area → state='Kitchen'."""
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == "Kitchen"
+
+    def test_areas_state_none_when_no_offline(self, mock_coordinator, mock_hass):
+        """All online → state='None'."""
+        mock_coordinator._device_states["binary_sensor.device_b"].is_offline = False
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == "None"
+
+    def test_areas_multiple_areas_sorted(self, mock_coordinator, mock_hass):
+        """Multiple offline entities in different areas → sorted output."""
+        mock_coordinator._device_states["binary_sensor.device_a"].is_offline = True
+        area_map = {
+            "binary_sensor.device_a": "Garage",
+            "binary_sensor.device_b": "Kitchen",
+            "binary_sensor.device_c": None,
+        }
+
+        def _area_side_effect(hass, entity_id):
+            return area_map.get(entity_id)
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            side_effect=_area_side_effect,
+        ):
+            sensor = AffectedAreasSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            value = sensor.native_value
+        # Sorted: Garage, Kitchen
+        assert value == "Garage, Kitchen"
+
+    def test_areas_unassigned_entities_in_attrs(self, mock_coordinator, mock_hass):
+        """Offline entity with no area shows up in unassigned_entities attr."""
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value=None,
+        ):
+            sensor = AffectedAreasSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            sensor.native_value  # populate cache
+            attrs = sensor.extra_state_attributes
+        assert "binary_sensor.device_b" in attrs["unassigned_entities"]
+        assert attrs["count"] == 0
+
+    def test_areas_truncation_at_255(self, mock_coordinator, mock_hass):
+        """Long area list is truncated to MAX_STATE_LENGTH."""
+        for i in range(50):
+            eid = f"binary_sensor.device_x{i:03d}"
+            mock_coordinator._device_states[eid] = DeviceState(
+                entity_id=eid, is_offline=True
+            )
+
+        def _area_side_effect(hass, entity_id):
+            return f"Very Long Area Name Number {entity_id[-3:]}"
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            side_effect=_area_side_effect,
+        ):
+            sensor = AffectedAreasSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            value = sensor.native_value
+        assert len(value) <= MAX_STATE_LENGTH
+        assert value.endswith("...")
+
+    # ------------------------------------------------------------------
+    # AffectedAreasRecentlyOfflineSensor
+    # ------------------------------------------------------------------
+
+    def test_recently_offline_entity_with_area_in_window(
+        self, mock_coordinator, mock_hass
+    ):
+        """Offline entity with recent offline_at within window → area shown."""
+        from datetime import timedelta
+
+        mock_coordinator._device_states[
+            "binary_sensor.device_b"
+        ].recently_offline_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasRecentlyOfflineSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == "Kitchen"
+
+    def test_recently_offline_outside_window_excluded(
+        self, mock_coordinator, mock_hass
+    ):
+        """recently_offline_at outside window → excluded."""
+        from datetime import timedelta
+
+        mock_coordinator._device_states[
+            "binary_sensor.device_b"
+        ].recently_offline_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasRecentlyOfflineSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == "None"
+
+    def test_recently_offline_no_timestamp_excluded(self, mock_coordinator, mock_hass):
+        """Entity without recently_offline_at → excluded."""
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasRecentlyOfflineSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == "None"
+
+    def test_recently_offline_attrs_have_window(self, mock_coordinator, mock_hass):
+        """extra_state_attributes includes window_minutes."""
+        from datetime import timedelta
+
+        mock_coordinator._device_states[
+            "binary_sensor.device_b"
+        ].recently_offline_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasRecentlyOfflineSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            sensor.native_value
+            attrs = sensor.extra_state_attributes
+        assert "window_minutes" in attrs
+        assert attrs["count"] == 1
+
+    # ------------------------------------------------------------------
+    # AffectedAreasRecentlyRecoveredSensor
+    # ------------------------------------------------------------------
+
+    def test_recently_recovered_all_online_with_recent_recovery(
+        self, mock_coordinator, mock_hass
+    ):
+        """All non-suppressed entities online + recent last_recovery → area shown."""
+        from datetime import timedelta
+
+        mock_coordinator._device_states["binary_sensor.device_a"].last_recovery = (
+            datetime.now(timezone.utc) - timedelta(minutes=2)
+        )
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasRecentlyRecoveredSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            # device_b is still offline → Kitchen NOT fully recovered
+            assert sensor.native_value == "None"
+
+    def test_recently_recovered_one_entity_still_offline_area_absent(
+        self, mock_coordinator, mock_hass
+    ):
+        """If one entity in area is still offline, area is absent."""
+        from datetime import timedelta
+
+        mock_coordinator._device_states["binary_sensor.device_a"].last_recovery = (
+            datetime.now(timezone.utc) - timedelta(minutes=2)
+        )
+        # device_b is already offline by default — so Kitchen is not fully recovered
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasRecentlyRecoveredSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == "None"
+
+    def test_recently_recovered_recovery_outside_window_absent(
+        self, mock_coordinator, mock_hass
+    ):
+        """Recovery outside window → area absent."""
+        from datetime import timedelta
+
+        # Make all online
+        mock_coordinator._device_states["binary_sensor.device_b"].is_offline = False
+        mock_coordinator._device_states["binary_sensor.device_a"].last_recovery = (
+            datetime.now(timezone.utc) - timedelta(minutes=10)
+        )
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasRecentlyRecoveredSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == "None"
+
+    def test_recently_recovered_suppressed_entity_not_blocking(
+        self, mock_coordinator, mock_hass
+    ):
+        """Suppressed entity not counted in 'all offline' check → area can still qualify."""
+        from datetime import timedelta
+
+        # device_b is offline but suppressed — should not block recovery
+        mock_coordinator._device_states["binary_sensor.device_b"].is_suppressed = True
+        mock_coordinator._device_states["binary_sensor.device_a"].last_recovery = (
+            datetime.now(timezone.utc) - timedelta(minutes=2)
+        )
+        # device_c is online with no recovery
+        area_map = {
+            "binary_sensor.device_a": "Kitchen",
+            "binary_sensor.device_b": "Kitchen",  # suppressed → ignored
+            "binary_sensor.device_c": "Kitchen",
+        }
+
+        def _area_side_effect(hass, entity_id):
+            return area_map.get(entity_id)
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            side_effect=_area_side_effect,
+        ):
+            sensor = AffectedAreasRecentlyRecoveredSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            # device_a and device_c both online, device_a has recent recovery → Kitchen qualifies
+            assert sensor.native_value == "Kitchen"
+
+    def test_recently_recovered_attrs_have_window(self, mock_coordinator, mock_hass):
+        """extra_state_attributes includes window_minutes."""
+        from datetime import timedelta
+
+        mock_coordinator._device_states["binary_sensor.device_b"].is_offline = False
+        mock_coordinator._device_states["binary_sensor.device_b"].last_recovery = (
+            datetime.now(timezone.utc) - timedelta(minutes=1)
+        )
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value="Kitchen",
+        ):
+            sensor = AffectedAreasRecentlyRecoveredSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            sensor.native_value
+            attrs = sensor.extra_state_attributes
+        assert "window_minutes" in attrs
+
+    def test_recently_offline_truncation(self, mock_coordinator, mock_hass):
+        """Long area list in AffectedAreasRecentlyOfflineSensor is truncated."""
+        from datetime import timedelta
+
+        # Add 50 offline entities with recently_offline_at within window
+        now = datetime.now(timezone.utc) - timedelta(minutes=1)
+        for i in range(50):
+            eid = f"binary_sensor.offline_{i:03d}"
+            mock_coordinator._device_states[eid] = DeviceState(
+                entity_id=eid,
+                is_offline=True,
+                recently_offline_at=now,
+            )
+
+        def _area_side_effect(hass, entity_id):
+            return f"Very Long Area Name For Entity {entity_id[-3:]}"
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            side_effect=_area_side_effect,
+        ):
+            sensor = AffectedAreasRecentlyOfflineSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            value = sensor.native_value
+        assert len(value) <= MAX_STATE_LENGTH
+        assert value.endswith("...")
+
+    def test_recently_recovered_no_area_skipped(self, mock_coordinator, mock_hass):
+        """Entity with no area is skipped in AffectedAreasRecentlyRecoveredSensor (line 799 branch)."""
+        from datetime import timedelta
+
+        mock_coordinator._device_states["binary_sensor.device_b"].is_offline = False
+        mock_coordinator._device_states["binary_sensor.device_b"].last_recovery = (
+            datetime.now(timezone.utc) - timedelta(minutes=1)
+        )
+        # Entities with no area → not added to area_devices → no areas qualify
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            return_value=None,
+        ):
+            sensor = AffectedAreasRecentlyRecoveredSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            assert sensor.native_value == "None"
+
+    def test_recently_recovered_truncation(self, mock_coordinator, mock_hass):
+        """Long area list in AffectedAreasRecentlyRecoveredSensor is truncated."""
+        from datetime import timedelta
+
+        # All devices online, all with recent recovery, all in unique areas
+        for d in mock_coordinator._device_states.values():
+            d.is_offline = False
+            d.last_recovery = datetime.now(timezone.utc) - timedelta(minutes=1)
+        # Add more devices in unique areas
+        for i in range(50):
+            eid = f"binary_sensor.rec_{i:03d}"
+            mock_coordinator._device_states[eid] = DeviceState(
+                entity_id=eid,
+                is_offline=False,
+                last_recovery=datetime.now(timezone.utc) - timedelta(minutes=1),
+            )
+
+        def _area_side_effect(hass, entity_id):
+            return f"Very Long Area Name For Entity {entity_id[-3:]}"
+
+        with patch(
+            "custom_components.entity_availability.sensor.resolve_area_name",
+            side_effect=_area_side_effect,
+        ):
+            sensor = AffectedAreasRecentlyRecoveredSensor(
+                mock_coordinator, "Test Group", "test_group", "test_entry_id"
+            )
+            sensor.hass = mock_hass
+            value = sensor.native_value
+        assert len(value) <= MAX_STATE_LENGTH
+        assert value.endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# resolve_area_name helper — branch coverage
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAreaName:
+    """Unit tests for resolve_area_name helper in helpers.py."""
+
+    def test_returns_none_when_entity_not_in_registry(self, mock_hass):
+        """Entity not in registry → None."""
+        from custom_components.entity_availability.helpers import resolve_area_name
+
+        mock_er = MagicMock()
+        mock_er.async_get.return_value = None
+        with patch(
+            "custom_components.entity_availability.helpers.er.async_get",
+            return_value=mock_er,
+        ):
+            result = resolve_area_name(mock_hass, "binary_sensor.device_a")
+        assert result is None
+
+    def test_returns_area_from_entity_area_id(self, mock_hass):
+        """Entity has area_id → returns area.name."""
+        from custom_components.entity_availability.helpers import resolve_area_name
+
+        mock_entry = MagicMock()
+        mock_entry.area_id = "area_abc"
+        mock_entry.device_id = None
+
+        mock_er = MagicMock()
+        mock_er.async_get.return_value = mock_entry
+
+        mock_area = MagicMock()
+        mock_area.name = "Kitchen"
+        mock_ar = MagicMock()
+        mock_ar.async_get_area.return_value = mock_area
+
+        with (
+            patch(
+                "custom_components.entity_availability.helpers.er.async_get",
+                return_value=mock_er,
+            ),
+            patch(
+                "custom_components.entity_availability.helpers.ar.async_get",
+                return_value=mock_ar,
+            ),
+        ):
+            result = resolve_area_name(mock_hass, "binary_sensor.device_a")
+        assert result == "Kitchen"
+
+    def test_falls_back_to_device_area_id(self, mock_hass):
+        """Entity has no area_id → falls back to device.area_id."""
+        from custom_components.entity_availability.helpers import resolve_area_name
+
+        mock_entry = MagicMock()
+        mock_entry.area_id = None
+        mock_entry.device_id = "device_xyz"
+
+        mock_device = MagicMock()
+        mock_device.area_id = "area_garage"
+
+        mock_er = MagicMock()
+        mock_er.async_get.return_value = mock_entry
+        mock_dr = MagicMock()
+        mock_dr.async_get.return_value = mock_device
+
+        mock_area = MagicMock()
+        mock_area.name = "Garage"
+        mock_ar = MagicMock()
+        mock_ar.async_get_area.return_value = mock_area
+
+        with (
+            patch(
+                "custom_components.entity_availability.helpers.er.async_get",
+                return_value=mock_er,
+            ),
+            patch(
+                "custom_components.entity_availability.helpers.dr.async_get",
+                return_value=mock_dr,
+            ),
+            patch(
+                "custom_components.entity_availability.helpers.ar.async_get",
+                return_value=mock_ar,
+            ),
+        ):
+            result = resolve_area_name(mock_hass, "binary_sensor.device_a")
+        assert result == "Garage"
+
+    def test_returns_none_when_no_area_id(self, mock_hass):
+        """Entity and device both have no area_id → None."""
+        from custom_components.entity_availability.helpers import resolve_area_name
+
+        mock_entry = MagicMock()
+        mock_entry.area_id = None
+        mock_entry.device_id = None
+
+        mock_er = MagicMock()
+        mock_er.async_get.return_value = mock_entry
+
+        with patch(
+            "custom_components.entity_availability.helpers.er.async_get",
+            return_value=mock_er,
+        ):
+            result = resolve_area_name(mock_hass, "binary_sensor.device_a")
+        assert result is None
+
+    def test_returns_none_when_area_not_found(self, mock_hass):
+        """area_id set but area not found in registry → None."""
+        from custom_components.entity_availability.helpers import resolve_area_name
+
+        mock_entry = MagicMock()
+        mock_entry.area_id = "area_missing"
+        mock_entry.device_id = None
+
+        mock_er = MagicMock()
+        mock_er.async_get.return_value = mock_entry
+
+        mock_ar = MagicMock()
+        mock_ar.async_get_area.return_value = None
+
+        with (
+            patch(
+                "custom_components.entity_availability.helpers.er.async_get",
+                return_value=mock_er,
+            ),
+            patch(
+                "custom_components.entity_availability.helpers.ar.async_get",
+                return_value=mock_ar,
+            ),
+        ):
+            result = resolve_area_name(mock_hass, "binary_sensor.device_a")
+        assert result is None
+
+    def test_returns_none_when_device_not_found(self, mock_hass):
+        """Entity has device_id but device not in registry → None."""
+        from custom_components.entity_availability.helpers import resolve_area_name
+
+        mock_entry = MagicMock()
+        mock_entry.area_id = None
+        mock_entry.device_id = "device_missing"
+
+        mock_er = MagicMock()
+        mock_er.async_get.return_value = mock_entry
+
+        mock_dr = MagicMock()
+        mock_dr.async_get.return_value = None
+
+        with (
+            patch(
+                "custom_components.entity_availability.helpers.er.async_get",
+                return_value=mock_er,
+            ),
+            patch(
+                "custom_components.entity_availability.helpers.dr.async_get",
+                return_value=mock_dr,
+            ),
+        ):
+            result = resolve_area_name(mock_hass, "binary_sensor.device_a")
+        assert result is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1729,8 +1729,8 @@ class TestAffectedAreasSensors:
             sensor.hass = mock_hass
             assert sensor.native_value == 1
 
-    def test_count_no_area_returns_zero(self, mock_coordinator, mock_hass):
-        """Offline entity with no area → count=0."""
+    def test_count_no_area_uses_sentinel(self, mock_coordinator, mock_hass):
+        """Offline entity with no area → counts as (No Area) sentinel → count=1."""
         with patch(
             "custom_components.entity_availability.sensor.resolve_area_name",
             return_value=None,
@@ -1739,7 +1739,7 @@ class TestAffectedAreasSensors:
                 mock_coordinator, "Test Group", "test_group", "test_entry_id"
             )
             sensor.hass = mock_hass
-            assert sensor.native_value == 0
+            assert sensor.native_value == 1
 
     def test_count_suppressed_excluded(self, mock_coordinator, mock_hass):
         """Suppressed offline entity excluded → count=0."""
@@ -1827,7 +1827,7 @@ class TestAffectedAreasSensors:
             sensor.native_value  # populate cache
             attrs = sensor.extra_state_attributes
         assert "binary_sensor.device_b" in attrs["unassigned_entities"]
-        assert attrs["count"] == 0
+        assert attrs["count"] == 1  # (No Area) sentinel appears in areas list
 
     def test_areas_truncation_at_255(self, mock_coordinator, mock_hass):
         """Long area list is truncated to MAX_STATE_LENGTH."""
@@ -2079,15 +2079,19 @@ class TestAffectedAreasSensors:
         assert len(value) <= MAX_STATE_LENGTH
         assert value.endswith("...")
 
-    def test_recently_recovered_no_area_skipped(self, mock_coordinator, mock_hass):
-        """Entity with no area is skipped in AffectedAreasRecentlyRecoveredSensor (line 799 branch)."""
+    def test_recently_recovered_no_area_uses_sentinel(
+        self, mock_coordinator, mock_hass
+    ):
+        """Entities with no area grouped under (No Area) sentinel; all online + recent recovery → sentinel qualifies."""
         from datetime import timedelta
 
         mock_coordinator._device_states["binary_sensor.device_b"].is_offline = False
         mock_coordinator._device_states["binary_sensor.device_b"].last_recovery = (
             datetime.now(timezone.utc) - timedelta(minutes=1)
         )
-        # Entities with no area → not added to area_devices → no areas qualify
+        # All entities have no area → all go into (No Area) bucket
+        # device_b is online with recent recovery; device_a, device_c are online with no recovery
+        # → (No Area) bucket: all online + recent recovery event → qualifies
         with patch(
             "custom_components.entity_availability.sensor.resolve_area_name",
             return_value=None,
@@ -2096,7 +2100,7 @@ class TestAffectedAreasSensors:
                 mock_coordinator, "Test Group", "test_group", "test_entry_id"
             )
             sensor.hass = mock_hass
-            assert sensor.native_value == "None"
+            assert sensor.native_value == "(No Area)"
 
     def test_recently_recovered_truncation(self, mock_coordinator, mock_hass):
         """Long area list in AffectedAreasRecentlyRecoveredSensor is truncated."""


### PR DESCRIPTION
## Summary

- **New `helpers.py`** — `resolve_area_name(hass, entity_id) → str | None` (entity area_id → device area_id → None) and `resolve_display_name` (consolidated from the duplicated `_resolve_display_name`/`_friendly_name` in sensor.py/combined_sensor.py)
- **4 new group sensors** per entry: `Affected Areas Count`, `Affected Areas`, `Areas Recently Offline`, `Areas Recently Recovered`
- **4 new combined sensors** per combined entry: same quartet, with set-union deduplication across source coordinators and per-coordinator `recovery_window_minutes`
- **All 11 locales** translated (da/de/en/es/fr/it/nb/nl/pl/pt/sv)
- **Docs**: CHANGELOG, README, info.md updated

## Sensor design

| Sensor | State | Key attributes |
|--------|-------|----------------|
| `affected_areas_count` | int (MEASUREMENT) | — |
| `affected_areas` | sorted comma-sep area names / `"None"` | `areas`, `count`, `unassigned_entities` |
| `affected_areas_recently_offline` | sorted comma-sep / `"None"` | `areas`, `count`, `window_minutes` |
| `affected_areas_recently_recovered` | sorted comma-sep / `"None"` | `areas`, `count`, `window_minutes` |

Area resolved: entity `area_id` → device `area_id` → excluded.  
Suppressed entities excluded from all 4 sensors.  
`recently_recovered` requires **all** non-suppressed entities in area to be online.  
No coordinator changes — pure read-time derivation from existing `device_states`.  
Always-on (no config toggle) — sensors show `0`/`"None"` for installs without area assignments.

## Test plan

- [ ] 510 tests pass, 100% coverage (all branches)
- [ ] `ruff check` + `ruff format --check` clean
- [ ] Beta tag `0.3.11-beta.1` → CI green → smoke test in Docker HA → stable tag
- [ ] Verify sensors appear in HA after config entry reload (no restart needed)
- [ ] Verify `unassigned_entities` attr shows entities without area
- [ ] Verify `recently_recovered` stays empty when one entity in area is still offline