### PR TITLE
feat(card): per-entity suppress toggle (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ All notable changes to this project will be documented in this file.
 - **Card: per-entity suppress toggle (opt-in)** — new card config key `show_suppress_toggle` (default `false`). When enabled, each entity row shows a bell-off icon button. Click suppresses the entity indefinitely; click the orange bell to unsuppress. Configurable from the card editor under "Show Per-Entity Suppress Toggle". Related to #34.
 
 ### Fixed
-- **`suppressed_until` attribute now includes indefinitely-suppressed entities** — previously, entities suppressed with no expiry were absent from the `suppressed_until` sensor attribute. They now appear with value `"indefinite"`, enabling automations and the card to correctly detect and display their suppressed state.
+- **`suppressed_until` attribute now includes indefinitely-suppressed entities** — previously, entities suppressed with no expiry were absent from the `suppressed_until` sensor attribute. They now appear with value `null` (Python `None`, JSON `null`), enabling automations and the card to correctly detect and display their suppressed state.
+
+### Breaking Changes
+- **`suppressed_until` value for indefinite suppression is now `null`** — the attribute previously omitted indefinitely-suppressed entities entirely. They now appear with a `null` value. Automations or templates that test truthiness of the value (e.g. `if suppressed_until.get(entity_id)`) will now evaluate as `False` for indefinitely-suppressed entities even though they are suppressed. Use `entity_id in suppressed_until` (key-presence check) to correctly detect any suppressed entity regardless of type.
 
 ## [0.3.14] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Card: per-entity suppress toggle (opt-in)** — new card config key `show_suppress_toggle` (default `false`). When enabled, each entity row shows a bell-off icon button. Click suppresses the entity indefinitely; click the orange bell to unsuppress. Configurable from the card editor under "Show Per-Entity Suppress Toggle". Related to #34.
+
+### Fixed
+- **`suppressed_until` attribute now includes indefinitely-suppressed entities** — previously, entities suppressed with no expiry were absent from the `suppressed_until` sensor attribute. They now appear with value `"indefinite"`, enabling automations and the card to correctly detect and display their suppressed state.
+
 ## [0.3.14] - 2026-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ availability_colors:
 | `show_availability` | `true` | Show availability progress bars (regular groups only) |
 | `show_entities` | `true` | Show expandable entity list (regular) or group breakdown table (combined) |
 | `entities_expanded` | `false` | Start entity list / group breakdown expanded |
-| `show_actions` | `false` | Show Suppress/Unsuppress All buttons (regular groups only) |
+| `show_actions` | `false` | Show Suppress/Unsuppress All buttons (regular groups only). **Suppress All** suppresses only currently-offline entities for 60 minutes. To suppress online entities individually, use `show_suppress_toggle`. |
 | `show_suppress_toggle` | `false` | Show per-entity suppress/unsuppress icon button on each entity row. Click suppresses indefinitely; click the orange bell to unsuppress. (regular groups only) |
 | `entity_detail` | `"off"` | `"off"` / `"tooltip"` (hover to see details) / `"inline"` (always show details). In compact mode with inline, shows state + last-changed time. Timestamp states are formatted as readable dates. (regular groups only) |
 | `entity_filter` | `"all"` | Filter entity list: `"all"`, `"offline"` (problems only: offline/stale/low battery), `"online"` (healthy only). Section title and count update to reflect filter (e.g., "Offline Entities (2/6)"). (regular groups only) |

--- a/README.md
+++ b/README.md
@@ -519,7 +519,8 @@ availability_colors:
 | `show_availability` | `true` | Show availability progress bars (regular groups only) |
 | `show_entities` | `true` | Show expandable entity list (regular) or group breakdown table (combined) |
 | `entities_expanded` | `false` | Start entity list / group breakdown expanded |
-| `show_actions` | `false` | Show Suppress/Unsuppress buttons (regular groups only) |
+| `show_actions` | `false` | Show Suppress/Unsuppress All buttons (regular groups only) |
+| `show_suppress_toggle` | `false` | Show per-entity suppress/unsuppress icon button on each entity row. Click suppresses indefinitely; click the orange bell to unsuppress. (regular groups only) |
 | `entity_detail` | `"off"` | `"off"` / `"tooltip"` (hover to see details) / `"inline"` (always show details). In compact mode with inline, shows state + last-changed time. Timestamp states are formatted as readable dates. (regular groups only) |
 | `entity_filter` | `"all"` | Filter entity list: `"all"`, `"offline"` (problems only: offline/stale/low battery), `"online"` (healthy only). Section title and count update to reflect filter (e.g., "Offline Entities (2/6)"). (regular groups only) |
 | `compact` | `false` | Reduced padding mode |

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -362,6 +362,11 @@ const cardStyles = css`
     text-align: right;
   }
 
+  .entity-legend-spacer {
+    width: 24px;
+    flex-shrink: 0;
+  }
+
   .entity-item {
     display: flex;
     align-items: center;
@@ -848,7 +853,7 @@ class EntityAvailabilityCard extends LitElement {
           <span class="entity-legend-name">Entity</span>
           <span class="entity-legend-status">State</span>
           ${hasBattery ? html`<span class="entity-legend-battery">Bat.</span>` : nothing}
-          ${this._config.show_suppress_toggle ? html`<span style="width:24px;flex-shrink:0"></span>` : nothing}
+          ${this._config.show_suppress_toggle ? html`<span class="entity-legend-spacer"></span>` : nothing}
         </div>
         ${items.map(
           (item) => html`
@@ -1059,7 +1064,7 @@ class EntityAvailabilityCard extends LitElement {
       { label: "HA State", value: lastChanged ? `${this._formatStateWithUnit(entityState)} · ${lastChanged}` : this._formatStateWithUnit(entityState) },
       { label: "Condition", value: suppressedUntil ? "Suppressed" : item.isOffline ? `Offline for ${item.status}` : item.status },
       item.battery !== null ? { label: "Battery", value: `${item.battery}%` } : null,
-      suppressedUntil ? { label: "Suppressed", value: `until ${suppressedUntil}` } : null,
+      suppressedUntil ? { label: "Suppressed", value: suppressedUntil === "indefinitely" ? "Indefinitely" : `until ${suppressedUntil}` } : null,
     ].filter(Boolean);
   }
 

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -377,6 +377,27 @@ const cardStyles = css`
     opacity: 0.8;
   }
 
+  .entity-suppress-btn {
+    margin-left: auto;
+    background: none;
+    border: none;
+    padding: 2px 4px;
+    cursor: pointer;
+    color: var(--secondary-text-color);
+    display: flex;
+    align-items: center;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+
+  .entity-suppress-btn.suppressed {
+    color: var(--warning-color, #ff9800);
+  }
+
+  .entity-suppress-btn:hover {
+    background: var(--secondary-background-color);
+  }
+
   .entity-detail-inline {
     width: 100%;
     padding: 2px 0 6px 20px;
@@ -578,6 +599,7 @@ class EntityAvailabilityCard extends LitElement {
       show_entities: true,
       entities_expanded: false,
       show_actions: false,
+      show_suppress_toggle: false,
       compact: false,
     };
   }
@@ -597,6 +619,7 @@ class EntityAvailabilityCard extends LitElement {
       show_entities: true,
       entities_expanded: false,
       show_actions: false,
+      show_suppress_toggle: false,
       compact: false,
       sort_by: "status",
       entity_detail: "off",
@@ -825,6 +848,7 @@ class EntityAvailabilityCard extends LitElement {
           <span class="entity-legend-name">Entity</span>
           <span class="entity-legend-status">State</span>
           ${hasBattery ? html`<span class="entity-legend-battery">Bat.</span>` : nothing}
+          ${this._config.show_suppress_toggle ? html`<span style="width:24px;flex-shrink:0"></span>` : nothing}
         </div>
         ${items.map(
           (item) => html`
