### PR TITLE
Fix: don't misreport stale entities as "Low Battery" when battery is above threshold

### DIFF
--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -225,7 +225,7 @@ class CombinedGroupSensor(CombinedSensorBase):
             g_low_battery = sum(
                 1
                 for d in states.values()
-                if d.is_degraded and not d.is_suppressed and d.battery_level is not None
+                if d.is_low_battery and not d.is_suppressed
             )
             battery_map = coord.entry.data.get(CONF_BATTERY_ENTITY_MAP, {})
             if battery_map:
@@ -251,7 +251,7 @@ class CombinedGroupSensor(CombinedSensorBase):
             low_battery_entities += [
                 d.entity_id
                 for d in states.values()
-                if d.is_degraded and not d.is_suppressed and d.battery_level is not None
+                if d.is_low_battery and not d.is_suppressed
             ]
             gname = coord.group_name
             groups[coord.entry.entry_id] = {
@@ -422,7 +422,7 @@ class CombinedLowBatterySensor(CombinedSensorBase):
             f"{_friendly_name(self.hass, d.entity_id, coord.entry.data.get(CONF_USE_DEVICE_NAMES, False))} ({d.battery_level}%)"
             for coord in coords
             for d in coord.device_states.values()
-            if d.is_degraded and not d.is_suppressed and d.battery_level is not None
+            if d.is_low_battery and not d.is_suppressed
         ]
         if not low:
             return "None"
@@ -439,7 +439,7 @@ class CombinedLowBatterySensor(CombinedSensorBase):
             d.entity_id: f"{d.battery_level}%"
             for coord in self._active_coordinators()
             for d in coord.device_states.values()
-            if d.is_degraded and not d.is_suppressed and d.battery_level is not None
+            if d.is_low_battery and not d.is_suppressed
         }
         return {"devices": devices, "count": len(devices)}
 
@@ -468,7 +468,7 @@ class CombinedLowBatteryCountSensor(CombinedSensorBase):
             1
             for coord in self._active_coordinators()
             for d in coord.device_states.values()
-            if d.is_degraded and not d.is_suppressed and d.battery_level is not None
+            if d.is_low_battery and not d.is_suppressed
         )
 
 

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -456,6 +456,7 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
             if device.is_suppressed:
                 device.is_degraded = False
                 device.is_stale = False
+                device.is_low_battery = False
                 _LOGGER.debug(
                     "[%s] Skipping suppressed entity %s (until=%s)",
                     self.group_name,
@@ -597,6 +598,7 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
 
             # Degraded = not offline but battery low or stale
             device.is_stale = is_stale
+            device.is_low_battery = (not device.is_offline) and battery_low
             device.is_degraded = (not device.is_offline) and (battery_low or is_stale)
 
         # Mark as dirty; save periodically (every ~5 min)

--- a/custom_components/entity_availability/models.py
+++ b/custom_components/entity_availability/models.py
@@ -16,6 +16,7 @@ class DeviceState:
     is_offline: bool = False
     is_degraded: bool = False
     is_stale: bool = False
+    is_low_battery: bool = False
     is_suppressed: bool = False
     suppress_until: datetime | None = None
     offline_since: datetime | None = None

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -254,7 +254,7 @@ class DegradedDevicesSensor(DedupCoordinatorSensor):
         low_bat = [
             self._format_device(d)
             for d in self.coordinator.device_states.values()
-            if d.is_degraded and not d.is_suppressed and d.battery_level is not None
+            if d.is_low_battery and not d.is_suppressed
         ]
         if not low_bat:
             return "None"
@@ -268,7 +268,7 @@ class DegradedDevicesSensor(DedupCoordinatorSensor):
         """Return per-device battery details."""
         devices: dict[str, Any] = {}
         for d in self.coordinator.device_states.values():
-            if d.is_degraded and not d.is_suppressed and d.battery_level is not None:
+            if d.is_low_battery and not d.is_suppressed:
                 devices[d.entity_id] = f"{d.battery_level}%"
         return {"devices": devices, "count": len(devices)}
 
@@ -309,7 +309,7 @@ class LowBatteryCountSensor(DedupCoordinatorSensor):
         return sum(
             1
             for d in self.coordinator.device_states.values()
-            if d.is_degraded and not d.is_suppressed and d.battery_level is not None
+            if d.is_low_battery and not d.is_suppressed
         )
 
 
@@ -578,9 +578,8 @@ class GroupSummarySensor(DedupCoordinatorSensor):
             eid
             for eid in self.coordinator.monitored_entities
             if states.get(eid)
-            and states[eid].is_degraded
+            and states[eid].is_low_battery
             and not states[eid].is_suppressed
-            and states[eid].battery_level is not None
         ]
         low_battery = len(low_battery_entities)
 

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -719,7 +719,7 @@ class TestCombinedLowBatterySensor:
             "entry_a": coordinators[0],
             "entry_b": coordinators[1],
         }
