### PR TITLE
feat(card): add opt-in affected areas pill row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,17 +20,6 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - **Card: Affected Areas pill row** — new opt-in section in the Lovelace card. When `show_affected_areas: true` (off by default), a compact pill row appears between the stats and availability sections listing offline area names. Named areas render in red; entities with no area assigned appear as italic "Unassigned". Works identically for regular and combined groups. Toggle via the card editor "Show Affected Areas" checkbox.
 
-### Added
-- **Area sensors** — four new sensors per group and combined group exposing which physical areas are affected by offline entities:
-  - **Affected Areas Count** (`affected_areas_count`) — integer count of unique HA areas containing ≥1 offline, unsuppressed entity. Entities with no area assigned contribute under the reserved sentinel `(No Area)` so `offline_count > 0` always implies `affected_areas_count ≥ 1`.
-  - **Affected Areas** (`affected_areas`) — comma-separated sorted list of area names (including `(No Area)` when unassigned entities are offline). Attributes: `areas` (list), `count`, `unassigned_entities` (entity IDs with no area assigned).
-  - **Areas Recently Offline** (`affected_areas_recently_offline`) — areas where ≥1 entity went offline within the group's `recovery_window_minutes`. Attributes: `areas`, `count`, `window_minutes`.
-  - **Areas Recently Recovered** (`affected_areas_recently_recovered`) — areas where ALL non-suppressed entities are back online and the most recent recovery happened within `recovery_window_minutes`. Attributes: `areas`, `count`, `window_minutes`.
-  - All four sensors appear on combined groups as well, with area deduplication across source groups.
-  - Area resolution: entity `area_id` → device `area_id` → `(No Area)` sentinel. The `unassigned_entities` attribute on `Affected Areas` lists entity IDs with no area for diagnostics.
-  - No new configuration required — sensors appear automatically on update and reuse the group's existing `recovery_window_minutes` setting.
-  - Entities are excluded if suppressed, consistent with all other sensors.
-
 ## [0.3.10] - 2026-06-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ All notable changes to this project will be documented in this file.
   - No new configuration required — sensors appear automatically on update and reuse the group's existing `recovery_window_minutes` setting.
   - Entities are excluded if suppressed, consistent with all other sensors.
 
+### Changed
+- **Card: Affected Areas pill row** — new opt-in section in the Lovelace card. When `show_affected_areas: true` (off by default), a compact pill row appears between the stats and availability sections listing offline area names. Named areas render in red; entities with no area assigned appear as italic "Unassigned". Works identically for regular and combined groups. Toggle via the card editor "Show Affected Areas" checkbox.
+
+### Added
+- **Area sensors** — four new sensors per group and combined group exposing which physical areas are affected by offline entities:
+  - **Affected Areas Count** (`affected_areas_count`) — integer count of unique HA areas containing ≥1 offline, unsuppressed entity. Entities with no area assigned contribute under the reserved sentinel `(No Area)` so `offline_count > 0` always implies `affected_areas_count ≥ 1`.
+  - **Affected Areas** (`affected_areas`) — comma-separated sorted list of area names (including `(No Area)` when unassigned entities are offline). Attributes: `areas` (list), `count`, `unassigned_entities` (entity IDs with no area assigned).
+  - **Areas Recently Offline** (`affected_areas_recently_offline`) — areas where ≥1 entity went offline within the group's `recovery_window_minutes`. Attributes: `areas`, `count`, `window_minutes`.
+  - **Areas Recently Recovered** (`affected_areas_recently_recovered`) — areas where ALL non-suppressed entities are back online and the most recent recovery happened within `recovery_window_minutes`. Attributes: `areas`, `count`, `window_minutes`.
+  - All four sensors appear on combined groups as well, with area deduplication across source groups.
+  - Area resolution: entity `area_id` → device `area_id` → `(No Area)` sentinel. The `unassigned_entities` attribute on `Affected Areas` lists entity IDs with no area for diagnostics.
+  - No new configuration required — sensors appear automatically on update and reuse the group's existing `recovery_window_minutes` setting.
+  - Entities are excluded if suppressed, consistent with all other sensors.
+
 ## [0.3.10] - 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -636,6 +636,7 @@ The card works with both regular groups and combined groups. It auto-detects the
 ```yaml
 type: custom:entity-availability-card
 group: security_devices
+show_affected_areas: false
 show_availability: true
 show_entities: true
 entities_expanded: false
@@ -658,6 +659,7 @@ availability_colors:
 |--------|---------|-------------|
 | `group` | (required) | Group slug (e.g., `security_devices`) — works for both regular and combined groups |
 | `title` | (auto from group) | Custom card title |
+| `show_affected_areas` | `false` | Show offline area names as pills between stats and availability bars (both regular and combined groups) |
 | `show_availability` | `true` | Show availability progress bars (regular groups only) |
 | `show_entities` | `true` | Show expandable entity list (regular) or group breakdown table (combined) |
 | `entities_expanded` | `false` | Start entity list / group breakdown expanded |

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -497,6 +497,7 @@ const cardStyles = css`
 
   .compact .card-header { padding: 12px 16px 8px; }
   .compact .stats-row { padding: 6px 16px; }