@@ -841,6 +865,12 @@ class EntityAvailabilityCard extends LitElement {
               ${this._config.entity_detail === "inline"
                 ? this._renderDetailInline(item, suppressedUntil)
                 : nothing}
+              ${this._config.show_suppress_toggle ? html`
+              <button class="entity-suppress-btn ${item.isSuppressed ? "suppressed" : ""}"
+                title="${item.isSuppressed ? "Unsuppress" : "Suppress indefinitely"}"
+                @click=${(e) => this._handleToggleSuppress(e, item.entityId, item.isSuppressed)}>
+                <ha-icon icon="${item.isSuppressed ? "mdi:bell-off" : "mdi:bell-off-outline"}" style="--mdc-icon-size:16px"></ha-icon>
+              </button>` : nothing}
             </div>
           `
         )}`}
@@ -1017,7 +1047,9 @@ class EntityAvailabilityCard extends LitElement {
     const areaName = areaId ? (this.hass.areas?.[areaId]?.name || null) : null;
 
     const suppressedUntilIso = suppressedUntilMap[item.entityId];
-    const suppressedUntil = suppressedUntilIso
+    const suppressedUntil = suppressedUntilIso === "indefinite"
+      ? "indefinitely"
+      : suppressedUntilIso
       ? this._formatFutureDate(suppressedUntilIso)
       : null;
 
@@ -1202,6 +1234,15 @@ class EntityAvailabilityCard extends LitElement {
   _handleEntityClick(e, entityId) {
     e.stopPropagation();
     this.dispatchEvent(new CustomEvent("hass-more-info", { detail: { entityId }, bubbles: true, composed: true }));
+  }
+
+  async _handleToggleSuppress(e, entityId, isSuppressed) {
+    e.stopPropagation();
+    if (isSuppressed) {
+      await this.hass.callService("entity_availability", "unsuppress", { entity_id: entityId });
+    } else {
+      await this.hass.callService("entity_availability", "suppress_indefinitely", { entity_id: entityId });
+    }
   }
 
   async _handleSuppressAll(e) {
@@ -1462,6 +1503,16 @@ class EntityAvailabilityCardEditor extends LitElement {
               @change=${(e) => this._updateConfig("show_actions", e.target.checked)}
             />
             Show Suppress/Unsuppress Buttons
+          </label>
+        </div>
+        <div class="editor-row checkbox">
+          <label>
+            <input
+              type="checkbox"
+              .checked=${this._config.show_suppress_toggle === true}
+              @change=${(e) => this._updateConfig("show_suppress_toggle", e.target.checked)}
+            />
+            Show Per-Entity Suppress Toggle
           </label>
         </div>
         ` : nothing}

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -931,10 +931,10 @@ class EntityAvailabilityCard extends LitElement {
     return html`
       <div class="divider"></div>
       <div class="actions-section">
-        <button class="action-btn suppress" @click=${this._handleSuppressAll}>
+        <button class="action-btn suppress" title="Suppress all currently offline entities for 60 minutes" @click=${this._handleSuppressAll}>
           Suppress All
         </button>
-        <button class="action-btn unsuppress" @click=${this._handleUnsuppressAll}>
+        <button class="action-btn unsuppress" title="Remove suppression from all entities in this group" @click=${this._handleUnsuppressAll}>
           Unsuppress All
         </button>
       </div>

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1047,7 +1047,7 @@ class EntityAvailabilityCard extends LitElement {
     const areaName = areaId ? (this.hass.areas?.[areaId]?.name || null) : null;
 
     const suppressedUntilIso = suppressedUntilMap[item.entityId];
-    const suppressedUntil = suppressedUntilIso === "indefinite"
+    const suppressedUntil = suppressedUntilIso === null
       ? "indefinitely"
       : suppressedUntilIso
       ? this._formatFutureDate(suppressedUntilIso)

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -609,8 +609,10 @@ class GroupSummarySensor(DedupCoordinatorSensor):
             },
             "suppressed_until": {
                 eid: d.suppress_until.isoformat()
+                if d.suppress_until is not None
+                else "indefinite"
                 for eid, d in states.items()
-                if d.is_suppressed and d.suppress_until is not None
+                if d.is_suppressed
             },
             "stale_entities": [
                 eid for eid, d in states.items() if d.is_stale and not d.is_suppressed

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -610,7 +610,7 @@ class GroupSummarySensor(DedupCoordinatorSensor):
             "suppressed_until": {
                 eid: d.suppress_until.isoformat()
                 if d.suppress_until is not None
-                else "indefinite"
+                else None
                 for eid, d in states.items()
                 if d.is_suppressed
             },

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -44,3 +44,4 @@ curl -s -X POST http://localhost:8123/auth/token \
 | EC8 | Combined: offline+low → low_battery drops, offline rises | #41 |
 | EC9 | Cleared battery map not re-suggested in options flow | #37 |
 | EC10 | Suppressed entity not counted in offline | core |
+| EC11 | suppress_indefinitely + unsuppress round-trip; suppressed_until=null for indefinite | #42 |

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -590,6 +590,49 @@ for e in cfg['data']['entries']:
     )
 
     # ------------------------------------------------------------------
+    print(
+        "\n=== EC11: suppress_indefinitely + unsuppress round-trip ===",
+        flush=True,
+    )
+    restore_all(ctx)
+    indef_entity = ctx["entities"][1]
+    api(
+        "POST",
+        "/api/services/entity_availability/suppress_indefinitely",
+        {"entity_id": indef_entity, "group": ctx["title"]},
+    )
+    wait()
+    summary_attrs = gs(f"{prefix}_group_summary").get("attributes", {})
+    chk(
+        "EC11 suppressed=1 after suppress_indefinitely",
+        str(summary_attrs.get("suppressed")),
+        "1",
+    )
+    chk(
+        "EC11 suppressed_until[entity]=null (indefinite)",
+        summary_attrs.get("suppressed_until", {}).get(indef_entity),
+        None,
+    )
+    ss(indef_entity, "unavailable", {"friendly_name": "test"})
+    wait()
+    chk(
+        "EC11 offline_count=0 (indefinitely suppressed not counted)",
+        gs(f"{prefix}_offline_count").get("state"),
+        "0",
+    )
+    api(
+        "POST",
+        "/api/services/entity_availability/unsuppress",
+        {"entity_id": indef_entity, "group": ctx["title"]},
+    )
+    wait()
+    chk(
+        "EC11 suppressed=0 after unsuppress",
+        str(gs(f"{prefix}_group_summary").get("attributes", {}).get("suppressed")),
+        "0",
+    )
+
+    # ------------------------------------------------------------------
     print("\n=== CLEANUP ===", flush=True)
     restore_all(ctx)
     print(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -559,6 +559,32 @@ class TestGroupSummarySensor:
         assert attrs["suppressed"] == 1
         assert attrs["online"] == 1  # total(3) - offline(1) - suppressed(1) = 1
 
+    def test_suppressed_until_timed(self, mock_coordinator, mock_hass):
+        """Timed suppression appears in suppressed_until as ISO string."""
+        from datetime import datetime, timezone
+
+        until = datetime(2030, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        mock_coordinator._device_states["binary_sensor.device_c"].is_suppressed = True
+        mock_coordinator._device_states["binary_sensor.device_c"].suppress_until = until
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert attrs["suppressed_until"]["binary_sensor.device_c"] == until.isoformat()
+
+    def test_suppressed_until_indefinite(self, mock_coordinator, mock_hass):
+        """Indefinite suppression appears in suppressed_until with None value."""
+        mock_coordinator._device_states["binary_sensor.device_c"].is_suppressed = True
+        mock_coordinator._device_states["binary_sensor.device_c"].suppress_until = None
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert "binary_sensor.device_c" in attrs["suppressed_until"]
+        assert attrs["suppressed_until"]["binary_sensor.device_c"] is None
+
     def test_attributes_low_battery_count(self, mock_coordinator, mock_hass):
         """Test low battery count in attributes."""
         mock_coordinator._device_states["binary_sensor.device_a"].is_low_battery = True


### PR DESCRIPTION
## Summary

- New card config key `show_suppress_toggle` (default `false`) — opt-in, no impact on existing cards
- When enabled, each entity row shows a `mdi:bell-off-outline` icon button; click suppresses indefinitely via `suppress_indefinitely` service
- Suppressed entities show orange `mdi:bell-off` icon; click calls `unsuppress`
- `suppressed_until` sensor attribute now includes indefinitely-suppressed entities with value `"indefinite"` (previously only timed suppresses appeared); card tooltip/inline detail renders this as "indefinitely"
- Toggle exposed in card editor under "Show Per-Entity Suppress Toggle"

Related to #34 (suppression part; critical flag is a separate future feature)

## Test plan

- [ ] Enable `show_suppress_toggle` in card editor on a regular group
- [ ] Click bell on an online entity → entity moves to suppressed state, bell turns orange
- [ ] Click orange bell → entity unsuppressed, bell returns to outline
- [ ] Verify suppressed entity not counted in offline when it goes unavailable
- [ ] Verify card with `show_suppress_toggle: false` (default) shows no bell icons
- [ ] Verify tooltip/inline detail shows "Suppressed indefinitely" for indefinitely-suppressed entity