### PR TITLE
fix: fire events after state mutation, enrich payload with offline count and entities

### DIFF
--- a/AUTOMATION_EXAMPLES.md
+++ b/AUTOMATION_EXAMPLES.md
@@ -12,8 +12,10 @@ The integration fires two events on the Home Assistant event bus at each transit
 
 | Event | Fired when | Data |
 |-------|-----------|------|
-| `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `offline_since` |
-| `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `downtime_seconds` |
+| `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `offline_since`, `offline_count`, `offline_entities` |
+| `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `downtime_seconds`, `offline_count`, `offline_entities` |
+
+`offline_count` and `offline_entities` reflect the group's offline state at the moment the event fires (after coordinator data is fully updated). Use `trigger.event.data.offline_count` in automations instead of querying the `offline_count` sensor — the sensor state is written asynchronously and may not yet reflect the transition that triggered the event.
 
 ### Notify when any monitored entity goes offline
 
@@ -29,6 +31,7 @@ automation:
         message: >
           {{ trigger.event.data.entity_id }} in
           {{ trigger.event.data.group }} went offline.
+          {{ trigger.event.data.offline_count }} device(s) now offline.
 ```
 
 ### Notify only for a specific group

--- a/AUTOMATION_EXAMPLES.md
+++ b/AUTOMATION_EXAMPLES.md
@@ -15,7 +15,7 @@ The integration fires two events on the Home Assistant event bus at each transit
 | `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `offline_since`, `offline_count`, `offline_entities` |
 | `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `downtime_seconds`, `offline_count`, `offline_entities` |
 
-`offline_count` and `offline_entities` reflect the group's offline state at the moment the event fires (after coordinator data is fully updated). Use `trigger.event.data.offline_count` in automations instead of querying the `offline_count` sensor — the sensor state is written asynchronously and may not yet reflect the transition that triggered the event.
+`offline_count` and `offline_entities` reflect the group's offline state at the moment the entity transitions (includes all entities that transitioned earlier in the same update cycle). Use `trigger.event.data.offline_count` in automations instead of querying the `offline_count` sensor — the sensor state is written asynchronously and may not yet reflect the transition that triggered the event.
 
 ### Notify when any monitored entity goes offline
 

--- a/AUTOMATION_EXAMPLES.md
+++ b/AUTOMATION_EXAMPLES.md
@@ -66,6 +66,74 @@ automation:
           {{ (trigger.event.data.downtime_seconds | float / 60) | round(1) }} min offline.
 ```
 