-        coordinators[0]._device_states["binary_sensor.a1"].is_degraded = True
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = True
         coordinators[0]._device_states["binary_sensor.a1"].battery_level = 12
         mock_hass.states.async_set(
             "binary_sensor.a1", STATE_ON, {"friendly_name": "Sensor A1"}
@@ -733,7 +733,7 @@ class TestCombinedLowBatterySensor:
             "entry_a": coordinators[0],
             "entry_b": coordinators[1],
         }
-        coordinators[0]._device_states["binary_sensor.a1"].is_degraded = True
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = True
         coordinators[0]._device_states["binary_sensor.a1"].battery_level = 8
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
         attrs = sensor.extra_state_attributes
@@ -776,9 +776,9 @@ class TestCombinedLowBatteryCountSensor:
             "entry_a": coordinators[0],
             "entry_b": coordinators[1],
         }
-        coordinators[0]._device_states["binary_sensor.a1"].is_degraded = True
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = True
         coordinators[0]._device_states["binary_sensor.a1"].battery_level = 5
-        coordinators[1]._device_states["binary_sensor.b1"].is_degraded = True
+        coordinators[1]._device_states["binary_sensor.b1"].is_low_battery = True
         coordinators[1]._device_states["binary_sensor.b1"].battery_level = 10
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
         assert sensor.native_value == 2
@@ -791,7 +791,7 @@ class TestCombinedLowBatteryCountSensor:
             "entry_a": coordinators[0],
             "entry_b": coordinators[1],
         }
-        coordinators[0]._device_states["binary_sensor.a1"].is_degraded = True
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = True
         coordinators[0]._device_states["binary_sensor.a1"].battery_level = 5
         coordinators[0]._device_states["binary_sensor.a1"].is_suppressed = True
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
@@ -802,6 +802,59 @@ class TestCombinedLowBatteryCountSensor:
         mock_hass.data[DOMAIN] = {}
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
         assert sensor.unique_id == "combined_1_combined_low_battery_count"
