### PR TITLE
0.3.13: fix ruff format + coordinator is_low_battery tests + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.13] - 2026-07-20
+
+### Fixed
+- **Stale entities miscounted as low battery** — stale entities whose battery was *above* the configured threshold were reported as low battery (e.g. a stale entity at 50% shown as low battery with a 40% threshold). The low-battery counters and lists used "degraded and has a battery reading" as a stand-in for "low battery", but degraded means low battery **or** stale, so any stale device with a battery reading was miscounted. Low battery is now tracked with an explicit `is_low_battery` flag set only when the battery is genuinely below threshold. Degraded status, staleness, offline/cooldown, and suppression are unchanged — this only corrects the low-battery count/list. Thanks to @dimatx for the fix.
+
 ## [0.3.12] - 2026-07-13
 
 ### Added

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -223,9 +223,7 @@ class CombinedGroupSensor(CombinedSensorBase):
                 1 for d in states.values() if d.is_stale and not d.is_suppressed
             )
             g_low_battery = sum(
-                1
-                for d in states.values()
-                if d.is_low_battery and not d.is_suppressed
+                1 for d in states.values() if d.is_low_battery and not d.is_suppressed
             )
             battery_map = coord.entry.data.get(CONF_BATTERY_ENTITY_MAP, {})
             if battery_map:

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1,9 +1,9 @@
 /**
- * Entity Availability Card v0.3.12
+ * Entity Availability Card v0.3.13
  * Custom Lovelace card for the Home Assistant Entity Availability integration.
  */
 
-const CARD_VERSION = "0.3.12";
+const CARD_VERSION = "0.3.13";
 
 console.info(
   `%c ENTITY-AVAILABILITY-CARD %c v${CARD_VERSION} %c — github.com/italo-lombardi `,

--- a/custom_components/entity_availability/manifest.json
+++ b/custom_components/entity_availability/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/italo-lombardi/Home-Assistant-EntityAvailability/issues",
     "quality_scale": "custom",
     "requirements": [],
-    "version": "0.3.12"
+    "version": "0.3.13"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3225,3 +3225,107 @@ def test_reset_statistics_offline_entity_restarts_clock(
     assert d.offline_event_count == 0
     assert d.offline_since is not None
     assert d.offline_since > old  # clock restarted to ~now
+
+
+# ---------------------------------------------------------------------------
+# is_low_battery computation (regression for #25): the coordinator must set
+# is_low_battery only when battery is genuinely below threshold, independent
+# of staleness. These run _async_update_data() so they guard the computation
+# itself (the sensor-level tests only set the flag by hand).
+# ---------------------------------------------------------------------------
+
+
+def _staleness_entry(mock_config_data) -> MockConfigEntry:
+    """Config entry with a 10-minute staleness threshold."""
+    data = dict(mock_config_data)
+    data[CONF_STALENESS_THRESHOLD] = 10
+    return MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Test Group",
+        data=data,
+        entry_id="test_entry_low_battery",
+        unique_id=f"{DOMAIN}_test_low_battery",
+    )
+
+
+async def _run_update(hass, entry):
+    """Run one coordinator update cycle and return device_a's state."""
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, entry)
+        coord._last_update = None
+        await coord._async_update_data()
+    return coord.device_states["binary_sensor.device_a"]
+
+
+async def test_stale_healthy_battery_not_low_battery(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """#25: stale entity with battery above threshold is degraded but NOT low battery."""
+    hass = mock_hass
+    old_time = datetime.now(timezone.utc) - timedelta(minutes=15)
+    hass.states.async_set(
+        "binary_sensor.device_a",
+        STATE_ON,
+        {"friendly_name": "Device A", "battery_level": 50},
+    )
+    hass.states._states["binary_sensor.device_a"] = State(
+        "binary_sensor.device_a",
+        STATE_ON,
+        {"friendly_name": "Device A", "battery_level": 50},
+        last_changed=old_time,
+        last_updated=old_time,
+    )
+
+    device_a = await _run_update(hass, _staleness_entry(mock_config_data))
+
+    assert device_a.battery_level == 50
+    assert device_a.is_stale is True
+    assert device_a.is_degraded is True
+    assert device_a.is_low_battery is False
+
+
+async def test_genuine_low_battery_sets_flag(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Battery below threshold: coordinator sets is_low_battery True."""
+    hass = mock_hass
+    hass.states.async_set(
+        "binary_sensor.device_a",
+        STATE_ON,
+        {"friendly_name": "Device A", "battery_level": 5},
+    )
+
+    device_a = await _run_update(hass, mock_config_entry)
+
+    assert device_a.battery_level == 5
+    assert device_a.is_low_battery is True
+    assert device_a.is_degraded is True
+
+
+async def test_low_battery_and_stale_both_flagged(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """Low battery AND stale: both flags set by the coordinator."""
+    hass = mock_hass
+    old_time = datetime.now(timezone.utc) - timedelta(minutes=15)
+    hass.states.async_set(
+        "binary_sensor.device_a",
+        STATE_ON,
+        {"friendly_name": "Device A", "battery_level": 5},
+    )
+    hass.states._states["binary_sensor.device_a"] = State(
+        "binary_sensor.device_a",
+        STATE_ON,
+        {"friendly_name": "Device A", "battery_level": 5},
+        last_changed=old_time,
+        last_updated=old_time,
+    )
+
+    device_a = await _run_update(hass, _staleness_entry(mock_config_data))
+
+    assert device_a.is_stale is True
+    assert device_a.is_low_battery is True
+    assert device_a.is_degraded is True


### PR DESCRIPTION
Follow-up to #27, which was merged via admin because its **Ruff Lint** check was failing (`ruff format --check` flagged `combined_sensor.py`).

## What this does
- **Ruff format** — reformats `combined_sensor.py` so `ruff format --check` passes (the check that blocked #27).
- **Coordinator-level tests** — adds 3 tests to `test_coordinator.py` that run `_async_update_data()` and assert `is_low_battery`:
  - stale + battery **above** threshold → `is_low_battery=False`, `is_degraded=True` (the #25 case)
  - genuine low battery → `is_low_battery=True`
  - low battery **and** stale → both flags set

  #27's regression tests set `is_low_battery` directly on the mock, so they exercised the sensor filtering but never the coordinator line that computes the flag (`device.is_low_battery = (not device.is_offline) and battery_low`). Deleting that line would still pass #27's tests; these guard it.
- **Version** — bump `manifest.json` 0.3.12 → 0.3.13.
- **CHANGELOG** — `[0.3.13]` Fixed entry describing the low-battery fix (credits @dimatx).

## Verification
- `559 passed`
- `ruff format --check .` clean, `ruff check .` clean