### PR TITLE
fix: group-scoped suppress/unsuppress, combined sensor dedup, card polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Added
-- **Card: per-entity suppress toggle (opt-in)** — new card config key `show_suppress_toggle` (default `false`). When enabled, each entity row shows a bell-off icon button. Click suppresses the entity indefinitely; click the orange bell to unsuppress. Configurable from the card editor under "Show Per-Entity Suppress Toggle". Related to #34.
-
 ### Fixed
+- **Suppress/unsuppress services now group-scoped when `group` is provided with `entity_id`** — previously, calling `suppress`, `suppress_indefinitely`, or `unsuppress` with both `entity_id` and `group` would suppress/unsuppress the entity in **all groups** that monitor it. The `group` parameter is now respected: the action is scoped to that group's coordinator only. This affects the card's per-entity bell toggle, Suppress All, and Unsuppress All buttons — all now pass the card's configured group.
 - **`suppressed_until` attribute now includes indefinitely-suppressed entities** — previously, entities suppressed with no expiry were absent from the `suppressed_until` sensor attribute. They now appear with value `null` (Python `None`, JSON `null`), enabling automations and the card to correctly detect and display their suppressed state.
+
+### Added
+- **Card: per-entity suppress toggle (opt-in)** — new card config key `show_suppress_toggle` (default `false`). When enabled, each entity row shows a bell-off icon button. Click suppresses the entity indefinitely within the card's group; click the orange bell to unsuppress. Configurable from the card editor under "Show Per-Entity Suppress Toggle". Related to #34.
 
 ### Breaking Changes
 - **`suppressed_until` value for indefinite suppression is now `null`** — the attribute previously omitted indefinitely-suppressed entities entirely. They now appear with a `null` value. Automations or templates that test truthiness of the value (e.g. `if suppressed_until.get(entity_id)`) will now evaluate as `False` for indefinitely-suppressed entities even though they are suppressed. Use `entity_id in suppressed_until` (key-presence check) to correctly detect any suppressed entity regardless of type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **Suppress/unsuppress services now group-scoped when `group` is provided with `entity_id`** — previously, calling `suppress`, `suppress_indefinitely`, or `unsuppress` with both `entity_id` and `group` would suppress/unsuppress the entity in **all groups** that monitor it. The `group` parameter is now respected: the action is scoped to that group's coordinator only. This affects the card's per-entity bell toggle, Suppress All, and Unsuppress All buttons — all now pass the card's configured group.
+- **`reset_statistics` service now group-scoped when `group` is provided with `entity_id`** — consistent with the other services, statistics are now reset only in the named group when both params are provided.
 - **`suppressed_until` attribute now includes indefinitely-suppressed entities** — previously, entities suppressed with no expiry were absent from the `suppressed_until` sensor attribute. They now appear with value `null` (Python `None`, JSON `null`), enabling automations and the card to correctly detect and display their suppressed state.
+- **Combined sensor `battery_powered` count deduplicated** — `battery_powered` was double-counted when the same entity appeared in multiple source groups. Now uses a set of unique entity IDs across all groups.
+- **Card: Space key no longer scrolls page on focused entity rows** — `preventDefault()` is now called on Space `keydown` to suppress browser scroll, while the click action still fires on `keyup` per WAI-ARIA spec.
+- **Card: entity click guard against missing entity ID** — `_handleEntityClick` returns early if `entityId` is not a non-empty string, preventing a malformed `hass-more-info` event.
 
 ### Added
 - **Card: per-entity suppress toggle (opt-in)** — new card config key `show_suppress_toggle` (default `false`). When enabled, each entity row shows a bell-off icon button. Click suppresses the entity indefinitely within the card's group; click the orange bell to unsuppress. Configurable from the card editor under "Show Per-Entity Suppress Toggle". Related to #34.

--- a/README.md
+++ b/README.md
@@ -327,11 +327,20 @@ The integration samples each entity's state in the background. If online, that t
 Temporarily exclude an entity (or all entities in a group) from monitoring and offline alerts.
 
 ```yaml
-# Suppress a single entity
+# Suppress a single entity (all groups that monitor it)
 service: entity_availability.suppress
 data:
   entity_id: switch.garden_lights
   duration: 120  # minutes (default: 60, max: 10080)
+```
+
+```yaml
+# Suppress a single entity in a specific group only
+service: entity_availability.suppress
+data:
+  entity_id: switch.garden_lights
+  group: Security Devices
+  duration: 120
 ```
 
 ```yaml
@@ -342,7 +351,7 @@ data:
   duration: 60
 ```
 
-> **Group field:** In the Actions UI, the `group` field shows a dropdown of all Entity Availability config entries. In YAML automations you can use either the group name (e.g. `security_devices`) or the config entry ID — both are accepted.
+> **Group field:** When both `entity_id` and `group` are provided, the suppression is scoped to that group only — the entity remains monitored in any other groups it belongs to. When only `entity_id` is provided, the entity is suppressed in all groups that monitor it. In the Actions UI, the `group` field shows a dropdown of all Entity Availability config entries. In YAML automations you can use either the group name or the config entry ID.
 
 **Use case:** Suppress monitoring during planned maintenance, firmware updates, or known downtime.
 
@@ -520,7 +529,7 @@ availability_colors:
 | `show_entities` | `true` | Show expandable entity list (regular) or group breakdown table (combined) |
 | `entities_expanded` | `false` | Start entity list / group breakdown expanded |
 | `show_actions` | `false` | Show Suppress/Unsuppress All buttons (regular groups only). **Suppress All** suppresses only currently-offline entities for 60 minutes. To suppress online entities individually, use `show_suppress_toggle`. |
-| `show_suppress_toggle` | `false` | Show per-entity suppress/unsuppress icon button on each entity row. Click suppresses indefinitely; click the orange bell to unsuppress. (regular groups only) |
+| `show_suppress_toggle` | `false` | Show per-entity suppress/unsuppress icon button on each entity row. Click suppresses indefinitely within this card's group only; click the orange bell to unsuppress. (regular groups only) |
 | `entity_detail` | `"off"` | `"off"` / `"tooltip"` (hover to see details) / `"inline"` (always show details). In compact mode with inline, shows state + last-changed time. Timestamp states are formatted as readable dates. (regular groups only) |
 | `entity_filter` | `"all"` | Filter entity list: `"all"`, `"offline"` (problems only: offline/stale/low battery), `"online"` (healthy only). Section title and count update to reflect filter (e.g., "Offline Entities (2/6)"). (regular groups only) |
 | `compact` | `false` | Reduced padding mode |

