### PR TITLE
fix: card suppress/unsuppress broken — group slug mismatch and entity row wrapping

### DIFF
--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -373,7 +373,6 @@ const cardStyles = css`
     padding: 5px 0;
     gap: 10px;
     position: relative;
-    flex-wrap: wrap;
     cursor: pointer;
     user-select: none;
   }

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timedelta, timezone
 
 import voluptuous as vol
@@ -61,27 +62,24 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     if hass.services.has_service(DOMAIN, SERVICE_SUPPRESS):
         return
 
-    def _find_coordinator(group: str):
-        """Find coordinator by group name, slug, or config entry ID."""
-        group_slug = group.lower().replace(" ", "_")
-        for coordinator in hass.data.get(DOMAIN, {}).values():
-            if not isinstance(coordinator, EntityAvailabilityCoordinator):
-                continue
-            if (
-                coordinator.group_name == group
-                or coordinator.entry.entry_id == group
-                or coordinator.group_name.lower().replace(" ", "_") == group_slug
-            ):
-                return coordinator
-        return None
+    def _slug(name: str) -> str:
+        return re.sub(r"\s+", "_", name.lower())
 
     def _matches_group(coordinator: EntityAvailabilityCoordinator, group: str) -> bool:
-        group_slug = group.lower().replace(" ", "_")
         return (
             coordinator.group_name == group
             or coordinator.entry.entry_id == group
-            or coordinator.group_name.lower().replace(" ", "_") == group_slug
+            or _slug(coordinator.group_name) == _slug(group)
         )
+
+    def _find_coordinator(group: str):
+        """Find coordinator by group name, slug, or config entry ID."""
+        for coordinator in hass.data.get(DOMAIN, {}).values():
+            if not isinstance(coordinator, EntityAvailabilityCoordinator):
+                continue
+            if _matches_group(coordinator, group):
+                return coordinator
+        return None
 
     async def handle_suppress(call: ServiceCall) -> None:
         """Handle suppress service call."""

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -62,13 +62,26 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         return
 
     def _find_coordinator(group: str):
-        """Find coordinator by group name or config entry ID."""
+        """Find coordinator by group name, slug, or config entry ID."""
+        group_slug = group.lower().replace(" ", "_")
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
-            if coordinator.group_name == group or coordinator.entry.entry_id == group:
+            if (
+                coordinator.group_name == group
+                or coordinator.entry.entry_id == group
+                or coordinator.group_name.lower().replace(" ", "_") == group_slug
+            ):
                 return coordinator
         return None
+
+    def _matches_group(coordinator: EntityAvailabilityCoordinator, group: str) -> bool:
+        group_slug = group.lower().replace(" ", "_")
+        return (
+            coordinator.group_name == group
+            or coordinator.entry.entry_id == group
+            or coordinator.group_name.lower().replace(" ", "_") == group_slug
+        )
 
     async def handle_suppress(call: ServiceCall) -> None:
         """Handle suppress service call."""
@@ -101,11 +114,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
-            if (
-                group
-                and coordinator.group_name != group
-                and coordinator.entry.entry_id != group
-            ):
+            if group and not _matches_group(coordinator, group):
                 continue
             if entity_id in coordinator.monitored_entities:
                 coordinator.suppress_entity(entity_id, until)
@@ -146,11 +155,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
-            if (
-                group
-                and coordinator.group_name != group
-                and coordinator.entry.entry_id != group
-            ):
+            if group and not _matches_group(coordinator, group):
                 continue
             if entity_id in coordinator.monitored_entities:
                 coordinator.suppress_entity(entity_id, until=None)
@@ -191,11 +196,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
-            if (
-                group
-                and coordinator.group_name != group
-                and coordinator.entry.entry_id != group
-            ):
+            if group and not _matches_group(coordinator, group):
                 continue
             if entity_id in coordinator.monitored_entities:
                 coordinator.unsuppress_entity(entity_id)
@@ -235,11 +236,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue
-            if (
-                group
-                and coordinator.group_name != group
-                and coordinator.entry.entry_id != group
-            ):
+            if group and not _matches_group(coordinator, group):
                 continue
             if entity_id in coordinator.monitored_entities:
                 coordinator.reset_statistics([entity_id])

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -66,9 +66,8 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         return re.sub(r"\s+", "_", name.lower())
 
     def _matches_group(coordinator: EntityAvailabilityCoordinator, group: str) -> bool:
-        return coordinator.entry.entry_id == group or _slug(
-            coordinator.group_name
-        ) == _slug(group)
+        coord_slug = _slug(coordinator.group_name)
+        return coordinator.entry.entry_id == group or coord_slug == _slug(group)
 
     def _find_coordinator(group: str):
         """Find coordinator by group name, slug, or config entry ID."""

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -66,11 +66,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         return re.sub(r"\s+", "_", name.lower())
 
     def _matches_group(coordinator: EntityAvailabilityCoordinator, group: str) -> bool:
-        return (
-            coordinator.group_name == group
-            or coordinator.entry.entry_id == group
-            or _slug(coordinator.group_name) == _slug(group)
-        )
+        return coordinator.entry.entry_id == group or _slug(
+            coordinator.group_name
+        ) == _slug(group)
 
     def _find_coordinator(group: str):
         """Find coordinator by group name, slug, or config entry ID."""

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -70,7 +70,11 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         return coordinator.entry.entry_id == group or coord_slug == _slug(group)
 
     def _find_coordinator(group: str):
-        """Find coordinator by group name, slug, or config entry ID."""
+        """Find coordinator by group name, slug, or config entry ID.
+
+        Returns the FIRST matching coordinator. If two groups share the same
+        slug (unlikely but possible), the first one wins.
+        """
         for coordinator in hass.data.get(DOMAIN, {}).values():
             if not isinstance(coordinator, EntityAvailabilityCoordinator):
                 continue

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -27,6 +27,8 @@ What is tested (covers PRs #37, #41, core):
   EC8  combined group: offline+low → combined low_battery drops, offline rises
   EC9  PR#37: cleared battery map entry not re-suggested in options flow
   EC10 suppression: suppressed+unavailable entity not counted in offline
+  EC11 suppress_indefinitely + unsuppress round-trip; suppressed_until=null for indefinite
+  EC12 group-scoped suppress: entity in two groups, suppress in one, other unaffected
 """
 
 import json
@@ -679,6 +681,58 @@ for e in cfg['data']['entries']:
         str(gs(f"{prefix}_group_summary").get("attributes", {}).get("suppressed")),
         "0",
     )
+
+    # ------------------------------------------------------------------
+    print(
+        "\n=== EC12: group-scoped suppress — entity in two groups ===",
+        flush=True,
+    )
+    restore_all(ctx)
+    # Find Beta group prefix (shares kitchen_1 with Alpha)
+    all_states = api("GET", "/api/states")
+    beta_prefix = None
+    for s in all_states:
+        eid = s["entity_id"]
+        if "entity_availability" in eid and "group_summary" in eid and "beta" in eid:
+            beta_prefix = eid.replace("_group_summary", "")
+            break
+    if beta_prefix:
+        shared_entity = ctx["entities"][0]  # kitchen_1 — in both Alpha and Beta
+        # Suppress in Alpha only (using slug)
+        alpha_slug = prefix.replace("sensor.entity_availability_", "")
+        api(
+            "POST",
+            "/api/services/entity_availability/suppress_indefinitely",
+            {"entity_id": shared_entity, "group": alpha_slug},
+        )
+        wait()
+        alpha_attrs = gs(f"{prefix}_group_summary").get("attributes", {})
+        beta_attrs = gs(f"{beta_prefix}_group_summary").get("attributes", {})
+        chk(
+            "EC12 suppressed=1 in Alpha",
+            str(alpha_attrs.get("suppressed")),
+            "1",
+        )
+        chk(
+            "EC12 suppressed=0 in Beta (group-scoped)",
+            str(beta_attrs.get("suppressed")),
+            "0",
+        )
+        # Unsuppress in Alpha only
+        api(
+            "POST",
+            "/api/services/entity_availability/unsuppress",
+            {"entity_id": shared_entity, "group": alpha_slug},
+        )
+        wait()
+        alpha_attrs = gs(f"{prefix}_group_summary").get("attributes", {})
+        chk(
+            "EC12 suppressed=0 in Alpha after unsuppress",
+            str(alpha_attrs.get("suppressed")),
+            "0",
+        )
+    else:
+        print("  EC12: skipped (no Beta group found)", flush=True)
 
     # ------------------------------------------------------------------
     print("\n=== CLEANUP ===", flush=True)

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -698,12 +698,12 @@ for e in cfg['data']['entries']:
             break
     if beta_prefix:
         shared_entity = ctx["entities"][0]  # kitchen_1 — in both Alpha and Beta
-        # Suppress in Alpha only (using slug)
-        alpha_slug = prefix.replace("sensor.entity_availability_", "")
+        # Suppress in Alpha only using the group title (exact match, no fragile string surgery)
+        alpha_title = ctx["title"]
         api(
             "POST",
             "/api/services/entity_availability/suppress_indefinitely",
-            {"entity_id": shared_entity, "group": alpha_slug},
+            {"entity_id": shared_entity, "group": alpha_title},
         )
         wait()
         alpha_attrs = gs(f"{prefix}_group_summary").get("attributes", {})
@@ -722,7 +722,7 @@ for e in cfg['data']['entries']:
         api(
             "POST",
             "/api/services/entity_availability/unsuppress",
-            {"entity_id": shared_entity, "group": alpha_slug},
+            {"entity_id": shared_entity, "group": alpha_title},
         )
         wait()
         alpha_attrs = gs(f"{prefix}_group_summary").get("attributes", {})

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -688,16 +688,25 @@ for e in cfg['data']['entries']:
         flush=True,
     )
     restore_all(ctx)
-    # Find Beta group prefix (shares kitchen_1 with Alpha)
+    # Find a second group that also monitors kitchen_1 — use friendly_name matching
     all_states = api("GET", "/api/states")
     beta_prefix = None
+    alpha_entities = set(ctx["entities"])
     for s in all_states:
         eid = s["entity_id"]
-        if "entity_availability" in eid and "group_summary" in eid and "beta" in eid:
-            beta_prefix = eid.replace("_group_summary", "")
+        if "entity_availability" not in eid or "group_summary" not in eid:
+            continue
+        candidate_prefix = eid.replace("_group_summary", "")
+        if candidate_prefix == ctx["prefix"]:
+            continue  # skip Alpha itself
+        candidate_entities = set(s.get("attributes", {}).get("entities", []))
+        if alpha_entities & candidate_entities:  # shares at least one entity with Alpha
+            beta_prefix = candidate_prefix
             break
     if beta_prefix:
-        shared_entity = ctx["entities"][0]  # kitchen_1 — in both Alpha and Beta
+        shared_entity = ctx["entities"][
+            0
+        ]  # kitchen_1 — in both Alpha and the found group
         # Suppress in Alpha only using the group title (exact match, no fragile string surgery)
         alpha_title = ctx["title"]
         api(
@@ -732,11 +741,12 @@ for e in cfg['data']['entries']:
             "0",
         )
     else:
-        print(
-            "FAIL EC12: Beta group not found — cannot verify group scoping", flush=True
+        chk(
+            "EC12 second group found",
+            False,
+            True,
+            "(no group sharing entities with Alpha)",
         )
-        global _failed
-        _failed += 1
 
     # ------------------------------------------------------------------
     print("\n=== CLEANUP ===", flush=True)

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -732,7 +732,11 @@ for e in cfg['data']['entries']:
             "0",
         )
     else:
-        print("  EC12: skipped (no Beta group found)", flush=True)
+        print(
+            "FAIL EC12: Beta group not found — cannot verify group scoping", flush=True
+        )
+        global _failed
+        _failed += 1
 
     # ------------------------------------------------------------------
     print("\n=== CLEANUP ===", flush=True)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1065,17 +1065,76 @@ async def test_reset_statistics_with_group_slug(
         }
         coord_b._device_states["binary_sensor.device_a"].offline_event_count = 3
         coord_b.data = None
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN]["entry_slug_rst_a"] = coord_a
-    hass.data[DOMAIN]["entry_slug_rst_b"] = coord_b
-    await async_setup_services(hass)
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN]["entry_slug_rst_a"] = coord_a
+        hass.data[DOMAIN]["entry_slug_rst_b"] = coord_b
+        await async_setup_services(hass)
 
-    # Pass slug "group_a" — should match "Group A" only
-    await hass.services.async_call(
-        DOMAIN,
-        "reset_statistics",
-        {ATTR_ENTITY_ID: "binary_sensor.device_a", ATTR_GROUP: "group_a"},
-        blocking=True,
+        # Pass slug "group_a" — should match "Group A" only
+        await hass.services.async_call(
+            DOMAIN,
+            "reset_statistics",
+            {ATTR_ENTITY_ID: "binary_sensor.device_a", ATTR_GROUP: "group_a"},
+            blocking=True,
+        )
+        assert coord_a.device_states["binary_sensor.device_a"].offline_event_count == 0
+        assert coord_b.device_states["binary_sensor.device_a"].offline_event_count == 3
+
+
+async def test_reset_statistics_group_only_slug(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """reset_statistics with group-only slug (no entity_id) resets all in matched group only."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.entity_availability.const import CONF_ENTITIES
+
+    hass = mock_hass
+    config_a = dict(mock_config_data)
+    config_a[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_a = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group A",
+        data=config_a,
+        entry_id="entry_grponly_a",
+        unique_id=f"{DOMAIN}_entry_grponly_a",
     )
-    assert coord_a.device_states["binary_sensor.device_a"].offline_event_count == 0
-    assert coord_b.device_states["binary_sensor.device_a"].offline_event_count == 3
+    config_b = dict(mock_config_data)
+    config_b[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_b = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group B",
+        data=config_b,
+        entry_id="entry_grponly_b",
+        unique_id=f"{DOMAIN}_entry_grponly_b",
+    )
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord_a = EntityAvailabilityCoordinator(hass, entry_a)
+        coord_a._device_states = {
+            "binary_sensor.device_a": DeviceState(entity_id="binary_sensor.device_a")
+        }
+        coord_a._device_states["binary_sensor.device_a"].offline_event_count = 7
+        coord_a.data = None
+        coord_b = EntityAvailabilityCoordinator(hass, entry_b)
+        coord_b._device_states = {
+            "binary_sensor.device_a": DeviceState(entity_id="binary_sensor.device_a")
+        }
+        coord_b._device_states["binary_sensor.device_a"].offline_event_count = 4
+        coord_b.data = None
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN]["entry_grponly_a"] = coord_a
+        hass.data[DOMAIN]["entry_grponly_b"] = coord_b
+        await async_setup_services(hass)
+
+        # group-only call with slug — should reset Group A, not Group B
+        await hass.services.async_call(
+            DOMAIN,
+            "reset_statistics",
+            {ATTR_GROUP: "group_a"},
+            blocking=True,
+        )
+        assert coord_a.device_states["binary_sensor.device_a"].offline_event_count == 0
+        assert coord_b.device_states["binary_sensor.device_a"].offline_event_count == 4

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -901,6 +901,59 @@ async def test_suppress_with_group_slug_matches(setup_services, caplog) -> None:
     assert "not found" not in caplog.text
 
 
+async def test_suppress_by_group_slug_only(setup_services, caplog) -> None:
+    """suppress with group slug and no entity_id suppresses all entities in group."""
+    import logging
+
+    hass, coord = setup_services
+    with caplog.at_level(logging.WARNING):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SUPPRESS,
+            {ATTR_GROUP: "test_group", ATTR_DURATION: 10},
+            blocking=True,
+        )
+    assert coord.device_states["binary_sensor.device_a"].is_suppressed is True
+    assert coord.device_states["binary_sensor.device_b"].is_suppressed is True
+    assert "not found" not in caplog.text
+
+
+async def test_suppress_indefinitely_by_group_slug_only(setup_services, caplog) -> None:
+    """suppress_indefinitely with group slug and no entity_id suppresses all."""
+    import logging
+
+    hass, coord = setup_services
+    with caplog.at_level(logging.WARNING):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SUPPRESS_INDEFINITELY,
+            {ATTR_GROUP: "test_group"},
+            blocking=True,
+        )
+    assert coord.device_states["binary_sensor.device_a"].is_suppressed is True
+    assert coord.device_states["binary_sensor.device_a"].suppress_until is None
+    assert "not found" not in caplog.text
+
+
+async def test_unsuppress_by_group_slug_only(setup_services, caplog) -> None:
+    """unsuppress with group slug and no entity_id unsuppresses all."""
+    import logging
+
+    hass, coord = setup_services
+    coord.suppress_entity("binary_sensor.device_a", None)
+    coord.suppress_entity("binary_sensor.device_b", None)
+    with caplog.at_level(logging.WARNING):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UNSUPPRESS,
+            {ATTR_GROUP: "test_group"},
+            blocking=True,
+        )
+    assert coord.device_states["binary_sensor.device_a"].is_suppressed is False
+    assert coord.device_states["binary_sensor.device_b"].is_suppressed is False
+    assert "not found" not in caplog.text
+
+
 async def test_suppress_entity_not_in_specified_group_warns(
     setup_services, caplog
 ) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -877,3 +877,101 @@ async def test_reset_statistics_with_group_scopes_to_that_group(
     )
     assert coord_a.device_states["binary_sensor.device_a"].offline_event_count == 0
     assert coord_b.device_states["binary_sensor.device_a"].offline_event_count == 3
+
+
+async def test_suppress_with_group_slug_matches(setup_services, caplog) -> None:
+    """suppress with slug form of group name (lowercase, spaces→underscores) resolves correctly."""
+    import logging
+
+    hass, coord = setup_services
+    with caplog.at_level(logging.WARNING):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SUPPRESS,
+            {
+                ATTR_ENTITY_ID: "binary_sensor.device_a",
+                ATTR_GROUP: "test_group",
+                ATTR_DURATION: 10,
+            },
+            blocking=True,
+        )
+    # coord group_name is "Test Group" (from mock_config_entry fixture)
+    # slug "test_group" should match — entity suppressed, no warning
+    assert coord.device_states["binary_sensor.device_a"].is_suppressed is True
+    assert "not found" not in caplog.text
+
+
+async def test_suppress_entity_not_in_specified_group_warns(
+    setup_services, caplog
+) -> None:
+    """suppress with entity_id+group warns when entity not in that group."""
+    import logging
+
+    hass, coord = setup_services
+    with caplog.at_level(logging.WARNING):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SUPPRESS,
+            {
+                ATTR_ENTITY_ID: "binary_sensor.device_a",
+                ATTR_GROUP: "Other Group",
+                ATTR_DURATION: 10,
+            },
+            blocking=True,
+        )
+    assert "not found in group" in caplog.text
+    assert coord.device_states["binary_sensor.device_a"].is_suppressed is False
+
+
+async def test_suppress_indefinitely_entity_not_in_group_warns(
+    setup_services, caplog
+) -> None:
+    """suppress_indefinitely with entity_id+group warns when entity not in that group."""
+    import logging
+
+    hass, coord = setup_services
+    with caplog.at_level(logging.WARNING):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SUPPRESS_INDEFINITELY,
+            {ATTR_ENTITY_ID: "binary_sensor.device_a", ATTR_GROUP: "Other Group"},
+            blocking=True,
+        )
+    assert "not found in group" in caplog.text
+    assert coord.device_states["binary_sensor.device_a"].is_suppressed is False
+
+
+async def test_unsuppress_entity_not_in_group_warns(setup_services, caplog) -> None:
+    """unsuppress with entity_id+group warns when entity not in that group."""
+    import logging
+
+    hass, coord = setup_services
+    coord.suppress_entity("binary_sensor.device_a", None)
+    with caplog.at_level(logging.WARNING):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UNSUPPRESS,
+            {ATTR_ENTITY_ID: "binary_sensor.device_a", ATTR_GROUP: "Other Group"},
+            blocking=True,
+        )
+    assert "not found in group" in caplog.text
+    assert coord.device_states["binary_sensor.device_a"].is_suppressed is True
+
+
+async def test_reset_statistics_entity_not_in_group_warns(
+    setup_services, caplog
+) -> None:
+    """reset_statistics with entity_id+group warns when entity not in that group."""
+    import logging
+
+    hass, coord = setup_services
+    coord.device_states["binary_sensor.device_a"].offline_event_count = 5
+    with caplog.at_level(logging.WARNING):
+        await hass.services.async_call(
+            DOMAIN,
+            "reset_statistics",
+            {ATTR_ENTITY_ID: "binary_sensor.device_a", ATTR_GROUP: "Other Group"},
+            blocking=True,
+        )
+    assert "not found in group" in caplog.text
+    assert coord.device_states["binary_sensor.device_a"].offline_event_count == 5

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -900,6 +900,25 @@ async def test_suppress_with_group_slug_matches(setup_services, caplog) -> None:
     assert "not found" not in caplog.text
 
 
+async def test_suppress_with_entry_id_matches(setup_services, caplog) -> None:
+    """suppress with entry_id (UUID) as group value matches correctly."""
+    hass, coord = setup_services
+    entry_id = list(hass.data[DOMAIN].keys())[0]
+    with caplog.at_level(logging.WARNING):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SUPPRESS,
+            {
+                ATTR_ENTITY_ID: "binary_sensor.device_a",
+                ATTR_GROUP: entry_id,
+                ATTR_DURATION: 10,
+            },
+            blocking=True,
+        )
+    assert coord.device_states["binary_sensor.device_a"].is_suppressed is True
+    assert "not found" not in caplog.text
+
+
 async def test_suppress_by_group_slug_only(setup_services, caplog) -> None:
     """suppress with group slug and no entity_id suppresses all entities in group."""
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -881,7 +881,6 @@ async def test_reset_statistics_with_group_scopes_to_that_group(
 
 async def test_suppress_with_group_slug_matches(setup_services, caplog) -> None:
     """suppress with slug form of group name (lowercase, spaces→underscores) resolves correctly."""
-    import logging
 
     hass, coord = setup_services
     with caplog.at_level(logging.WARNING):
@@ -903,7 +902,6 @@ async def test_suppress_with_group_slug_matches(setup_services, caplog) -> None:
 
 async def test_suppress_by_group_slug_only(setup_services, caplog) -> None:
     """suppress with group slug and no entity_id suppresses all entities in group."""
-    import logging
 
     hass, coord = setup_services
     with caplog.at_level(logging.WARNING):
@@ -920,7 +918,6 @@ async def test_suppress_by_group_slug_only(setup_services, caplog) -> None:
 
 async def test_suppress_indefinitely_by_group_slug_only(setup_services, caplog) -> None:
     """suppress_indefinitely with group slug and no entity_id suppresses all."""
-    import logging
 
     hass, coord = setup_services
     with caplog.at_level(logging.WARNING):
@@ -937,7 +934,6 @@ async def test_suppress_indefinitely_by_group_slug_only(setup_services, caplog) 
 
 async def test_unsuppress_by_group_slug_only(setup_services, caplog) -> None:
     """unsuppress with group slug and no entity_id unsuppresses all."""
-    import logging
 
     hass, coord = setup_services
     coord.suppress_entity("binary_sensor.device_a", None)
@@ -958,7 +954,6 @@ async def test_suppress_entity_not_in_specified_group_warns(
     setup_services, caplog
 ) -> None:
     """suppress with entity_id+group warns when entity not in that group."""
-    import logging
 
     hass, coord = setup_services
     with caplog.at_level(logging.WARNING):
@@ -980,7 +975,6 @@ async def test_suppress_indefinitely_entity_not_in_group_warns(
     setup_services, caplog
 ) -> None:
     """suppress_indefinitely with entity_id+group warns when entity not in that group."""
-    import logging
 
     hass, coord = setup_services
     with caplog.at_level(logging.WARNING):
@@ -996,7 +990,6 @@ async def test_suppress_indefinitely_entity_not_in_group_warns(
 
 async def test_unsuppress_entity_not_in_group_warns(setup_services, caplog) -> None:
     """unsuppress with entity_id+group warns when entity not in that group."""
-    import logging
 
     hass, coord = setup_services
     coord.suppress_entity("binary_sensor.device_a", None)
@@ -1015,7 +1008,6 @@ async def test_reset_statistics_entity_not_in_group_warns(
     setup_services, caplog
 ) -> None:
     """reset_statistics with entity_id+group warns when entity not in that group."""
-    import logging
 
     hass, coord = setup_services
     coord.device_states["binary_sensor.device_a"].offline_event_count = 5
@@ -1028,3 +1020,62 @@ async def test_reset_statistics_entity_not_in_group_warns(
         )
     assert "not found in group" in caplog.text
     assert coord.device_states["binary_sensor.device_a"].offline_event_count == 5
+
+
+async def test_reset_statistics_with_group_slug(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """reset_statistics with slug form of group name resets only the matching group."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.entity_availability.const import CONF_ENTITIES
+
+    hass = mock_hass
+    config_a = dict(mock_config_data)
+    config_a[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_a = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group A",
+        data=config_a,
+        entry_id="entry_slug_rst_a",
+        unique_id=f"{DOMAIN}_entry_slug_rst_a",
+    )
+    config_b = dict(mock_config_data)
+    config_b[CONF_ENTITIES] = ["binary_sensor.device_a"]
+    entry_b = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Group B",
+        data=config_b,
+        entry_id="entry_slug_rst_b",
+        unique_id=f"{DOMAIN}_entry_slug_rst_b",
+    )
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord_a = EntityAvailabilityCoordinator(hass, entry_a)
+        coord_a._device_states = {
+            "binary_sensor.device_a": DeviceState(entity_id="binary_sensor.device_a")
+        }
+        coord_a._device_states["binary_sensor.device_a"].offline_event_count = 5
+        coord_a.data = None
+        coord_b = EntityAvailabilityCoordinator(hass, entry_b)
+        coord_b._device_states = {
+            "binary_sensor.device_a": DeviceState(entity_id="binary_sensor.device_a")
+        }
+        coord_b._device_states["binary_sensor.device_a"].offline_event_count = 3
+        coord_b.data = None
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["entry_slug_rst_a"] = coord_a
+    hass.data[DOMAIN]["entry_slug_rst_b"] = coord_b
+    await async_setup_services(hass)
+
+    # Pass slug "group_a" — should match "Group A" only
+    await hass.services.async_call(
+        DOMAIN,
+        "reset_statistics",
+        {ATTR_ENTITY_ID: "binary_sensor.device_a", ATTR_GROUP: "group_a"},
+        blocking=True,
+    )
+    assert coord_a.device_states["binary_sensor.device_a"].offline_event_count == 0
+    assert coord_b.device_states["binary_sensor.device_a"].offline_event_count == 3


### PR DESCRIPTION
## Summary

Two bugs introduced after the PR 42/43 merge:

1. **Suppress bell / Suppress All / Unsuppress All did nothing** — the card passes `this._config.group` as a slug (e.g. `test_group_alpha`) but the service matched only by exact group name ("Test Group Alpha") or entry_id. The service now also matches by slug (`group_name.lower().replace(' ', '_')`). A `_matches_group` helper deduplicates this across all 4 services.

2. **Bell button rendered on a new line below the entity** — `.entity-item` had `flex-wrap: wrap` which caused the suppress button to overflow onto a new row. Removed.

## Test plan
- [ ] 5 new tests: slug matching, entity-not-in-group warnings for suppress, suppress_indefinitely, unsuppress, reset_statistics
- [ ] 596 tests pass at 99% coverage