### PR TITLE
chore: bump to 0.3.14

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install ruff
-        run: pip install ruff
+        run: pip install ruff==0.15.12
       - name: Run ruff check
         run: ruff check .
       - name: Run ruff format check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.14] - 2026-07-28
+
+### Fixed
+- **Battery mapping: cleared entries no longer re-populated** — explicitly clearing a battery entity mapping in the options flow now persists correctly. Previously, a cleared mapping (stored as `""`) was treated identically to "never configured", so auto-detection re-ran on the next visit and silently re-added the removed mapping. The options flow now distinguishes between an explicitly-cleared entry and one that was never set, so cleared mappings stay cleared. Resolves #38.
+
 ## [0.3.13] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [0.3.14] - 2026-07-28
 
 ### Fixed
-- **Battery mapping: cleared entries no longer re-populated** — explicitly clearing a battery entity mapping in the options flow now persists correctly. Previously, a cleared mapping (stored as `""`) was treated identically to "never configured", so auto-detection re-ran on the next visit and silently re-added the removed mapping. The options flow now distinguishes between an explicitly-cleared entry and one that was never set, so cleared mappings stay cleared. Resolves #38.
+- **Battery mapping: cleared entries no longer re-populated** — explicitly clearing a battery entity mapping in the options flow now persists correctly. Previously, a cleared mapping (stored as `""`) was treated identically to "never configured", so auto-detection re-ran on the next visit and silently re-added the removed mapping. The options flow now distinguishes between an explicitly-cleared entry and one that was never set, so cleared mappings stay cleared. Resolves #38. Thanks to @dimatx for the fix.
 
 ## [0.3.13] - 2026-07-22
 

--- a/custom_components/entity_availability/manifest.json
+++ b/custom_components/entity_availability/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/italo-lombardi/Home-Assistant-EntityAvailability/issues",
     "quality_scale": "custom",
     "requirements": [],
-    "version": "0.3.13"
+    "version": "0.3.14"
 }


### PR DESCRIPTION
Bumps version to 0.3.14 and adds changelog entry for the battery mapping fix landed in #37.

## Changes
- `manifest.json`: `0.3.13` → `0.3.14`
- `CHANGELOG.md`: new `[0.3.14]` section documenting the #38 fix