+  .compact .affected-areas-row { padding: 0 16px 6px; }
   .compact .availability-section { padding: 6px 16px; }
   .compact .entity-section-header { padding: 6px 16px; }
   .compact .actions-section { padding: 4px 16px 8px; }

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -3,7 +3,7 @@
  * Custom Lovelace card for the Home Assistant Entity Availability integration.
  */
 
-const CARD_VERSION = "0.3.10";
+const CARD_VERSION = "0.3.11";
 
 console.info(
   `%c ENTITY-AVAILABILITY-CARD %c v${CARD_VERSION} %c — github.com/italo-lombardi `,
@@ -500,6 +500,30 @@ const cardStyles = css`
   .compact .availability-section { padding: 6px 16px; }
   .compact .entity-section-header { padding: 6px 16px; }
   .compact .actions-section { padding: 4px 16px 8px; }
+
+  .affected-areas-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 0 16px 8px;
+    font-size: 13px;
+  }
+
+  .affected-areas-label {
+    color: var(--eac-text-secondary);
+    margin-right: 4px;
+    flex-shrink: 0;
+  }
+
+  .area-pill {
+    display: inline-block;
+    padding: 1px 7px;
+    border-radius: 10px;
+    background: rgba(244, 67, 54, 0.12);
+    font-size: 12px;
+    font-weight: 500;
+  }
 `;
 
 class EntityAvailabilityCard extends LitElement {
@@ -557,6 +581,7 @@ class EntityAvailabilityCard extends LitElement {
       sort_by: "status",
       entity_detail: "off",
       entity_filter: "all",
+      show_affected_areas: false,
       ...config,
     };
     // backwards compat: show_entity_tooltips: true → entity_detail: "tooltip"
@@ -621,6 +646,7 @@ class EntityAvailabilityCard extends LitElement {
           ${this._renderHeader(title, statusColor, statusText)}
           <div class="divider"></div>
           ${this._renderStats(online, offline, lowBattery, suppressed)}
+          ${this._config.show_affected_areas ? this._renderAffectedAreas(`entity_availability_combined_${this._config.group}`) : nothing}
           ${suppressed > 0 ? html`<div class="suppressed-banner">${suppressed} ${suppressed > 1 ? "entities" : "entity"} suppressed</div>` : nothing}
           ${this._config.show_entities ? this._renderCombinedGroupBreakdown(groups) : nothing}
           ${this._config.show_actions ? this._renderActions(prefix) : nothing}
@@ -670,6 +696,7 @@ class EntityAvailabilityCard extends LitElement {
         ${this._renderHeader(title, statusColor, statusText)}
         <div class="divider"></div>
         ${this._renderStats(online, offline, lowBattery, suppressed)}
+        ${this._config.show_affected_areas ? this._renderAffectedAreas(prefix) : nothing}
         ${suppressed > 0 ? html`<div class="suppressed-banner">${suppressed} ${suppressed > 1 ? "entities" : "entity"} suppressed</div>` : nothing}
         ${this._config.show_availability ? this._renderAvailability(prefix) : nothing}
         ${this._config.show_entities ? this._renderEntityList(entities, batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames) : nothing}
@@ -855,6 +882,30 @@ class EntityAvailabilityCard extends LitElement {
     `;
   }
 
+  _renderAffectedAreas(prefix) {
+    const sensor = this._getEntity(`sensor.${prefix}_affected_areas`);
+    if (!sensor || sensor.state === "None" || sensor.state === "unavailable" || sensor.state === "unknown") {
+      return nothing;
+    }
+    const rawAreas = sensor.attributes?.areas ?? [];
+    if (rawAreas.length === 0) return nothing;
+
+    const named = rawAreas.filter((a) => a !== "(No Area)");
+    const hasUnassigned = rawAreas.includes("(No Area)");
+    const pills = [
+      ...named.map((a) => html`<span class="area-pill" style="color:var(--eac-red)">${a}</span>`),
+      ...(hasUnassigned ? [html`<span class="area-pill" style="font-style:italic;color:var(--eac-text-secondary)">${"Unassigned"}</span>`] : []),
+    ];
+
+    return html`
+      <div class="affected-areas-row">
+        <ha-icon icon="mdi:home-alert" style="color:var(--eac-red);--mdc-icon-size:16px;flex-shrink:0"></ha-icon>
+        <span class="affected-areas-label">Affected:</span>
+        ${pills}
+      </div>
+    `;
+  }
+
   _buildEntityItems(entities, batteryLevels, staleEntities, offlineSince, suppressedUntil, lowBatteryEntities = [], displayNames = {}) {
     const items = entities.map((entityId) => {
       const state = this.hass.states[entityId];
@@ -1021,16 +1072,18 @@ class EntityAvailabilityCard extends LitElement {
     const group = this._config.group;
     if (this._isCombinedGroup()) {
       const prefix = `entity_availability_combined_${group}`;
-      return [
+      const ids = [
         `sensor.${prefix}_combined_summary`,
         `sensor.${prefix}_offline_entities`,
         `sensor.${prefix}_low_battery`,
         `sensor.${prefix}_low_battery_count`,
         `binary_sensor.${prefix}_any_offline`,
       ];
+      if (this._config.show_affected_areas) ids.push(`sensor.${prefix}_affected_areas`);
+      return ids;
     }
     const prefix = `entity_availability_${group}`;
-    return [
+    const ids = [
       `sensor.${prefix}_group_summary`,
       `sensor.${prefix}_offline_count`,
       `sensor.${prefix}_offline_entities`,
@@ -1041,6 +1094,8 @@ class EntityAvailabilityCard extends LitElement {
       `sensor.${prefix}_availability_7d`,
       `binary_sensor.${prefix}_any_offline`,
     ];
+    if (this._config.show_affected_areas) ids.push(`sensor.${prefix}_affected_areas`);
+    return ids;
   }
 
   _computeDuration(entityId) {
@@ -1333,6 +1388,16 @@ class EntityAvailabilityCardEditor extends LitElement {
               @change=${(e) => this._updateConfig("show_entities", e.target.checked)}
             />
             Show Entity List
+          </label>
+        </div>
+        <div class="editor-row checkbox">
+          <label>
+            <input
+              type="checkbox"
+              .checked=${this._config.show_affected_areas === true}
+              @change=${(e) => this._updateConfig("show_affected_areas", e.target.checked)}
+            />
+            Show Affected Areas
           </label>
         </div>
         ${!this._isSelectedGroupCombined() ? html`

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1377,6 +1377,16 @@ class EntityAvailabilityCardEditor extends LitElement {
             placeholder="Custom card title"
           />
         </div>
+        <div class="editor-row checkbox">
+          <label>
+            <input
+              type="checkbox"
+              .checked=${this._config.show_affected_areas === true}
+              @change=${(e) => this._updateConfig("show_affected_areas", e.target.checked)}
+            />
+            Show Affected Areas
+          </label>
+        </div>
         ${!this._isSelectedGroupCombined() ? html`
         <div class="editor-row checkbox">
           <label>
@@ -1397,16 +1407,6 @@ class EntityAvailabilityCardEditor extends LitElement {
               @change=${(e) => this._updateConfig("show_entities", e.target.checked)}
             />
             Show Entity List
-          </label>
-        </div>
-        <div class="editor-row checkbox">
-          <label>
-            <input
-              type="checkbox"
-              .checked=${this._config.show_affected_areas === true}
-              @change=${(e) => this._updateConfig("show_affected_areas", e.target.checked)}
-            />
-            Show Affected Areas
           </label>
         </div>
         ${!this._isSelectedGroupCombined() ? html`

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -524,6 +524,15 @@ const cardStyles = css`
     font-size: 12px;
     font-weight: 500;
   }
+
+  .area-pill--named {
+    color: var(--eac-red);
+  }
+
+  .area-pill--unassigned {
+    font-style: italic;
+    color: var(--eac-text-secondary);
+  }
 `;
 
 class EntityAvailabilityCard extends LitElement {
@@ -893,8 +902,8 @@ class EntityAvailabilityCard extends LitElement {
     const named = rawAreas.filter((a) => a !== "(No Area)");
     const hasUnassigned = rawAreas.includes("(No Area)");
     const pills = [
-      ...named.map((a) => html`<span class="area-pill" style="color:var(--eac-red)">${a}</span>`),
-      ...(hasUnassigned ? [html`<span class="area-pill" style="font-style:italic;color:var(--eac-text-secondary)">${"Unassigned"}</span>`] : []),
+      ...named.map((a) => html`<span class="area-pill area-pill--named">${a}</span>`),
+      ...(hasUnassigned ? [html`<span class="area-pill area-pill--unassigned">Unassigned</span>`] : []),
     ];
 
     return html`

--- a/info.md
+++ b/info.md
@@ -14,6 +14,7 @@ Monitor entity availability across your Home Assistant setup. Track offline enti
 - Battery entities that report `low` (text) are supported in addition to numeric percentages
 - Device name display — optionally show the HA device name instead of entity friendly name in offline/recovered sensor states
 - Area sensors — four sensors per group exposing which physical areas are affected: Affected Areas Count, Affected Areas, Areas Recently Offline, Areas Recently Recovered; area resolution follows entity → device → excluded; no new configuration required
+- Card: Affected Areas pill row — opt-in (`show_affected_areas: false` by default); shows offline area names as colored pills between stats and availability bars; named areas in red, unassigned entities as italic "Unassigned"; works for regular and combined groups
 - Degraded entity detection — flag entities with low battery or stale data
 - Group Summary sensor — total, online, offline, suppressed, battery_powered, low_battery counts + full entity list
 - Maintenance/suppression mode — suppress individual entities or entire groups


### PR DESCRIPTION
## Summary
- New `show_affected_areas` config key (default `false`) — zero impact on existing cards
- When enabled: compact pill row between stats and availability sections listing offline area names
- Named areas render in red; `(No Area)` sentinel → italic "Unassigned"
- Works for both regular and combined groups
- Toggle via card editor "Show Affected Areas" checkbox

## Test plan
- [ ] Existing cards with `show_affected_areas` absent render unchanged
- [ ] Enable checkbox in editor → pill row appears when areas are offline
- [ ] `(No Area)` entities render as italic "Unassigned"
- [ ] Combined group card shows deduplicated area list
- [ ] Zero offline entities → pill row hidden