+
+
+# ---------------------------------------------------------------------------
+# Regression: stale entity with healthy battery must NOT appear as low battery
+# ---------------------------------------------------------------------------
+
+
+class TestStaleButHealthyBatteryNotLowBattery:
+    """Regression tests: stale entities with battery above threshold excluded from combined low-battery sensors."""
+
+    def test_stale_healthy_battery_not_counted_by_combined_low_battery_count(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Stale entity with battery above threshold is NOT counted as low battery in combined sensor."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        # Stale but healthy: is_degraded=True, is_stale=True, is_low_battery=False
+        coordinators[0]._device_states["binary_sensor.a1"].is_degraded = True
+        coordinators[0]._device_states["binary_sensor.a1"].is_stale = True
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = False
+        coordinators[0]._device_states["binary_sensor.a1"].battery_level = 50
+        sensor = CombinedLowBatteryCountSensor(
+            mock_hass,
+            combined_entry,
+            "Combined",
+            "combined",
+            coordinators,
+            [c.entry.entry_id for c in coordinators],
+        )
+        assert sensor.native_value == 0
+
+    def test_genuine_low_battery_still_counted_by_combined_sensor(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Entity with battery genuinely below threshold IS counted as low battery in combined sensor."""
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        coordinators[0]._device_states["binary_sensor.a1"].is_degraded = True
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = True
+        coordinators[0]._device_states["binary_sensor.a1"].battery_level = 15
+        sensor = CombinedLowBatteryCountSensor(
+            mock_hass,
+            combined_entry,
+            "Combined",
+            "combined",
+            coordinators,
+            [c.entry.entry_id for c in coordinators],
+        )
+        assert sensor.native_value == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -213,7 +213,7 @@ class TestDegradedDevicesSensor:
 
     def test_native_value_lists_low_battery(self, mock_coordinator, mock_hass):
         """Test native_value returns low battery device names."""
-        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True
         mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 15
         sensor = DegradedDevicesSensor(
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
@@ -231,7 +231,7 @@ class TestDegradedDevicesSensor:
 
     def test_excludes_suppressed_degraded(self, mock_coordinator, mock_hass):
         """Test suppressed degraded devices are excluded."""
-        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True
         mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 10
         mock_coordinator._device_states["binary_sensor.device_a"].is_suppressed = True
         sensor = DegradedDevicesSensor(
@@ -242,7 +242,7 @@ class TestDegradedDevicesSensor:
 
     def test_extra_state_attributes_shows_battery(self, mock_coordinator, mock_hass):
         """Test that battery levels are reported in attributes."""
-        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True
         mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 15
         sensor = DegradedDevicesSensor(
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
@@ -268,9 +268,9 @@ class TestLowBatteryCountSensor:
 
     def test_native_value_counts_low_battery(self, mock_coordinator, mock_hass):
         """Test count reflects low battery devices."""
-        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True
         mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 10
-        mock_coordinator._device_states["binary_sensor.device_b"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_b"].is_low_battery = True
         mock_coordinator._device_states["binary_sensor.device_b"].battery_level = 5
         sensor = LowBatteryCountSensor(
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
@@ -280,7 +280,7 @@ class TestLowBatteryCountSensor:
 
     def test_excludes_suppressed(self, mock_coordinator, mock_hass):
         """Test suppressed devices are excluded from count."""
-        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True
         mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 10
         mock_coordinator._device_states["binary_sensor.device_a"].is_suppressed = True
         sensor = LowBatteryCountSensor(
@@ -290,7 +290,7 @@ class TestLowBatteryCountSensor:
         assert sensor.native_value == 0
 
     def test_excludes_degraded_without_battery(self, mock_coordinator, mock_hass):
-        """Test degraded devices without battery_level are excluded."""
+        """Test degraded-only devices (stale, not low battery) are excluded."""
         mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
         mock_coordinator._device_states["binary_sensor.device_a"].battery_level = None
         sensor = LowBatteryCountSensor(
@@ -305,6 +305,82 @@ class TestLowBatteryCountSensor:
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
         )
         assert sensor.unique_id == "test_entry_id_low_battery_count"
+
+
+class TestStaleButHealthyBatteryNotLowBattery:
+    """Regression tests: stale entities with battery above threshold must not appear as low battery."""
+
+    def test_stale_healthy_battery_not_counted_by_low_battery_count_sensor(
+        self, mock_coordinator, mock_hass
+    ):
+        """Stale entity with battery above threshold must NOT be counted as low battery."""
+        # Entity is stale (is_degraded=True, is_stale=True) but battery is above threshold
+        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_stale = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = False
+        mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 50
+        sensor = LowBatteryCountSensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        assert sensor.native_value == 0
+
+    def test_stale_healthy_battery_not_listed_by_degraded_devices_sensor(
+        self, mock_coordinator, mock_hass
+    ):
+        """Stale entity with battery above threshold must NOT appear in low battery list."""
+        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_stale = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = False
+        mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 50
+        sensor = DegradedDevicesSensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        assert sensor.native_value == "None"
+        assert sensor.extra_state_attributes["count"] == 0
+
+    def test_stale_healthy_battery_not_in_group_summary_low_battery_entities(
+        self, mock_coordinator, mock_hass
+    ):
+        """Stale entity with battery above threshold must NOT be in low_battery_entities."""
+        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_stale = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = False
+        mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 50
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert attrs["low_battery"] == 0
+        assert "binary_sensor.device_a" not in attrs["low_battery_entities"]
+
+    def test_genuine_low_battery_still_counted(self, mock_coordinator, mock_hass):
+        """Entity with battery genuinely below threshold must be counted as low battery."""
+        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True
+        mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 10
+        sensor = LowBatteryCountSensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        assert sensor.native_value == 1
+
+    def test_genuine_low_battery_appears_in_group_summary(
+        self, mock_coordinator, mock_hass
+    ):
+        """Entity with battery below threshold must appear in group summary low_battery_entities."""
+        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True
+        mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 10
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert attrs["low_battery"] == 1
+        assert "binary_sensor.device_a" in attrs["low_battery_entities"]
 
 
 class TestAvailabilitySensor:
@@ -443,7 +519,7 @@ class TestGroupSummarySensor:
 
     def test_attributes_low_battery_count(self, mock_coordinator, mock_hass):
         """Test low battery count in attributes."""
-        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True
         mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 10
         sensor = GroupSummarySensor(
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
@@ -920,7 +996,7 @@ class TestDegradedDevicesFallbackName:
         """_format_device falls back to entity_id slug when state is None."""
         mock_hass.states.async_remove("binary_sensor.device_a")
 
-        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True
         mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 12
         sensor = DegradedDevicesSensor(
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
@@ -935,7 +1011,7 @@ class TestDegradedDevicesFallbackName:
         """_format_device uses entity_id slug when state exists but has no friendly_name."""
         mock_hass.states.async_set("binary_sensor.device_a", "on", {})
 
-        mock_coordinator._device_states["binary_sensor.device_a"].is_degraded = True
+        mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True
         mock_coordinator._device_states["binary_sensor.device_a"].battery_level = 8
         sensor = DegradedDevicesSensor(
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
@@ -960,6 +1036,7 @@ class TestDegradedDevicesTruncation:
             mock_coordinator._device_states[eid] = DeviceState(
                 entity_id=eid,
                 is_degraded=True,
+                is_low_battery=True,
                 battery_level=5,
             )
             mock_hass.states.async_set(


### PR DESCRIPTION
Fixes italo-lombardi/Home-Assistant-EntityAvailability#25

## What this fixes

Entities that are **stale** were being reported as **Low Battery** even when their battery level is *above* the configured threshold (e.g. a stale entity at 50% battery shown as low battery with a 40% threshold).

This is a **display/counting bug only** — it does **not** change how devices are classified. "Degraded" status, staleness, offline/cooldown, and suppression all behave exactly as before.

## Root cause

`is_degraded` means "low battery **OR** stale". The low-battery counters used `is_degraded and battery_level is not None` as a stand-in for "low battery", so any stale device with a battery reading was miscounted as low battery regardless of its actual level.

## The fix

Track low battery explicitly with a new `is_low_battery` flag and have the low-battery counters read that flag instead of inferring it from `is_degraded`:

```python
device.is_stale       = is_stale
device.is_low_battery = (not device.is_offline) and battery_low            # NEW: true only when battery is actually below threshold
device.is_degraded    = (not device.is_offline) and (battery_low or is_stale)  # UNCHANGED
```

## Behavior

| Condition | Low Battery count | Degraded status |
|---|---|---|
| Battery below threshold | counted (unchanged) | Degraded (unchanged) |
| Stale, battery above threshold | **no longer counted** (the fix) | Degraded (unchanged) |
| Low battery **and** stale | counted (unchanged) | Degraded (unchanged) |

## Changes

- `models.py` — add `is_low_battery` to `DeviceState`.
- `coordinator.py` — set `is_low_battery` in the update loop; clear it for suppressed entities.
- `sensor.py` / `combined_sensor.py` — low-battery counters/lists use `is_low_battery and not is_suppressed`.
- Tests — regression tests for the stale-but-healthy-battery case (per-group and combined), plus positive cases confirming genuine low-battery devices are still counted.