### PR TITLE
fix: truncate availability sensor now to minute resolution to reduce recorder writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ## [0.3.13] - 2026-07-20
 
 ### Fixed
+- **Availability sensor recorder churn** — `AvailabilitySensor.native_value` and `extra_state_attributes` truncate `now` to minute resolution before computing the rolling window cutoff. Previously, sub-second precision advancing every 30s coordinator tick caused the computed % to drift fractionally on every update; even after 1-decimal rounding, high-churn groups wrote a new distinct value every ~35s (~2,400 writes/day per `_today` sensor, 821K total over 45 days across 17 groups). With minute truncation the cutoff moves at most once per minute, capping writes at 1,440/day per sensor. No user-visible impact: the 1-decimal display precision is preserved and the ≤59s window shift is smaller than the rounding resolution. - 2026-07-20
+
+### Fixed
 - **Combined group coordinator staleness** — combined sensors now resolve source coordinators from `hass.data` at every update instead of holding references captured at setup time. Coordinators that load after the combined entry (boot-order race) are automatically subscribed on first access (`_active_coordinators` late-subscribe path). `hasattr` guard replaced with a typed class-level `_on_coordinator_update: ... | None = None` annotation so the guard is safe even if properties are called before `async_added_to_hass`.
 - **Combined group config flow entry filter** — the "Groups to Include" selector in both the create and edit flows now only shows entries in `ConfigEntryState.LOADED` state, preventing partially-loaded or errored entries from appearing as valid options.
 - **`strings.json` out of sync** — `strings.json` was missing the `group` step, `selector.entry_type`, and `options` data descriptions introduced in 0.3.x. Synced to match `en.json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.3.13] - 2026-07-20
+## [0.3.13] - 2026-07-22
 
 ### Fixed
 - **Availability sensor recorder churn** — `AvailabilitySensor.native_value` and `extra_state_attributes` truncate `now` to minute resolution before computing the rolling window cutoff. Previously, sub-second precision advancing every 30s coordinator tick caused the computed % to drift fractionally on every update; even after 1-decimal rounding, high-churn groups wrote a new distinct value every ~35s (~2,400 writes/day per `_today` sensor, 821K total over 45 days across 17 groups). With minute truncation the cutoff moves at most once per minute, capping writes at 1,440/day per sensor. No user-visible impact: the 1-decimal display precision is preserved and the ≤59s window shift is smaller than the rounding resolution. - 2026-07-20

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -342,7 +342,7 @@ class AvailabilitySensor(DedupCoordinatorSensor):
     @property
     def native_value(self) -> float | None:
         """Return group availability % (1-decimal precision)."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
         storage = self.coordinator.availability_storage
 
         values: list[float] = []
@@ -369,7 +369,7 @@ class AvailabilitySensor(DedupCoordinatorSensor):
         coordinator tick, defeating ``WriteDedupMixin`` even when the
         group-level rounded value was stable (v5.5 audit finding F-EA-1).
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
         storage = self.coordinator.availability_storage
         breakdown: dict[str, float | None] = {}
         for entity_id in self.coordinator.monitored_entities:

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -339,10 +339,14 @@ class AvailabilitySensor(DedupCoordinatorSensor):
         self._attr_translation_key = f"availability_{window}"
         self._attr_device_info = _device_info(entry_id, group_slug, group_name)
 
+    @staticmethod
+    def _truncated_now() -> datetime:
+        return datetime.now(timezone.utc).replace(second=0, microsecond=0)
+
     @property
     def native_value(self) -> float | None:
         """Return group availability % (1-decimal precision)."""
-        now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+        now = self._truncated_now()
         storage = self.coordinator.availability_storage
 
         values: list[float] = []
@@ -369,7 +373,7 @@ class AvailabilitySensor(DedupCoordinatorSensor):
         coordinator tick, defeating ``WriteDedupMixin`` even when the
         group-level rounded value was stable (v5.5 audit finding F-EA-1).
         """
-        now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+        now = self._truncated_now()
         storage = self.coordinator.availability_storage
         breakdown: dict[str, float | None] = {}
         for entity_id in self.coordinator.monitored_entities:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1391,7 +1391,7 @@ class TestAvailabilitySensorMinuteTruncation:
 
         assert all(t.second == 0 and t.microsecond == 0 for t in captured)
         # Both calls land on the same truncated minute
-        assert len({t for t in captured}) == 1
+        assert captured[0] == captured[-1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from freezegun import freeze_time
+
 import pytest
 
 from homeassistant.components.sensor import SensorDeviceClass
@@ -1344,6 +1346,52 @@ class TestAvailabilitySensorQuantization:
         assert write.call_count < 10, (
             f"dedup failed to suppress sub-0.1% drift: {write.call_count} writes"
         )
+
+
+# ---------------------------------------------------------------------------
+# AvailabilitySensor — minute-resolution truncation
+# ---------------------------------------------------------------------------
+
+
+class TestAvailabilitySensorMinuteTruncation:
+    """``_truncated_now`` always returns second=0, microsecond=0."""
+
+    @freeze_time("2026-01-01 12:34:56.789012+00:00")
+    def test_truncated_now_strips_sub_minute(self, mock_coordinator, mock_hass):
+        """_truncated_now returns current minute with second=0, microsecond=0."""
+        sensor = AvailabilitySensor(
+            mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        now = sensor._truncated_now()
+        assert now.second == 0
+        assert now.microsecond == 0
+        assert now.hour == 12
+        assert now.minute == 34
+
+    @freeze_time("2026-01-01 12:34:56.789012+00:00")
+    def test_native_value_and_attrs_receive_same_truncated_now(
+        self, mock_coordinator, mock_hass
+    ):
+        """native_value and extra_state_attributes pass identical truncated now to storage."""
+        sensor = AvailabilitySensor(
+            mock_coordinator, "Test Group", "test_group", "today", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        storage = mock_coordinator.availability_storage
+        captured = []
+
+        def _capture(_eid, _window, now):
+            captured.append(now)
+            return 100.0
+
+        with patch.object(storage, "get_availability", side_effect=_capture):
+            sensor.native_value
+            sensor.extra_state_attributes
+
+        assert all(t.second == 0 and t.microsecond == 0 for t in captured)
+        # Both calls land on the same truncated minute
+        assert len({t for t in captured}) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

In `AvailabilitySensor.native_value` and `AvailabilitySensor.extra_state_attributes` (sensor.py:345, sensor.py:372):

```python
# before
now = datetime.now(timezone.utc)

# after
now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
```

## Why

`get_availability()` computes a rolling window cutoff from `now`. With sub-second precision advancing every 30s coordinator tick, the computed availability % drifts fractionally on every tick. Even after dedup rounding to 1 decimal, high-churn groups produced a new distinct value every ~35s — **~2,400 recorder writes/day per `_today` sensor**.

DB analysis over a 45-day window: **821K total writes** from `_today` sensors across 17 groups.

Truncating `now` to minute precision means the window cutoff moves only once per minute. The rounded % can only change at a minute boundary → **at most 1,440 writes/day per sensor** (~40% reduction).

For 3d/5d/7d windows the denominator is large enough that truncating to minutes has no measurable effect on the computed value.

## User-visible impact

None. Availability % is rounded to 1 decimal on display. A 60s update cadence vs ~35s is imperceptible on dashboards. Automations using threshold conditions (e.g. `> 95%`) are unaffected.