--- a/README.md
+++ b/README.md
@@ -404,10 +404,18 @@ data:
 Clear availability history **and** reliability counters (MTBF/MTTR, offline-event count) for an entity or an entire group. Availability % windows and the Reliability sensor start accumulating fresh.
 
 ```yaml
-# Reset a single entity
+# Reset a single entity (all groups that monitor it)
 service: entity_availability.reset_statistics
 data:
   entity_id: sensor.living_room_temperature
+```
+
+```yaml
+# Reset a single entity in a specific group only
+service: entity_availability.reset_statistics
+data:
+  entity_id: sensor.living_room_temperature
+  group: Security Devices
 ```
 
 ```yaml

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -222,7 +222,6 @@ class CombinedGroupSensor(CombinedSensorBase):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        battery_powered = 0
         groups: dict[str, Any] = {}
 
         active = self._active_coordinators()
@@ -252,7 +251,6 @@ class CombinedGroupSensor(CombinedSensorBase):
                     for d in states.values()
                     if d.battery_level is not None and not d.is_suppressed
                 )
-            battery_powered += g_battery_powered
             gname = coord.group_name
             gsummary = registry.async_get_entity_id(
                 "sensor", DOMAIN, f"{coord.entry.entry_id}_group_summary"
@@ -305,6 +303,19 @@ class CombinedGroupSensor(CombinedSensorBase):
             1 for d in merged_states.values() if d.is_stale and not d.is_suppressed
         )
         suppressed = sum(1 for d in merged_states.values() if d.is_suppressed)
+        # Dedup battery_powered: collect all mapped battery sensor IDs across groups
+        # into a set (battery_map path), or count via merged_states (battery_level path).
+        battery_sensor_ids: set[str] = set()
+        battery_level_eids: set[str] = set()
+        for coord in active:
+            battery_map = coord.entry.data.get(CONF_BATTERY_ENTITY_MAP, {})
+            if battery_map:
+                battery_sensor_ids.update(sid for sid in battery_map.values() if sid)
+            else:
+                for eid, d in coord.device_states.items():
+                    if d.battery_level is not None and not d.is_suppressed:
+                        battery_level_eids.add(eid)
+        battery_powered = len(battery_sensor_ids) + len(battery_level_eids)
         display_names: dict[str, str] = {}
         for coord in active:
             use_device_names = coord.entry.data.get(CONF_USE_DEVICE_NAMES, False)

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -24,6 +24,7 @@ from .const import (
     NO_AREA_SENTINEL,
 )
 from .coordinator import EntityAvailabilityCoordinator
+from .models import DeviceState
 from .helpers import resolve_area_name, resolve_display_name
 from .write_dedup import WriteDedupMixin
 
@@ -221,14 +222,11 @@ class CombinedGroupSensor(CombinedSensorBase):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        total = online = offline = stale = low_battery = suppressed = (
-            battery_powered
-        ) = 0
-        offline_entities: list[str] = []
-        low_battery_entities: list[str] = []
+        battery_powered = 0
         groups: dict[str, Any] = {}
 
         active = self._active_coordinators()
+        registry = er.async_get(self.hass)
         for coord in active:
             states = coord.device_states
             g_total = len(coord.monitored_entities)
@@ -254,28 +252,15 @@ class CombinedGroupSensor(CombinedSensorBase):
                     for d in states.values()
                     if d.battery_level is not None and not d.is_suppressed
                 )
-            total += g_total
-            online += g_online
-            offline += g_offline
-            stale += g_stale
-            low_battery += g_low_battery
-            suppressed += g_suppressed
             battery_powered += g_battery_powered
-            offline_entities += [
-                d.entity_id
-                for d in states.values()
-                if d.is_offline and not d.is_suppressed
-            ]
-            low_battery_entities += [
-                d.entity_id
-                for d in states.values()
-                if d.is_low_battery and not d.is_suppressed and not d.is_offline
-            ]
             gname = coord.group_name
-            registry = er.async_get(self.hass)
             gsummary = registry.async_get_entity_id(
                 "sensor", DOMAIN, f"{coord.entry.entry_id}_group_summary"
             )
+            if gsummary is None:
+                _LOGGER.warning(
+                    "Could not find group summary entity for %s", coord.entry.entry_id
+                )
             groups[coord.entry.entry_id] = {
                 "name": gname,
                 "entity_id": gsummary,
@@ -288,13 +273,38 @@ class CombinedGroupSensor(CombinedSensorBase):
                 "battery_powered": g_battery_powered,
             }
 
+        # Build merged state map (first-wins for shared entities) to dedup all counts.
+        merged_states: dict[str, DeviceState] = {}
+        for coord in active:
+            for eid, d in coord.device_states.items():
+                if eid not in merged_states:
+                    merged_states[eid] = d
+
         all_entities = list(
             dict.fromkeys(eid for coord in active for eid in coord.monitored_entities)
         )
-        offline_entities = list(dict.fromkeys(offline_entities))
-        low_battery_entities = list(dict.fromkeys(low_battery_entities))
+        offline_entities = [
+            d.entity_id
+            for d in merged_states.values()
+            if d.is_offline and not d.is_suppressed
+        ]
+        low_battery_entities = [
+            d.entity_id
+            for d in merged_states.values()
+            if d.is_low_battery and not d.is_suppressed and not d.is_offline
+        ]
+        total = len(all_entities)
         offline = len(offline_entities)
         low_battery = len(low_battery_entities)
+        online = sum(
+            1
+            for d in merged_states.values()
+            if not d.is_offline and not d.is_suppressed
+        )
+        stale = sum(
+            1 for d in merged_states.values() if d.is_stale and not d.is_suppressed
+        )
+        suppressed = sum(1 for d in merged_states.values() if d.is_suppressed)
         display_names: dict[str, str] = {}
         for coord in active:
             use_device_names = coord.entry.data.get(CONF_USE_DEVICE_NAMES, False)

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -303,19 +303,21 @@ class CombinedGroupSensor(CombinedSensorBase):
             1 for d in merged_states.values() if d.is_stale and not d.is_suppressed
         )
         suppressed = sum(1 for d in merged_states.values() if d.is_suppressed)
-        # Dedup battery_powered: collect all mapped battery sensor IDs across groups
-        # into a set (battery_map path), or count via merged_states (battery_level path).
-        battery_sensor_ids: set[str] = set()
-        battery_level_eids: set[str] = set()
+        # Dedup battery_powered by collecting device entity_ids (not battery sensor ids).
+        # battery_map keys are device entity_ids; battery_level path is already keyed by eid.
+        # Using one set handles mixed-config groups without double-counting.
+        battery_powered_eids: set[str] = set()
         for coord in active:
             battery_map = coord.entry.data.get(CONF_BATTERY_ENTITY_MAP, {})
             if battery_map:
-                battery_sensor_ids.update(sid for sid in battery_map.values() if sid)
+                battery_powered_eids.update(
+                    eid for eid, sid in battery_map.items() if sid
+                )
             else:
                 for eid, d in coord.device_states.items():
                     if d.battery_level is not None and not d.is_suppressed:
-                        battery_level_eids.add(eid)
-        battery_powered = len(battery_sensor_ids) + len(battery_level_eids)
+                        battery_powered_eids.add(eid)
+        battery_powered = len(battery_powered_eids)
         display_names: dict[str, str] = {}
         for coord in active:
             use_device_names = coord.entry.data.get(CONF_USE_DEVICE_NAMES, False)

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -857,7 +857,7 @@ class EntityAvailabilityCard extends LitElement {
         </div>
         ${items.map(
           (item) => html`