+### Rich push + email notification (offline and recovery)
+
+Uses `trigger.event.data.offline_count` and `trigger.event.data.offline_entities` from the event payload directly — no sensor state reads, no race condition.
+
+```yaml
+automation:
+  alias: EA — offline rich notification
+  trigger:
+    - platform: event
+      event_type: entity_availability_offline
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        title: "Device offline ({{ trigger.event.data.offline_count }} now offline)"
+        message: >-
+          {{ device_attr(device_id(trigger.event.data.entity_id), 'name_by_user')
+             or device_attr(device_id(trigger.event.data.entity_id), 'name')
+             or trigger.event.data.entity_id }}
+          in {{ trigger.event.data.group }} went offline
+          ({{ as_local(as_datetime(trigger.event.data.offline_since)).strftime('%d.%m.%Y %H:%M:%S') }}).
+    - service: notify.email
+      data:
+        title: "Device offline ({{ trigger.event.data.offline_count }} now offline)"
+        message: |-
+          Device: {{ device_attr(device_id(trigger.event.data.entity_id), 'name_by_user')
+                     or device_attr(device_id(trigger.event.data.entity_id), 'name')
+                     or trigger.event.data.entity_id }}
+          Group: {{ trigger.event.data.group }}
+          Offline since: {{ as_local(as_datetime(trigger.event.data.offline_since)).strftime('%d.%m.%Y %H:%M:%S') }}
+
+          Still offline ({{ trigger.event.data.offline_count }}):
+          • {{ trigger.event.data.offline_entities | join('\n• ') }}
+```
+
+```yaml
+automation:
+  alias: EA — recovery rich notification
+  trigger:
+    - platform: event
+      event_type: entity_availability_recovered
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        title: "Device recovered ({{ trigger.event.data.offline_count }} still offline)"
+        message: >-
+          {{ device_attr(device_id(trigger.event.data.entity_id), 'name_by_user')
+             or device_attr(device_id(trigger.event.data.entity_id), 'name')
+             or trigger.event.data.entity_id }}
+          in {{ trigger.event.data.group }} returned online after
+          {{ (trigger.event.data.downtime_seconds | float / 60) | round(0) }} minutes.
+    - service: notify.email
+      data:
+        title: "Device recovered ({{ trigger.event.data.offline_count }} still offline)"
+        message: |-
+          Device: {{ device_attr(device_id(trigger.event.data.entity_id), 'name_by_user')
+                     or device_attr(device_id(trigger.event.data.entity_id), 'name')
+                     or trigger.event.data.entity_id }}
+          Group: {{ trigger.event.data.group }}
+          Downtime: {{ (trigger.event.data.downtime_seconds | float / 60) | round(0) }} minutes
+
+          Still offline ({{ trigger.event.data.offline_count }}):
+          {% if trigger.event.data.offline_entities %}
+          • {{ trigger.event.data.offline_entities | join('\n• ') }}
+          {% else %}
+          None — all devices online.
+          {% endif %}
+```
+
 ### Escalate only for long outages
 
 ```yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
-
-### Fixed
-- **Bus events now carry `offline_count` and `offline_entities` in payload** — `entity_availability_offline` and `entity_availability_recovered` now include the number of non-suppressed offline entities in the group and their entity IDs at the moment of firing. For the offline event the newly-offline entity is included; for the recovered event it is already excluded. Use `trigger.event.data.offline_count` in automations instead of querying the `offline_count` sensor — the sensor state is written asynchronously and may not yet reflect the transition. Events also now fire after all device state mutations in the update cycle complete, eliminating a race where the event could fire before `is_offline` was fully propagated. Resolves #46.
-
 ## [0.3.14] - 2026-07-28
 
 ### Fixed
+- **Bus events now carry `offline_count` and `offline_entities` in payload** — `entity_availability_offline` and `entity_availability_recovered` now include the number of non-suppressed offline entities in the group and their entity IDs at the moment of firing. For the offline event the newly-offline entity is included; for the recovered event it is already excluded. Use `trigger.event.data.offline_count` in automations instead of querying the `offline_count` sensor — the sensor state is written asynchronously and may not yet reflect the transition. Events also now fire after all device state mutations in the update cycle complete, eliminating a race where the event could fire before `is_offline` was fully propagated. Resolves #46.
 - **Suppress/unsuppress services now group-scoped when `group` is provided with `entity_id`** — previously, calling `suppress`, `suppress_indefinitely`, or `unsuppress` with both `entity_id` and `group` would suppress/unsuppress the entity in **all groups** that monitor it. The `group` parameter is now respected: the action is scoped to that group's coordinator only. This affects the card's per-entity bell toggle, Suppress All, and Unsuppress All buttons — all now pass the card's configured group.
 - **`reset_statistics` service now group-scoped when `group` is provided with `entity_id`** — consistent with the other services, statistics are now reset only in the named group when both params are provided.
 - **`suppressed_until` attribute now includes indefinitely-suppressed entities** — previously, entities suppressed with no expiry were absent from the `suppressed_until` sensor attribute. They now appear with value `null` (Python `None`, JSON `null`), enabling automations and the card to correctly detect and display their suppressed state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Bus events now carry `offline_count` and `offline_entities` in payload** — `entity_availability_offline` and `entity_availability_recovered` now include the number of non-suppressed offline entities in the group and their entity IDs at the moment of firing. For the offline event the newly-offline entity is included; for the recovered event it is already excluded. Use `trigger.event.data.offline_count` in automations instead of querying the `offline_count` sensor — the sensor state is written asynchronously and may not yet reflect the transition. Events also now fire after all device state mutations in the update cycle complete, eliminating a race where the event could fire before `is_offline` was fully propagated. Resolves #46.
+
 ## [0.3.14] - 2026-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ The integration fires two events on the Home Assistant event bus when a monitore
 | `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `offline_since`, `offline_count`, `offline_entities` |
 | `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `downtime_seconds`, `offline_count`, `offline_entities` |
 
-`offline_count` is the number of non-suppressed entities still offline at fire time. `offline_entities` is the list of their entity IDs. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is excluded (it is already back online).
+`offline_count` is the number of non-suppressed entities still offline at the moment the entity transitions (includes all entities that transitioned earlier in the same update cycle). `offline_entities` is the list of their entity IDs. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is excluded (it is already back online).
 
 These are cleaner automation triggers than watching sensor attributes with templates:
 

--- a/README.md
+++ b/README.md
@@ -435,8 +435,10 @@ The integration fires two events on the Home Assistant event bus when a monitore
 
 | Event | Fired when | Data |
 |-------|-----------|------|
-| `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `offline_since` |
-| `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `downtime_seconds` |
+| `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `offline_since`, `offline_count`, `offline_entities` |
+| `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `downtime_seconds`, `offline_count`, `offline_entities` |
+
+`offline_count` is the number of non-suppressed entities still offline at fire time. `offline_entities` is the list of their entity IDs. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is excluded (it is already back online).
 
 These are cleaner automation triggers than watching sensor attributes with templates:
 
@@ -472,7 +474,9 @@ automation:
   action:
     - service: notify.mobile_app_my_phone
       data:
-        message: "{{ trigger.event.data.entity_id }} in {{ trigger.event.data.group }} went offline."
+        message: >-
+          {{ trigger.event.data.entity_id }} in {{ trigger.event.data.group }} went offline.
+          {{ trigger.event.data.offline_count }} device(s) now offline.
 ```
 
 ```yaml

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -634,27 +634,30 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
         # Mark as dirty; save periodically (every ~5 min)
         self._dirty = True
         self._update_count += 1
-        if self._update_count >= _SAVE_INTERVAL_UPDATES:
-            try:
-                await self._async_save_storage()
-            except Exception:  # noqa: BLE001
-                _LOGGER.warning(
-                    "[%s] Failed to save storage — will retry next interval",
-                    self.group_name,
-                )
-            finally:
-                self._update_count = 0
+        try:
+            if self._update_count >= _SAVE_INTERVAL_UPDATES:
+                try:
+                    await self._async_save_storage()
+                except Exception:  # noqa: BLE001
+                    _LOGGER.warning(
+                        "[%s] Failed to save storage — will retry next interval",
+                        self.group_name,
+                    )
+                finally:
+                    self._update_count = 0
 
-        for event_name, payload in pending_events:
-            self.hass.bus.async_fire(event_name, payload)
+            for event_name, payload in pending_events:
+                self.hass.bus.async_fire(event_name, payload)
 
-        return EntityAvailabilityData(
-            devices=dict(self._device_states),
-            buckets=dict(self._availability_storage.buckets),
-        )
+            return EntityAvailabilityData(
+                devices=dict(self._device_states),
+                buckets=dict(self._availability_storage.buckets),
+            )
+        finally:
+            pending_events.clear()
 
     def _offline_entity_ids(self) -> list[str]:
-        """Return entity_ids that are currently offline and not suppressed."""
+        """Return entity_ids that are currently offline and not suppressed, in insertion order."""
         return [
             eid
             for eid, d in self._device_states.items()

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -469,6 +469,14 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                 device.is_degraded = False
                 device.is_stale = False
                 device.is_low_battery = False
+                # Clear stale offline flag if entity recovered while suppressed;
+                # done silently — no event fires for a suppressed transition.
+                is_bad = state is None or state.state in self._bad_states
+                if not is_bad and device.is_offline:
+                    device.is_offline = False
+                    device.offline_since = None
+                    device.recently_offline_at = None
+                    device.cooldown_start = None
                 _LOGGER.debug(
                     "[%s] Skipping suppressed entity %s (until=%s)",
                     self.group_name,
@@ -645,8 +653,11 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
             finally:
                 self._update_count = 0
 
-        for event_name, payload in pending_events:
-            self.hass.bus.async_fire(event_name, payload)
+        try:
+            for event_name, payload in pending_events:
+                self.hass.bus.async_fire(event_name, payload)
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning("[%s] Failed to fire event", self.group_name, exc_info=True)
 
         return EntityAvailabilityData(
             devices=dict(self._device_states),

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -436,6 +436,8 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
         # Maximum reasonable elapsed is 2x the scan interval
         elapsed = min(elapsed, SCAN_INTERVAL * 2)
 
+        pending_events: list[tuple[str, dict]] = []
+
         for entity_id in self._entities:
             state = self.hass.states.get(entity_id)
             if entity_id not in self._device_states:
@@ -546,15 +548,20 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                         device.offline_since = device.cooldown_start
                         device.recently_offline_at = now
                         device.offline_event_count += 1
-                        self.hass.bus.async_fire(
-                            EVENT_OFFLINE,
-                            {
-                                "entity_id": entity_id,
-                                "group": self.group_name,
-                                "offline_since": device.offline_since.isoformat()
-                                if device.offline_since
-                                else None,
-                            },
+                        offline_ids = self._offline_entity_ids()
+                        pending_events.append(
+                            (
+                                EVENT_OFFLINE,
+                                {
+                                    "entity_id": entity_id,
+                                    "group": self.group_name,
+                                    "offline_since": device.offline_since.isoformat()
+                                    if device.offline_since
+                                    else None,
+                                    "offline_count": len(offline_ids),
+                                    "offline_entities": offline_ids,
+                                },
+                            )
                         )
                     elif in_grace:
                         _LOGGER.debug(
@@ -593,13 +600,18 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                     device.is_offline = False
                     device.offline_since = None
                     device.recently_offline_at = None
-                    self.hass.bus.async_fire(
-                        EVENT_RECOVERED,
-                        {
-                            "entity_id": entity_id,
-                            "group": self.group_name,
-                            "downtime_seconds": device.last_downtime_seconds,
-                        },
+                    recovered_offline_ids = self._offline_entity_ids()
+                    pending_events.append(
+                        (
+                            EVENT_RECOVERED,
+                            {
+                                "entity_id": entity_id,
+                                "group": self.group_name,
+                                "downtime_seconds": device.last_downtime_seconds,
+                                "offline_count": len(recovered_offline_ids),
+                                "offline_entities": recovered_offline_ids,
+                            },
+                        )
                     )
                 device.cooldown_start = None
                 self._availability_storage.record_online(entity_id, elapsed, now)
@@ -633,10 +645,21 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
             finally:
                 self._update_count = 0
 
+        for event_name, payload in pending_events:
+            self.hass.bus.async_fire(event_name, payload)
+
         return EntityAvailabilityData(
             devices=dict(self._device_states),
             buckets=dict(self._availability_storage.buckets),
         )
+
+    def _offline_entity_ids(self) -> list[str]:
+        """Return entity_ids that are currently offline and not suppressed."""
+        return [
+            eid
+            for eid, d in self._device_states.items()
+            if d.is_offline and not d.is_suppressed
+        ]
 
     def _get_battery_level(self, entity_id: str) -> int | None:
         """Get battery level for an entity using configured mapping or auto-detection."""

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -634,27 +634,24 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
         # Mark as dirty; save periodically (every ~5 min)
         self._dirty = True
         self._update_count += 1
-        try:
-            if self._update_count >= _SAVE_INTERVAL_UPDATES:
-                try:
-                    await self._async_save_storage()
-                except Exception:  # noqa: BLE001
-                    _LOGGER.warning(
-                        "[%s] Failed to save storage — will retry next interval",
-                        self.group_name,
-                    )
-                finally:
-                    self._update_count = 0
+        if self._update_count >= _SAVE_INTERVAL_UPDATES:
+            try:
+                await self._async_save_storage()
+            except Exception:  # noqa: BLE001
+                _LOGGER.warning(
+                    "[%s] Failed to save storage — will retry next interval",
+                    self.group_name,
+                )
+            finally:
+                self._update_count = 0
 
-            for event_name, payload in pending_events:
-                self.hass.bus.async_fire(event_name, payload)
+        for event_name, payload in pending_events:
+            self.hass.bus.async_fire(event_name, payload)
 
-            return EntityAvailabilityData(
-                devices=dict(self._device_states),
-                buckets=dict(self._availability_storage.buckets),
-            )
-        finally:
-            pending_events.clear()
+        return EntityAvailabilityData(
+            devices=dict(self._device_states),
+            buckets=dict(self._availability_storage.buckets),
+        )
 
     def _offline_entity_ids(self) -> list[str]:
         """Return entity_ids that are currently offline and not suppressed, in insertion order."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2956,10 +2956,14 @@ async def test_bus_events_fired_on_transitions(
     )
     assert offline_evt.data["entity_id"] == "binary_sensor.device_a"
     assert offline_evt.data["group"] == "Test Group"
+    assert offline_evt.data["offline_count"] == 1
+    assert "binary_sensor.device_a" in offline_evt.data["offline_entities"]
     recovered_evt = next(
         e for e in events if e.event_type == "entity_availability_recovered"
     )
     assert recovered_evt.data["downtime_seconds"] is not None
+    assert recovered_evt.data["offline_count"] == 0
+    assert recovered_evt.data["offline_entities"] == []
 
 
 async def test_counters_accumulate(mock_hass: HomeAssistant, mock_config_entry) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3084,6 +3084,57 @@ async def test_bus_events_suppressed_entity_excluded(
         assert last_evt.data["offline_entities"] == ["binary_sensor.device_b"]
 
 
+async def test_suppressed_entity_clears_offline_while_suppressed(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """is_offline cleared silently when entity recovers while suppressed."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_UNAVAILABLE)
+
+    events: list = []
+    hass.bus.async_listen("entity_availability_offline", lambda e: events.append(e))
+    hass.bus.async_listen("entity_availability_recovered", lambda e: events.append(e))
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+        device_a = coord.device_states["binary_sensor.device_a"]
+
+        # Step 1: entity goes offline
+        device_a.cooldown_start = datetime.now(timezone.utc) - timedelta(seconds=61)
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+        assert device_a.is_offline is True
+        events.clear()  # discard the offline event
+
+        # Step 2: suppress the entity
+        coord.suppress_entity("binary_sensor.device_a")
+        assert device_a.is_suppressed is True
+
+        # Step 3: entity recovers in HA while still suppressed
+        hass.states.async_set("binary_sensor.device_a", STATE_ON)
+
+        # Step 4: coordinator update — suppressed, so loop continues early
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+        # is_offline must be cleared silently — no event fired
+        assert device_a.is_offline is False
+        assert device_a.offline_since is None
+        assert device_a.cooldown_start is None
+        assert events == []
+
+        # Step 5: unsuppress — next update should not fire a spurious recovery
+        coord.unsuppress_entity("binary_sensor.device_a")
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+        assert device_a.is_offline is False
+        assert events == []
+
+
 async def test_counters_accumulate(mock_hass: HomeAssistant, mock_config_entry) -> None:
     """total_offline_seconds accumulates across events."""
     hass = mock_hass

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3019,7 +3019,7 @@ async def test_bus_events_multi_entity_offline_count(
         assert second_evt.data["offline_entities"] == [
             "binary_sensor.device_a",
             "binary_sensor.device_b",
-        ]
+        ]  # order matches self._entities insertion order (dict, Python 3.7+)
         assert isinstance(second_evt.data["offline_entities"], list)
 
         # Recover device_a only
@@ -3034,6 +3034,54 @@ async def test_bus_events_multi_entity_offline_count(
         assert rec_evt.data["offline_count"] == 1
         assert rec_evt.data["offline_entities"] == ["binary_sensor.device_b"]
         assert isinstance(rec_evt.data["offline_entities"], list)
+
+
+async def test_bus_events_suppressed_entity_excluded(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Suppressed entities are excluded from offline_count and offline_entities."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_UNAVAILABLE)
+    hass.states.async_set("binary_sensor.device_b", STATE_UNAVAILABLE)
+
+    offline_events: list = []
+    hass.bus.async_listen(
+        "entity_availability_offline", lambda e: offline_events.append(e)
+    )
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+        device_a = coord.device_states["binary_sensor.device_a"]
+        device_b = coord.device_states["binary_sensor.device_b"]
+
+        # Force device_a offline first
+        device_a.cooldown_start = datetime.now(timezone.utc) - timedelta(seconds=61)
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+
+        assert device_a.is_offline is True
+        # Now suppress device_a
+        coord.suppress_entity("binary_sensor.device_a")
+        assert device_a.is_suppressed is True
+
+        # Force device_b offline — fires event while device_a is suppressed
+        device_b.cooldown_start = datetime.now(timezone.utc) - timedelta(seconds=61)
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+
+        assert device_b.is_offline is True
+
+        # Last offline event is for device_b
+        last_evt = offline_events[-1]
+        assert last_evt.data["entity_id"] == "binary_sensor.device_b"
+        # Suppressed device_a must not appear
+        assert last_evt.data["offline_count"] == 1
+        assert last_evt.data["offline_entities"] == ["binary_sensor.device_b"]
 
 
 async def test_counters_accumulate(mock_hass: HomeAssistant, mock_config_entry) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2966,6 +2966,76 @@ async def test_bus_events_fired_on_transitions(
     assert recovered_evt.data["offline_entities"] == []
 
 
+async def test_bus_events_multi_entity_offline_count(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """offline_count and offline_entities reflect all offline devices at fire time."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_UNAVAILABLE)
+    hass.states.async_set("binary_sensor.device_b", STATE_UNAVAILABLE)
+
+    offline_events: list = []
+    recovered_events: list = []
+    hass.bus.async_listen(
+        "entity_availability_offline", lambda e: offline_events.append(e)
+    )
+    hass.bus.async_listen(
+        "entity_availability_recovered", lambda e: recovered_events.append(e)
+    )
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+        device_a = coord.device_states["binary_sensor.device_a"]
+        device_b = coord.device_states["binary_sensor.device_b"]
+
+        # Force both cooldowns to elapsed so both go offline on the same update
+        device_a.cooldown_start = datetime.now(timezone.utc) - timedelta(seconds=61)
+        device_b.cooldown_start = datetime.now(timezone.utc) - timedelta(seconds=61)
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+
+        assert device_a.is_offline is True
+        assert device_b.is_offline is True
+        assert len(offline_events) == 2
+
+        # Both offline events fired in entity insertion order (device_a first)
+        first_evt = offline_events[0]
+        second_evt = offline_events[1]
+        assert first_evt.data["entity_id"] == "binary_sensor.device_a"
+        assert second_evt.data["entity_id"] == "binary_sensor.device_b"
+
+        # When device_a fired: only device_a was offline (device_b not yet marked)
+        assert first_evt.data["offline_count"] == 1
+        assert first_evt.data["offline_entities"] == ["binary_sensor.device_a"]
+        assert isinstance(first_evt.data["offline_entities"], list)
+
+        # When device_b fired: both were offline
+        assert second_evt.data["offline_count"] == 2
+        assert second_evt.data["offline_entities"] == [
+            "binary_sensor.device_a",
+            "binary_sensor.device_b",
+        ]
+        assert isinstance(second_evt.data["offline_entities"], list)
+
+        # Recover device_a only
+        hass.states.async_set("binary_sensor.device_a", STATE_ON)
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+
+        assert len(recovered_events) == 1
+        rec_evt = recovered_events[0]
+        assert rec_evt.data["entity_id"] == "binary_sensor.device_a"
+        # device_a recovered; device_b still offline
+        assert rec_evt.data["offline_count"] == 1
+        assert rec_evt.data["offline_entities"] == ["binary_sensor.device_b"]
+        assert isinstance(rec_evt.data["offline_entities"], list)
+
+
 async def test_counters_accumulate(mock_hass: HomeAssistant, mock_config_entry) -> None:
     """total_offline_seconds accumulates across events."""
     hass = mock_hass


### PR DESCRIPTION
## Summary

Fixes #46 — event fires before sensor state is written.

### Root cause

`async_fire` was called inline during the `_async_update_data` entity loop. HA's coordinator framework calls `async_set_updated_data` → listener callbacks → `async_write_ha_state` *after* `_async_update_data` returns, so any automation reading the sensor state immediately on the event was racing against the state write.

### Fix 1 — Deferred event firing

Events are now collected in a `pending_events: list[tuple[str, dict]]` during the loop and fired in a single pass just before `return`. At fire time the coordinator data is fully consistent (all device state mutations are complete for this update cycle).

### Fix 2 — Enriched event payload

Both events now include:
- `offline_count` — number of non-suppressed offline devices in the group at fire time
- `offline_entities` — list of their `entity_id` strings

For `entity_availability_offline` the newly-offline entity is included in both fields. For `entity_availability_recovered` it is excluded (it is already back online when the event fires).

This eliminates the ordering dependency for the common automation pattern: automation authors can use `trigger.event.data.offline_count` directly instead of reading the sensor state, which avoids the race entirely.

### Migration

Existing automations that only read `entity_id`, `group`, `offline_since`, or `downtime_seconds` are unaffected — those fields are unchanged. To adopt the new fields:

```yaml
# Before (races against sensor state write)
message: "{{ states('sensor.entity_availability_my_group_offline_count') }} offline"

# After (safe — data is in the event payload)
message: "{{ trigger.event.data.offline_count }} offline"
```

## Test plan

- [ ] `python3 -m pytest tests/test_coordinator.py -x -q` — 119 passed
- [ ] `test_bus_events_fired_on_transitions` asserts `offline_count == 1` and entity in `offline_entities` for the offline event; `offline_count == 0` and empty list for the recovered event
- [ ] Coverage 99% (pre-existing uncovered line 112 — `availability_storage` property — unchanged)
- [ ] `ruff format` — no changes