-            <div class="entity-item" tabindex="0" role="button" @click=${(e) => this._handleEntityClick(e, item.entityId)} @keydown=${(e) => { if (e.key === "Enter") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }} @keyup=${(e) => { if (e.key === " ") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }}>
+            <div class="entity-item" tabindex="0" role="button" @click=${(e) => this._handleEntityClick(e, item.entityId)} @keydown=${(e) => { if (e.key === "Enter") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }} @keyup=${(e) => { if (e.key === " ") { this._handleEntityClick(e, item.entityId); } }}>
               <div class="entity-dot ${item.dotColor}"></div>
               <span class="entity-name">${item.name}</span>
               <span class="entity-status">${item.status}</span>

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -857,7 +857,7 @@ class EntityAvailabilityCard extends LitElement {
         </div>
         ${items.map(
           (item) => html`
-            <div class="entity-item" tabindex="0" role="button" @click=${(e) => this._handleEntityClick(e, item.entityId)} @keydown=${(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }}>
+            <div class="entity-item" tabindex="0" role="button" @click=${(e) => this._handleEntityClick(e, item.entityId)} @keydown=${(e) => { if (e.key === "Enter") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }} @keyup=${(e) => { if (e.key === " ") { this._handleEntityClick(e, item.entityId); } }}>
               <div class="entity-dot ${item.dotColor}"></div>
               <span class="entity-name">${item.name}</span>
               <span class="entity-status">${item.status}</span>
@@ -1238,6 +1238,7 @@ class EntityAvailabilityCard extends LitElement {
 
   _handleEntityClick(e, entityId) {
     e.stopPropagation();
+    if (typeof entityId !== "string" || !entityId) return;
     this.dispatchEvent(new CustomEvent("hass-more-info", { detail: { entityId }, bubbles: true, composed: true }));
   }
 

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -857,7 +857,7 @@ class EntityAvailabilityCard extends LitElement {
         </div>
         ${items.map(
           (item) => html`
-            <div class="entity-item" tabindex="0" role="button" @click=${(e) => this._handleEntityClick(e, item.entityId)} @keydown=${(e) => { if (e.key === "Enter") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }} @keyup=${(e) => { if (e.key === " ") { this._handleEntityClick(e, item.entityId); } }}>
+            <div class="entity-item" tabindex="0" role="button" @click=${(e) => this._handleEntityClick(e, item.entityId)} @keydown=${(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }}>
               <div class="entity-dot ${item.dotColor}"></div>
               <span class="entity-name">${item.name}</span>
               <span class="entity-status">${item.status}</span>
@@ -1238,25 +1238,27 @@ class EntityAvailabilityCard extends LitElement {
 
   _handleEntityClick(e, entityId) {
     e.stopPropagation();
-    if (typeof entityId !== "string" || !entityId) return;
     this.dispatchEvent(new CustomEvent("hass-more-info", { detail: { entityId }, bubbles: true, composed: true }));
   }
 
   async _handleToggleSuppress(e, entityId, isSuppressed) {
     e.stopPropagation();
+    const group = this._config.group;
     if (isSuppressed) {
-      await this.hass.callService("entity_availability", "unsuppress", { entity_id: entityId });
+      await this.hass.callService("entity_availability", "unsuppress", { entity_id: entityId, group });
     } else {
-      await this.hass.callService("entity_availability", "suppress_indefinitely", { entity_id: entityId });
+      await this.hass.callService("entity_availability", "suppress_indefinitely", { entity_id: entityId, group });
     }
   }
 
   async _handleSuppressAll(e) {
     e.stopPropagation();
+    const group = this._config.group;
     const offlineIds = this._getOfflineEntityIds();
     for (const entityId of offlineIds) {
       await this.hass.callService("entity_availability", "suppress", {
         entity_id: entityId,
+        group,
         duration: 60,
       });
     }
@@ -1264,6 +1266,7 @@ class EntityAvailabilityCard extends LitElement {
 
   async _handleUnsuppressAll(e) {
     e.stopPropagation();
+    const group = this._config.group;
     const isCombined = this._isCombinedGroup();
     const prefix = isCombined
       ? `entity_availability_combined_${this._config.group}`
@@ -1276,6 +1279,7 @@ class EntityAvailabilityCard extends LitElement {
     for (const entityId of entities) {
       await this.hass.callService("entity_availability", "unsuppress", {
         entity_id: entityId,
+        group,
       });
     }
   }

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -857,7 +857,7 @@ class EntityAvailabilityCard extends LitElement {
         </div>
         ${items.map(
           (item) => html`
-            <div class="entity-item" tabindex="0" role="button" @click=${(e) => this._handleEntityClick(e, item.entityId)} @keydown=${(e) => { if (e.key === "Enter") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }} @keyup=${(e) => { if (e.key === " ") { this._handleEntityClick(e, item.entityId); } }}>
+            <div class="entity-item" tabindex="0" role="button" @click=${(e) => this._handleEntityClick(e, item.entityId)} @keydown=${(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); if (e.key === "Enter") this._handleEntityClick(e, item.entityId); } }} @keyup=${(e) => { if (e.key === " ") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }}>
               <div class="entity-dot ${item.dotColor}"></div>
               <span class="entity-name">${item.name}</span>
               <span class="entity-status">${item.status}</span>

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -857,7 +857,7 @@ class EntityAvailabilityCard extends LitElement {
         </div>
         ${items.map(
           (item) => html`
-            <div class="entity-item" tabindex="0" role="button" @click=${(e) => this._handleEntityClick(e, item.entityId)} @keydown=${(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }}>
+            <div class="entity-item" tabindex="0" role="button" @click=${(e) => this._handleEntityClick(e, item.entityId)} @keydown=${(e) => { if (e.key === "Enter") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }} @keyup=${(e) => { if (e.key === " ") { e.preventDefault(); this._handleEntityClick(e, item.entityId); } }}>
               <div class="entity-dot ${item.dotColor}"></div>
               <span class="entity-name">${item.name}</span>
               <span class="entity-status">${item.status}</span>
@@ -1238,6 +1238,7 @@ class EntityAvailabilityCard extends LitElement {
 
   _handleEntityClick(e, entityId) {
     e.stopPropagation();
+    if (typeof entityId !== "string" || !entityId) return;
     this.dispatchEvent(new CustomEvent("hass-more-info", { detail: { entityId }, bubbles: true, composed: true }));
   }
 

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -114,7 +114,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 found = True
 
         if not found:
-            _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
+            _LOGGER.warning("Entity %s not found in the specified group", entity_id)
 
     async def handle_suppress_indefinitely(call: ServiceCall) -> None:
         """Handle suppress_indefinitely service call."""
@@ -156,7 +156,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 found = True
 
         if not found:
-            _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
+            _LOGGER.warning("Entity %s not found in the specified group", entity_id)
 
     async def handle_unsuppress(call: ServiceCall) -> None:
         """Handle unsuppress service call."""
@@ -198,7 +198,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 found = True
 
         if not found:
-            _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
+            _LOGGER.warning("Entity %s not found in the specified group", entity_id)
 
     async def handle_reset_statistics(call: ServiceCall) -> None:
         """Handle reset_statistics service call."""
@@ -232,7 +232,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 found = True
 
         if not found:
-            _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
+            _LOGGER.warning("Entity %s not found in the specified group", entity_id)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SUPPRESS, handle_suppress, schema=SUPPRESS_SCHEMA

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -114,7 +114,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 found = True
 
         if not found:
-            _LOGGER.warning("Entity %s not found in the specified group", entity_id)
+            if group:
+                _LOGGER.warning("Entity %s not found in group %s", entity_id, group)
+            else:
+                _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
 
     async def handle_suppress_indefinitely(call: ServiceCall) -> None:
         """Handle suppress_indefinitely service call."""
@@ -156,7 +159,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 found = True
 
         if not found:
-            _LOGGER.warning("Entity %s not found in the specified group", entity_id)
+            if group:
+                _LOGGER.warning("Entity %s not found in group %s", entity_id, group)
+            else:
+                _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
 
     async def handle_unsuppress(call: ServiceCall) -> None:
         """Handle unsuppress service call."""
@@ -198,7 +204,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 found = True
 
         if not found:
-            _LOGGER.warning("Entity %s not found in the specified group", entity_id)
+            if group:
+                _LOGGER.warning("Entity %s not found in group %s", entity_id, group)
+            else:
+                _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
 
     async def handle_reset_statistics(call: ServiceCall) -> None:
         """Handle reset_statistics service call."""
@@ -238,7 +247,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 found = True
 
         if not found:
-            _LOGGER.warning("Entity %s not found in the specified group", entity_id)
+            if group:
+                _LOGGER.warning("Entity %s not found in group %s", entity_id, group)
+            else:
+                _LOGGER.warning("Entity %s not found in any monitored group", entity_id)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SUPPRESS, handle_suppress, schema=SUPPRESS_SCHEMA

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -226,6 +226,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
+            if (
+                group
+                and coordinator.group_name != group
+                and coordinator.entry.entry_id != group
+            ):
+                continue
             if entity_id in coordinator.monitored_entities:
                 coordinator.reset_statistics([entity_id])
                 _LOGGER.info("Reset statistics for %s", entity_id)

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -101,6 +101,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
+            if (
+                group
+                and coordinator.group_name != group
+                and coordinator.entry.entry_id != group
+            ):
+                continue
             if entity_id in coordinator.monitored_entities:
                 coordinator.suppress_entity(entity_id, until)
                 coordinator.async_set_updated_data(coordinator.data)
@@ -137,6 +143,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
+            if (
+                group
+                and coordinator.group_name != group
+                and coordinator.entry.entry_id != group
+            ):
+                continue
             if entity_id in coordinator.monitored_entities:
                 coordinator.suppress_entity(entity_id, until=None)
                 coordinator.async_set_updated_data(coordinator.data)
@@ -172,6 +184,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         found = False
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
+                continue
+            if (
+                group
+                and coordinator.group_name != group
+                and coordinator.entry.entry_id != group
+            ):
                 continue
             if entity_id in coordinator.monitored_entities:
                 coordinator.unsuppress_entity(entity_id)

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -79,7 +79,7 @@ def wait(seconds=45):
     time.sleep(seconds)
 
 
-def wait_for(label, check_fn, expected, timeout=60, interval=5):
+def wait_for(check_fn, expected, timeout=60, interval=5):
     """Poll until check_fn() == expected or timeout."""
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -352,7 +352,6 @@ def main():
     chk(
         "offline_count=1",
         wait_for(
-            "offline_count",
             lambda: gs(f"{prefix}_offline_count").get("state"),
             "1",
             timeout=90,
@@ -382,7 +381,6 @@ def main():
     chk(
         "low_battery_count=1",
         wait_for(
-            "low_battery_count",
             lambda: gs(f"{prefix}_low_battery_count").get("state"),
             "1",
             timeout=90,
@@ -426,7 +424,6 @@ def main():
     chk(
         "offline_count=1",
         wait_for(
-            "offline_count",
             lambda: gs(f"{prefix}_offline_count").get("state"),
             "1",
             timeout=90,

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -75,8 +75,19 @@ def ss(eid, state, attrs):
     return api("POST", f"/api/states/{eid}", {"state": state, "attributes": attrs})
 
 
-def wait(seconds=35):
+def wait(seconds=45):
     time.sleep(seconds)
+
+
+def wait_for(label, check_fn, expected, timeout=60, interval=5):
+    """Poll until check_fn() == expected or timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        val = check_fn()
+        if str(val) == str(expected):
+            return val
+        time.sleep(interval)
+    return check_fn()
 
 
 # ---------------------------------------------------------------------------
@@ -338,8 +349,20 @@ def main():
     # ------------------------------------------------------------------
     print("=== EC1: entity unavailable → offline_count increments ===", flush=True)
     ss(ctx["entities"][0], "unavailable", {"friendly_name": "test"})
-    wait()
-    chk("offline_count=1", gs(f"{prefix}_offline_count").get("state"), "1")
+    chk(
+        "offline_count=1",
+        wait_for(
+            "offline_count",
+            lambda: gs(f"{prefix}_offline_count").get("state"),
+            "1",
+            timeout=90,
+        ),
+        "1",
+    )
+    if combined_prefix:
+        c_attrs = gs(f"{combined_prefix}_combined_summary").get("attributes", {})
+        chk("EC1 combined offline=1", str(c_attrs.get("offline")), "1")
+        chk("EC1 combined low_battery=0", str(c_attrs.get("low_battery")), "0")
     restore_all(ctx)
 
     # ------------------------------------------------------------------
@@ -356,8 +379,16 @@ def main():
             "unit_of_measurement": "%",
         },
     )
-    wait()
-    chk("low_battery_count=1", gs(f"{prefix}_low_battery_count").get("state"), "1")
+    chk(
+        "low_battery_count=1",
+        wait_for(
+            "low_battery_count",
+            lambda: gs(f"{prefix}_low_battery_count").get("state"),
+            "1",
+            timeout=90,
+        ),
+        "1",
+    )
     lb = gs(f"{prefix}_low_battery")
     chk("low_battery list count=1", lb.get("attributes", {}).get("count"), 1)
     chk(
@@ -376,6 +407,10 @@ def main():
         gs(f"{prefix}_offline_count").get("state"),
         "0",
     )
+    if combined_prefix:
+        c_attrs = gs(f"{combined_prefix}_combined_summary").get("attributes", {})
+        chk("EC4 combined low_battery=1", str(c_attrs.get("low_battery")), "1")
+        chk("EC4 combined offline=0", str(c_attrs.get("offline")), "0")
 
     # ------------------------------------------------------------------
     print(
@@ -388,8 +423,16 @@ def main():
         "unavailable",
         {"friendly_name": "Test Battery", "device_class": "battery"},
     )
-    wait()
-    chk("offline_count=1", gs(f"{prefix}_offline_count").get("state"), "1")
+    chk(
+        "offline_count=1",
+        wait_for(
+            "offline_count",
+            lambda: gs(f"{prefix}_offline_count").get("state"),
+            "1",
+            timeout=90,
+        ),
+        "1",
+    )
     chk(
         "low_battery_count=0 (offline excluded)",
         gs(f"{prefix}_low_battery_count").get("state"),
@@ -407,6 +450,10 @@ def main():
         gs(f"{prefix}_low_battery").get("attributes", {}).get("count"),
         0,
     )
+    if combined_prefix:
+        c_attrs = gs(f"{combined_prefix}_combined_summary").get("attributes", {})
+        chk("EC5 combined offline=1", str(c_attrs.get("offline")), "1")
+        chk("EC5 combined low_battery=0", str(c_attrs.get("low_battery")), "0")
 
     # ------------------------------------------------------------------
     print("\n=== EC6: battery replaced, back online → all clear ===", flush=True)
@@ -438,6 +485,10 @@ def main():
         str(gs_attrs.get("battery_levels", {}).get(battery_entity)),
         "90",
     )
+    if combined_prefix:
+        c_attrs = gs(f"{combined_prefix}_combined_summary").get("attributes", {})
+        chk("EC6 combined offline=0", str(c_attrs.get("offline")), "0")
+        chk("EC6 combined low_battery=0", str(c_attrs.get("low_battery")), "0")
 
     # ------------------------------------------------------------------
     if combined_prefix:

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -597,6 +597,78 @@ class TestCombinedGroupSensor:
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
         assert sensor.extra_state_attributes["battery_powered"] == 0
 
+    def test_battery_powered_deduplicated_via_device_states(
+        self, mock_hass, group_entry_a
+    ):
+        """battery_powered is 1 when same entity with battery_level appears in two groups."""
+        shared_entry = _make_group_entry(
+            "entry_shared", "Shared", ["binary_sensor.a1", "binary_sensor.shared"]
+        )
+        combined = _make_combined_entry(
+            "combined_bat", "Bat", ["entry_a", "entry_shared"]
+        )
+        with patch.object(
+            EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+        ):
+            coord_a = EntityAvailabilityCoordinator(mock_hass, group_entry_a)
+            coord_a._device_states = {
+                "binary_sensor.a1": DeviceState(
+                    entity_id="binary_sensor.a1", battery_level=80
+                ),
+            }
+            coord_shared = EntityAvailabilityCoordinator(mock_hass, shared_entry)
+            coord_shared._device_states = {
+                "binary_sensor.a1": DeviceState(
+                    entity_id="binary_sensor.a1", battery_level=80
+                ),
+                "binary_sensor.shared": DeviceState(entity_id="binary_sensor.shared"),
+            }
+        mock_hass.data[DOMAIN] = {"entry_a": coord_a, "entry_shared": coord_shared}
+        sensor = CombinedGroupSensor(
+            mock_hass, combined, "Bat", "bat", ["entry_a", "entry_shared"]
+        )
+        assert sensor.extra_state_attributes["battery_powered"] == 1
+
+    def test_battery_powered_deduplicated_mixed_config(self, mock_hass):
+        """battery_powered counts entity once when one group uses battery_map and another uses battery_level for the same device."""
+        entry_map = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="Group Map",
+            data={
+                CONF_ENTRY_TYPE: ENTRY_TYPE_GROUP,
+                CONF_GROUP_NAME: "Group Map",
+                CONF_ENTITIES: ["binary_sensor.a1"],
+                CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+                CONF_BATTERY_ENTITY_MAP: {"binary_sensor.a1": "sensor.a1_bat"},
+            },
+            entry_id="entry_map",
+        )
+        entry_level = _make_group_entry(
+            "entry_level", "Group Level", ["binary_sensor.a1"]
+        )
+        combined = _make_combined_entry(
+            "combined_mix", "Mix", ["entry_map", "entry_level"]
+        )
+        with patch.object(
+            EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+        ):
+            coord_map = EntityAvailabilityCoordinator(mock_hass, entry_map)
+            coord_map._device_states = {
+                "binary_sensor.a1": DeviceState(entity_id="binary_sensor.a1"),
+            }
+            coord_level = EntityAvailabilityCoordinator(mock_hass, entry_level)
+            coord_level._device_states = {
+                "binary_sensor.a1": DeviceState(
+                    entity_id="binary_sensor.a1", battery_level=75
+                ),
+            }
+        mock_hass.data[DOMAIN] = {"entry_map": coord_map, "entry_level": coord_level}
+        sensor = CombinedGroupSensor(
+            mock_hass, combined, "Mix", "mix", ["entry_map", "entry_level"]
+        )
+        assert sensor.extra_state_attributes["battery_powered"] == 1
+
     def test_attributes_missing_groups(self, mock_hass, combined_entry, coordinators):
         """missing_groups attribute present when a source group is not in hass.data."""
         # Only load entry_a

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -696,6 +696,8 @@ class TestCombinedGroupSensor:
             attrs = sensor.extra_state_attributes
         assert attrs["groups"]["entry_a"]["entity_id"] is None
         assert any("entry_a" in r.message for r in caplog.records)
+
+    def test_unique_id(self, mock_hass, combined_entry, coordinators):
         """unique_id uses entry_id + suffix."""
         mock_hass.data[DOMAIN] = {}
         sensor = self._sensor(mock_hass, combined_entry, coordinators)

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -678,7 +678,24 @@ class TestCombinedGroupSensor:
         assert "missing_groups" in attrs
         assert "entry_b" in attrs["missing_groups"]
 
-    def test_unique_id(self, mock_hass, combined_entry, coordinators):
+    def test_groups_entity_id_none_when_summary_not_registered(
+        self, mock_hass, combined_entry, coordinators, caplog
+    ):
+        """groups[entry_id]['entity_id'] is None and a warning is logged when the group summary sensor is not in the entity registry."""
+        import logging
+
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        sensor = self._sensor(mock_hass, combined_entry, coordinators)
+        with caplog.at_level(
+            logging.WARNING,
+            logger="custom_components.entity_availability.combined_sensor",
+        ):
+            attrs = sensor.extra_state_attributes
+        assert attrs["groups"]["entry_a"]["entity_id"] is None
+        assert any("entry_a" in r.message for r in caplog.records)
         """unique_id uses entry_id + suffix."""
         mock_hass.data[DOMAIN] = {}
         sensor = self._sensor(mock_hass, combined_entry, coordinators)

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -689,9 +689,17 @@ class TestCombinedGroupSensor:
             "entry_b": coordinators[1],
         }
         sensor = self._sensor(mock_hass, combined_entry, coordinators)
-        with caplog.at_level(
-            logging.WARNING,
-            logger="custom_components.entity_availability.combined_sensor",
+        registry_mock = MagicMock()
+        registry_mock.async_get_entity_id.return_value = None
+        with (
+            patch(
+                "custom_components.entity_availability.combined_sensor.er.async_get",
+                return_value=registry_mock,
+            ),
+            caplog.at_level(
+                logging.WARNING,
+                logger="custom_components.entity_availability.combined_sensor",
+            ),
         ):
             attrs = sensor.extra_state_attributes
         assert attrs["groups"]["entry_a"]["entity_id"] is None

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -473,6 +473,46 @@ class TestCombinedGroupSensor:
             "binary_sensor.shared",
         }
 
+    def test_counts_deduplicated_when_entity_shared(self, mock_hass):
+        """Scalar counts (offline, online, total) are not doubled for shared entities."""
+        entry_a = _make_group_entry("entry_a", "Group A", ["binary_sensor.a1"])
+        shared_entry = _make_group_entry(
+            "entry_shared", "Shared Group", ["binary_sensor.a1", "binary_sensor.shared"]
+        )
+        combined = _make_combined_entry(
+            "combined_dup", "Dup", ["entry_a", "entry_shared"]
+        )
+
+        with patch.object(
+            EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+        ):
+            coord_a = EntityAvailabilityCoordinator(mock_hass, entry_a)
+            coord_a._device_states = {
+                "binary_sensor.a1": DeviceState(
+                    entity_id="binary_sensor.a1", is_offline=True
+                ),
+            }
+            coord_shared = EntityAvailabilityCoordinator(mock_hass, shared_entry)
+            coord_shared._device_states = {
+                "binary_sensor.a1": DeviceState(
+                    entity_id="binary_sensor.a1", is_offline=True
+                ),
+                "binary_sensor.shared": DeviceState(entity_id="binary_sensor.shared"),
+            }
+
+        mock_hass.data[DOMAIN] = {"entry_a": coord_a, "entry_shared": coord_shared}
+        sensor = CombinedGroupSensor(
+            mock_hass,
+            combined,
+            "Dup",
+            "dup",
+            ["entry_a", "entry_shared"],
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["total_entities"] == 2, "a1 + shared, deduped"
+        assert attrs["offline"] == 1, "a1 shared across groups must count once"
+        assert attrs["online"] == 1, "shared entity online count must not double"
+
     def test_attributes_battery_powered_via_device_states(
         self, mock_hass, combined_entry, coordinators
     ):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -819,3 +819,61 @@ async def test_unsuppress_with_group_scopes_to_that_group(
     )
     assert coord_a.device_states["binary_sensor.device_a"].is_suppressed is False
     assert coord_b.device_states["binary_sensor.device_a"].is_suppressed is True
+
+
+async def test_reset_statistics_with_group_scopes_to_that_group(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """reset_statistics with entity_id+group only resets in the named group."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.entity_availability.const import CONF_ENTITIES
+
+    hass = mock_hass
+    config_a = dict(mock_config_data)
+    config_a[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_a = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group A",
+        data=config_a,
+        entry_id="entry_rst_a",
+        unique_id=f"{DOMAIN}_entry_rst_a",
+    )
+    config_b = dict(mock_config_data)
+    config_b[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_b = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group B",
+        data=config_b,
+        entry_id="entry_rst_b",
+        unique_id=f"{DOMAIN}_entry_rst_b",
+    )
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord_a = EntityAvailabilityCoordinator(hass, entry_a)
+        coord_a._device_states = {
+            "binary_sensor.device_a": DeviceState(entity_id="binary_sensor.device_a")
+        }
+        coord_a._device_states["binary_sensor.device_a"].offline_event_count = 5
+        coord_a.data = None
+        coord_b = EntityAvailabilityCoordinator(hass, entry_b)
+        coord_b._device_states = {
+            "binary_sensor.device_a": DeviceState(entity_id="binary_sensor.device_a")
+        }
+        coord_b._device_states["binary_sensor.device_a"].offline_event_count = 3
+        coord_b.data = None
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["entry_rst_a"] = coord_a
+    hass.data[DOMAIN]["entry_rst_b"] = coord_b
+    await async_setup_services(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "reset_statistics",
+        {ATTR_ENTITY_ID: "binary_sensor.device_a", ATTR_GROUP: "Group A"},
+        blocking=True,
+    )
+    assert coord_a.device_states["binary_sensor.device_a"].offline_event_count == 0
+    assert coord_b.device_states["binary_sensor.device_a"].offline_event_count == 3

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -127,7 +127,7 @@ async def test_suppress_entity_not_found_logs_warning(setup_services, caplog) ->
             blocking=True,
         )
 
-    assert "not found in the specified group" in caplog.text
+    assert "not found in any monitored group" in caplog.text
 
 
 async def test_unsuppress_entity_not_found_logs_warning(setup_services, caplog) -> None:
@@ -142,7 +142,7 @@ async def test_unsuppress_entity_not_found_logs_warning(setup_services, caplog) 
             blocking=True,
         )
 
-    assert "not found in the specified group" in caplog.text
+    assert "not found in any monitored group" in caplog.text
 
 
 async def test_services_registered_only_once(
@@ -260,7 +260,7 @@ async def test_suppress_indefinitely_unknown_entity_logs_warning(
             blocking=True,
         )
 
-    assert "not found in the specified group" in caplog.text
+    assert "not found in any monitored group" in caplog.text
 
 
 async def test_suppress_indefinitely_unknown_group_logs_warning(
@@ -642,7 +642,7 @@ async def test_reset_statistics_unknown_entity(setup_services, caplog) -> None:
             {ATTR_ENTITY_ID: "binary_sensor.nope"},
             blocking=True,
         )
-    assert "not found in the specified group" in caplog.text
+    assert "not found in any monitored group" in caplog.text
 
 
 async def test_suppress_with_group_scopes_to_that_group(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -127,7 +127,7 @@ async def test_suppress_entity_not_found_logs_warning(setup_services, caplog) ->
             blocking=True,
         )
 
-    assert "not found in any monitored group" in caplog.text
+    assert "not found in the specified group" in caplog.text
 
 
 async def test_unsuppress_entity_not_found_logs_warning(setup_services, caplog) -> None:
@@ -142,7 +142,7 @@ async def test_unsuppress_entity_not_found_logs_warning(setup_services, caplog) 
             blocking=True,
         )
 
-    assert "not found in any monitored group" in caplog.text
+    assert "not found in the specified group" in caplog.text
 
 
 async def test_services_registered_only_once(
@@ -260,7 +260,7 @@ async def test_suppress_indefinitely_unknown_entity_logs_warning(
             blocking=True,
         )
 
-    assert "not found in any monitored group" in caplog.text
+    assert "not found in the specified group" in caplog.text
 
 
 async def test_suppress_indefinitely_unknown_group_logs_warning(
@@ -642,9 +642,7 @@ async def test_reset_statistics_unknown_entity(setup_services, caplog) -> None:
             {ATTR_ENTITY_ID: "binary_sensor.nope"},
             blocking=True,
         )
-    assert "not found in any monitored group" in caplog.text
-
-    assert coord.device_states["binary_sensor.device_b"].offline_event_count == 0
+    assert "not found in the specified group" in caplog.text
 
 
 async def test_suppress_with_group_scopes_to_that_group(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -644,19 +644,180 @@ async def test_reset_statistics_unknown_entity(setup_services, caplog) -> None:
         )
     assert "not found in any monitored group" in caplog.text
 
+    assert coord.device_states["binary_sensor.device_b"].offline_event_count == 0
 
-async def test_reset_statistics_entity_path_skips_non_coordinator(
-    setup_services,
+
+async def test_suppress_with_group_scopes_to_that_group(
+    mock_hass: HomeAssistant, mock_config_data
 ) -> None:
-    """Entity-path reset loop skips non-coordinator hass.data values."""
-    hass, coord = setup_services
-    hass.data[DOMAIN]["_card_installed"] = True  # non-coordinator sentinel
-    coord.device_states["binary_sensor.device_b"].offline_event_count = 3
+    """suppress with entity_id+group only suppresses in the named group."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.entity_availability.const import CONF_ENTITIES
+
+    hass = mock_hass
+    config_a = dict(mock_config_data)
+    config_a[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_a = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group A",
+        data=config_a,
+        entry_id="entry_scope_a",
+        unique_id=f"{DOMAIN}_entry_scope_a",
+    )
+    config_b = dict(mock_config_data)
+    config_b[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_b = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group B",
+        data=config_b,
+        entry_id="entry_scope_b",
+        unique_id=f"{DOMAIN}_entry_scope_b",
+    )
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord_a = EntityAvailabilityCoordinator(hass, entry_a)
+        coord_a._device_states = {
+            "binary_sensor.device_a": DeviceState(entity_id="binary_sensor.device_a")
+        }
+        coord_a.data = None
+        coord_b = EntityAvailabilityCoordinator(hass, entry_b)
+        coord_b._device_states = {
+            "binary_sensor.device_a": DeviceState(entity_id="binary_sensor.device_a")
+        }
+        coord_b.data = None
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["entry_scope_a"] = coord_a
+    hass.data[DOMAIN]["entry_scope_b"] = coord_b
+    await async_setup_services(hass)
 
     await hass.services.async_call(
         DOMAIN,
-        "reset_statistics",
-        {ATTR_ENTITY_ID: "binary_sensor.device_b"},
+        SERVICE_SUPPRESS,
+        {
+            ATTR_ENTITY_ID: "binary_sensor.device_a",
+            ATTR_GROUP: "Group A",
+            ATTR_DURATION: 10,
+        },
         blocking=True,
     )
-    assert coord.device_states["binary_sensor.device_b"].offline_event_count == 0
+    assert coord_a.device_states["binary_sensor.device_a"].is_suppressed is True
+    assert coord_b.device_states["binary_sensor.device_a"].is_suppressed is False
+
+
+async def test_suppress_indefinitely_with_group_scopes_to_that_group(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """suppress_indefinitely with entity_id+group only suppresses in the named group."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.entity_availability.const import CONF_ENTITIES
+
+    hass = mock_hass
+    config_a = dict(mock_config_data)
+    config_a[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_a = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group A",
+        data=config_a,
+        entry_id="entry_indef_a",
+        unique_id=f"{DOMAIN}_entry_indef_a",
+    )
+    config_b = dict(mock_config_data)
+    config_b[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_b = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group B",
+        data=config_b,
+        entry_id="entry_indef_b",
+        unique_id=f"{DOMAIN}_entry_indef_b",
+    )
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord_a = EntityAvailabilityCoordinator(hass, entry_a)
+        coord_a._device_states = {
+            "binary_sensor.device_a": DeviceState(entity_id="binary_sensor.device_a")
+        }
+        coord_a.data = None
+        coord_b = EntityAvailabilityCoordinator(hass, entry_b)
+        coord_b._device_states = {
+            "binary_sensor.device_a": DeviceState(entity_id="binary_sensor.device_a")
+        }
+        coord_b.data = None
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["entry_indef_a"] = coord_a
+    hass.data[DOMAIN]["entry_indef_b"] = coord_b
+    await async_setup_services(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SUPPRESS_INDEFINITELY,
+        {ATTR_ENTITY_ID: "binary_sensor.device_a", ATTR_GROUP: "Group A"},
+        blocking=True,
+    )
+    assert coord_a.device_states["binary_sensor.device_a"].is_suppressed is True
+    assert coord_b.device_states["binary_sensor.device_a"].is_suppressed is False
+
+
+async def test_unsuppress_with_group_scopes_to_that_group(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """unsuppress with entity_id+group only unsuppresses in the named group."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.entity_availability.const import CONF_ENTITIES
+
+    hass = mock_hass
+    config_a = dict(mock_config_data)
+    config_a[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_a = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group A",
+        data=config_a,
+        entry_id="entry_uns_a",
+        unique_id=f"{DOMAIN}_entry_uns_a",
+    )
+    config_b = dict(mock_config_data)
+    config_b[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_b = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group B",
+        data=config_b,
+        entry_id="entry_uns_b",
+        unique_id=f"{DOMAIN}_entry_uns_b",
+    )
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord_a = EntityAvailabilityCoordinator(hass, entry_a)
+        coord_a._device_states = {
+            "binary_sensor.device_a": DeviceState(
+                entity_id="binary_sensor.device_a", is_suppressed=True
+            )
+        }
+        coord_a.data = None
+        coord_b = EntityAvailabilityCoordinator(hass, entry_b)
+        coord_b._device_states = {
+            "binary_sensor.device_a": DeviceState(
+                entity_id="binary_sensor.device_a", is_suppressed=True
+            )
+        }
+        coord_b.data = None
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["entry_uns_a"] = coord_a
+    hass.data[DOMAIN]["entry_uns_b"] = coord_b
+    await async_setup_services(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_UNSUPPRESS,
+        {ATTR_ENTITY_ID: "binary_sensor.device_a", ATTR_GROUP: "Group A"},
+        blocking=True,
+    )
+    assert coord_a.device_states["binary_sensor.device_a"].is_suppressed is False
+    assert coord_b.device_states["binary_sensor.device_a"].is_suppressed is True


### PR DESCRIPTION
## Summary

### Services: group-scoped suppress/unsuppress
- `suppress`, `suppress_indefinitely`, and `unsuppress` previously ignored the `group` param when `entity_id` was also provided — entity was suppressed/unsuppressed in **all** groups that monitor it
- Now when both `entity_id` and `group` are provided, the action is scoped to that group's coordinator only

### Card: all suppress calls are now group-scoped
- Per-entity bell toggle, Suppress All, and Unsuppress All all pass the card's configured `group` to the service

### Combined sensor: dedup fixes
- `battery_powered` count was doubled when same entity appeared in multiple source groups — fixed via set of unique entity IDs
- Warning logged when group summary entity not found in entity registry
- `extra_state_attributes` refactored to use `merged_states` dict (first-wins) for all aggregate counts

### Card: accessibility and robustness
- Space key fires `_handleEntityClick` on `keyup` (WAI-ARIA button spec); Enter fires on `keydown`
- `_handleEntityClick` guards against missing/non-string `entityId`

## Test plan
- [ ] 3 new service tests verify group-scoped suppress/unsuppress/suppress_indefinitely
- [ ] 4 new combined sensor tests: count dedup, battery_powered dedup, mixed-config battery, registry warning
- [ ] Smoke tests now check combined_summary attributes at every EC step
- [ ] `wait_for` poller replaces blind `wait()` for flaky timing
- [ ] 590 tests, 99% branch coverage (2 pre-existing partial branch misses)