### PR TITLE
feat: event payload consistency — combined groups fan-out, entry_id on all events

### DIFF
--- a/AUTOMATION_EXAMPLES.md
+++ b/AUTOMATION_EXAMPLES.md
@@ -17,6 +17,11 @@ The integration fires two events on the Home Assistant event bus at each transit
 
 `offline_count` and `offline_entities` reflect the group's offline state at the moment the entity transitions. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is already excluded. Use `trigger.event.data.offline_count` in automations instead of querying the `offline_count` sensor — the sensor state is written asynchronously and may not yet reflect the transition.
 
+**`offline_since`** is always an ISO timestamp string for individual group events. For combined group events it may be `null` if the coordinator has not yet recorded the transition time — guard with `| default(none)` before passing to `as_datetime()`:
+```yaml
+{{ as_local(as_datetime(trigger.event.data.offline_since | default(none))) if trigger.event.data.offline_since else "unknown" }}
+```
+
 **Combined groups fire the same events with the same payload shape** — one event per affected entity. An automation written for an individual group works unchanged on a combined group; just change the `group` name in the trigger filter.
 
 ### Notify when any monitored entity goes offline

--- a/AUTOMATION_EXAMPLES.md
+++ b/AUTOMATION_EXAMPLES.md
@@ -12,10 +12,12 @@ The integration fires two events on the Home Assistant event bus at each transit
 
 | Event | Fired when | Data |
 |-------|-----------|------|
-| `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `offline_since`, `offline_count`, `offline_entities` |
-| `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `downtime_seconds`, `offline_count`, `offline_entities` |
+| `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `entry_id`, `offline_since`, `offline_count`, `offline_entities` |
+| `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `entry_id`, `downtime_seconds`, `offline_count`, `offline_entities` |
 
-`offline_count` and `offline_entities` reflect the group's offline state at the moment the entity transitions (includes all entities that transitioned earlier in the same update cycle). Use `trigger.event.data.offline_count` in automations instead of querying the `offline_count` sensor — the sensor state is written asynchronously and may not yet reflect the transition that triggered the event.
+`offline_count` and `offline_entities` reflect the group's offline state at the moment the entity transitions. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is already excluded. Use `trigger.event.data.offline_count` in automations instead of querying the `offline_count` sensor — the sensor state is written asynchronously and may not yet reflect the transition.
+
+**Combined groups fire the same events with the same payload shape** — one event per affected entity. An automation written for an individual group works unchanged on a combined group; just change the `group` name in the trigger filter.
 
 ### Notify when any monitored entity goes offline
 
@@ -392,11 +394,53 @@ automation:
 
 ## Combined groups
 
-Combined groups aggregate several groups into one sensor set. The `any_offline` binary sensor is the simplest whole-home trigger.
+Combined groups aggregate several groups into one sensor set. They fire the same `entity_availability_offline` and `entity_availability_recovered` events as individual groups — one event per affected entity, same payload fields. Automations written for an individual group work unchanged on a combined group; just change the `group` name.
+
+### Notify when anything goes offline across all groups
 
 ```yaml
 automation:
-  alias: EA — anything offline anywhere
+  alias: EA — anything offline anywhere (event)
+  trigger:
+    - platform: event
+      event_type: entity_availability_offline
+      event_data:
+        group: All Home
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        title: "Device offline ({{ trigger.event.data.offline_count }} total)"
+        message: >-
+          {{ trigger.event.data.entity_id }} in
+          {{ trigger.event.data.group }} went offline.
+          {{ trigger.event.data.offline_count }} device(s) now offline.
+```
+
+### Notify on recovery from a combined group
+
+```yaml
+automation:
+  alias: EA — anything recovered anywhere (event)
+  trigger:
+    - platform: event
+      event_type: entity_availability_recovered
+      event_data:
+        group: All Home
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        message: >-
+          {{ trigger.event.data.entity_id }} recovered.
+          {{ trigger.event.data.offline_count }} device(s) still offline.
+```
+
+### Binary sensor fallback (no event needed)
+
+The `any_offline` binary sensor is a simple whole-home trigger when event details aren't needed.
+
+```yaml
+automation:
+  alias: EA — anything offline anywhere (binary sensor)
   trigger:
     - platform: state
       entity_id: binary_sensor.entity_availability_combined_all_devices_any_offline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [0.3.14] - 2026-07-30
 
 ### Added
-- Combined groups now fire `entity_availability_offline` and `entity_availability_recovered` events with `group`, `entry_id`, `offline_count`, `offline_entities`, `newly_offline` (offline event), and `recovered_entities` (recovered event). Events fire only on set changes; no spurious fires on startup. Duplicate entities deduplicated across all combined sensor outputs.
+- Combined groups now fire `entity_availability_offline` and `entity_availability_recovered` events. One event fires per affected entity using the same payload shape as individual group events: `entity_id`, `group`, `entry_id`, `offline_since`, `offline_count`, `offline_entities`. Automations written for individual groups work unchanged on combined groups — only the `group` name in the trigger filter differs. Events fire only on set changes; no spurious fires on startup. Duplicate entities deduplicated across all combined sensor outputs.
+- Individual group events now include `entry_id` in the payload.
 - Card: per-entity suppress toggle (`show_suppress_toggle`, opt-in, default `false`).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ The integration fires two events on the Home Assistant event bus when a monitore
 | `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `entry_id`, `offline_since`, `offline_count`, `offline_entities` |
 | `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `entry_id`, `downtime_seconds`, `offline_count`, `offline_entities` |
 
-`offline_count` and `offline_entities` reflect the group's offline state at the moment of the event. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is already excluded.
+`offline_count` and `offline_entities` reflect the group's offline state at the moment of the event. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is already excluded. `offline_since` is always set for individual group events; for combined groups it may be `null` if the coordinator has not yet recorded the transition — guard with `if trigger.event.data.offline_since` before using `as_datetime()`.
 
 **Combined groups fire the same events with the same payload shape** — one event per affected entity. An automation written for an individual group works unchanged on a combined group; just change the `group` name in the trigger filter.
 

--- a/README.md
+++ b/README.md
@@ -435,10 +435,12 @@ The integration fires two events on the Home Assistant event bus when a monitore
 
 | Event | Fired when | Data |
 |-------|-----------|------|
-| `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `offline_since`, `offline_count`, `offline_entities` |
-| `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `downtime_seconds`, `offline_count`, `offline_entities` |
+| `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `entry_id`, `offline_since`, `offline_count`, `offline_entities` |
+| `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `entry_id`, `downtime_seconds`, `offline_count`, `offline_entities` |
 
-`offline_count` is the number of non-suppressed entities still offline at the moment the entity transitions (includes all entities that transitioned earlier in the same update cycle). `offline_entities` is the list of their entity IDs. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is excluded (it is already back online).
+`offline_count` and `offline_entities` reflect the group's offline state at the moment of the event. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is already excluded.
+
+**Combined groups fire the same events with the same payload shape** — one event per affected entity. An automation written for an individual group works unchanged on a combined group; just change the `group` name in the trigger filter.
 
 These are cleaner automation triggers than watching sensor attributes with templates:
 

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -226,32 +226,57 @@ class CombinedGroupSensor(CombinedSensorBase):
 
         @callback
         def _on_update() -> None:
+            coords = self._active_coordinators()
+            # Build a map of entity_id → device state (first coord wins on dupes)
+            device_map: dict[str, Any] = {}
+            for coord in coords:
+                for d in coord.device_states.values():
+                    if d.entity_id not in device_map:
+                        device_map[d.entity_id] = d
+
             current = frozenset(
-                d.entity_id
-                for coord in self._active_coordinators()
-                for d in coord.device_states.values()
+                eid
+                for eid, d in device_map.items()
                 if d.is_offline and not d.is_suppressed
             )
             prev = self._prev_offline_set
             self._prev_offline_set = current
+
             if current != prev:
+                group_name = self._entry.data.get(CONF_GROUP_NAME, "")
+                entry_id = self._entry.entry_id
                 offline_list = sorted(current)
-                base = {
-                    "group": self._entry.data.get(CONF_GROUP_NAME, ""),
-                    "entry_id": self._entry.entry_id,
-                    "offline_count": len(current),
-                    "offline_entities": offline_list,
-                }
-                if current - prev:
+                offline_count = len(current)
+
+                for eid in sorted(current - prev):
+                    d = device_map.get(eid)
                     self.hass.bus.async_fire(
                         EVENT_OFFLINE,
-                        {**base, "newly_offline": sorted(current - prev)},
+                        {
+                            "entity_id": eid,
+                            "group": group_name,
+                            "entry_id": entry_id,
+                            "offline_since": d.offline_since.isoformat()
+                            if d and d.offline_since
+                            else None,
+                            "offline_count": offline_count,
+                            "offline_entities": offline_list,
+                        },
                     )
-                if prev - current:
+                for eid in sorted(prev - current):
+                    d = device_map.get(eid)
                     self.hass.bus.async_fire(
                         EVENT_RECOVERED,
-                        {**base, "recovered_entities": sorted(prev - current)},
+                        {
+                            "entity_id": eid,
+                            "group": group_name,
+                            "entry_id": entry_id,
+                            "downtime_seconds": d.last_downtime_seconds if d else None,
+                            "offline_count": offline_count,
+                            "offline_entities": offline_list,
+                        },
                     )
+
             if self._ea_should_write():
                 self.async_write_ha_state()
 

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -227,25 +227,21 @@ class CombinedGroupSensor(CombinedSensorBase):
         @callback
         def _on_update() -> None:
             coords = self._active_coordinators()
-            # Build a map of entity_id → device state (first coord wins on dupes).
             # Late-joining coordinators are auto-subscribed by _active_coordinators;
             # if one joins between priming and this first tick its entities appear in
             # current but not prev, which may fire a spurious OFFLINE event.
-            device_map: dict[str, Any] = {}
-            for coord in coords:
-                for d in coord.device_states.values():
-                    if d.entity_id not in device_map:
-                        device_map[d.entity_id] = d
-
-            current = frozenset(
-                eid
-                for eid, d in device_map.items()
-                if d.is_offline and not d.is_suppressed
-            )
+            current = self._current_offline_set(coords)
             prev = self._prev_offline_set
             self._prev_offline_set = current
 
             if current != prev:
+                # Build device_map only when needed for per-entity payload fields.
+                device_map: dict[str, Any] = {}
+                for coord in coords:
+                    for d in coord.device_states.values():
+                        if d.entity_id not in device_map:
+                            device_map[d.entity_id] = d
+
                 group_name = self._entry.data.get(CONF_GROUP_NAME, "")
                 entry_id = self._entry.entry_id
                 offline_list = sorted(current)

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -227,7 +227,10 @@ class CombinedGroupSensor(CombinedSensorBase):
         @callback
         def _on_update() -> None:
             coords = self._active_coordinators()
-            # Build a map of entity_id → device state (first coord wins on dupes)
+            # Build a map of entity_id → device state (first coord wins on dupes).
+            # Late-joining coordinators are auto-subscribed by _active_coordinators;
+            # if one joins between priming and this first tick its entities appear in
+            # current but not prev, which may fire a spurious OFFLINE event.
             device_map: dict[str, Any] = {}
             for coord in coords:
                 for d in coord.device_states.values():
@@ -264,6 +267,9 @@ class CombinedGroupSensor(CombinedSensorBase):
                         },
                     )
                 for eid in sorted(prev - current):
+                    # d may be None if the coordinator that owned this entity was
+                    # removed between ticks; fire the event with null downtime rather
+                    # than silently dropping it.
                     d = device_map.get(eid)
                     self.hass.bus.async_fire(
                         EVENT_RECOVERED,
@@ -282,23 +288,25 @@ class CombinedGroupSensor(CombinedSensorBase):
 
         return _on_update
 
+    def _current_offline_set(
+        self, coords: list[EntityAvailabilityCoordinator]
+    ) -> frozenset[str]:
+        """Return deduplicated set of offline, non-suppressed entity IDs."""
+        seen: dict[str, Any] = {}
+        for coord in coords:
+            for d in coord.device_states.values():
+                if d.entity_id not in seen:
+                    seen[d.entity_id] = d
+        return frozenset(
+            eid for eid, d in seen.items() if d.is_offline and not d.is_suppressed
+        )
+
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-        # Prime after subscribing to avoid spurious events for pre-existing offline entities
-        active = [
-            c
-            for eid in self._combined_entry_ids
-            if isinstance(
-                c := self.hass.data.get(DOMAIN, {}).get(eid),
-                EntityAvailabilityCoordinator,
-            )
-        ]
-        self._prev_offline_set = frozenset(
-            d.entity_id
-            for coord in active
-            for d in coord.device_states.values()
-            if d.is_offline and not d.is_suppressed
-        )
+        # Prime _prev_offline_set using the same dedup logic as _on_update so the
+        # two code paths can't diverge. Must happen after super() subscribes so
+        # _active_coordinators() returns the full list.
+        self._prev_offline_set = self._current_offline_set(self._active_coordinators())
 
     @property
     def native_value(self) -> int:

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -563,6 +563,7 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                                 {
                                     "entity_id": entity_id,
                                     "group": self.group_name,
+                                    "entry_id": self.entry.entry_id,
                                     "offline_since": device.offline_since.isoformat()
                                     if device.offline_since
                                     else None,
@@ -615,6 +616,7 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                             {
                                 "entity_id": entity_id,
                                 "group": self.group_name,
+                                "entry_id": self.entry.entry_id,
                                 "downtime_seconds": device.last_downtime_seconds,
                                 "offline_count": len(recovered_offline_ids),
                                 "offline_entities": recovered_offline_ids,

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -18,7 +18,7 @@ The test auto-discovers the first entity_availability group whose title contains
 EA_SMOKE_GROUP, then discovers its monitored entities and battery entity map from
 the live sensor attributes — no hardcoded entity IDs, entry IDs, or device names.
 
-What is tested (covers PRs #37, #41, #50, #52, core):
+What is tested (covers PRs #37, #41, #50, #52, #53, core):
   EC1  entity goes unavailable → offline_count increments
   EC4  device online + battery below threshold → low_battery_count=1, list populated
   EC5  device+battery unavailable → offline=1, low_battery=0 (PR#41: no double-count)
@@ -35,6 +35,9 @@ What is tested (covers PRs #37, #41, #50, #52, core):
   EC16 PR#52: combined offline_count rises when member entity goes offline
   EC17 PR#52: combined offline_entities list contains the offline entity
   EC18 PR#52: combined offline_count drops to baseline after recovery
+  EC19 PR#53: combined config entry has non-empty entry_id (event payload source)
+  EC20 PR#53: individual group offline_count also rises when entity goes offline (fan-out parity)
+  EC21 PR#53: combined and individual group offline_entities agree on the offline entity
 """
 
 import json
@@ -954,6 +957,76 @@ for e in cfg['data']['entries']:
                 )
         else:
             print("  EC16-EC18: skipped (no combined group found)", flush=True)
+
+    # ------------------------------------------------------------------
+    if ec_enabled(19) or ec_enabled(20) or ec_enabled(21):
+        print(
+            "\n=== EC19-EC21: PR#53 — event consistency: entry_id, fan-out parity ===",
+            flush=True,
+        )
+        restore_all(ctx)
+        wait()
+        if combined_prefix:
+            target = ctx["entities"][0]
+            c_offline_eid = f"{combined_prefix}_offline_count"
+            i_offline_eid = f"{prefix}_offline_count"
+
+            if ec_enabled(19):
+                # EC19: combined config entry has a non-empty entry_id
+                entries = api("GET", "/api/config/config_entries/entry")
+                combined_entry = next(
+                    (
+                        e
+                        for e in entries
+                        if e["domain"] == "entity_availability"
+                        and "combined" in e["title"].lower()
+                    ),
+                    None,
+                )
+                chk(
+                    "EC19 combined config entry has non-empty entry_id",
+                    bool(combined_entry and combined_entry.get("entry_id", "")),
+                    True,
+                    f"entry={combined_entry}",
+                )
+
+            if ec_enabled(20):
+                # EC20: individual group offline_count rises when entity goes offline
+                # (fan-out parity: both individual and combined track the same entity)
+                i_baseline = int(gs(i_offline_eid).get("state", "0"))
+                ss(target, "unavailable", {"friendly_name": "smoke test device"})
+                wait()
+                i_after = int(gs(i_offline_eid).get("state", "0"))
+                chk(
+                    "EC20 individual offline_count rises for entity in combined group",
+                    i_after,
+                    i_baseline + 1,
+                    f"sensor={i_offline_eid} baseline={i_baseline} after={i_after}",
+                )
+
+            if ec_enabled(21):
+                if not ec_enabled(20):
+                    ss(target, "unavailable", {"friendly_name": "smoke test device"})
+                    wait()
+                # EC21: combined and individual offline_entities both contain the entity
+                c_entities = gs(c_offline_eid).get("attributes", {}).get("entities", [])
+                i_entities = gs(i_offline_eid).get("attributes", {}).get("entities", [])
+                chk(
+                    "EC21 individual offline_entities contains the offline entity",
+                    target in i_entities,
+                    True,
+                    f"target={target} individual={i_entities}",
+                )
+                chk(
+                    "EC21 combined offline_entities contains the offline entity",
+                    target in c_entities,
+                    True,
+                    f"target={target} combined={c_entities}",
+                )
+                restore_all(ctx)
+                wait()
+        else:
+            print("  EC19-EC21: skipped (no combined group found)", flush=True)
 
     # ------------------------------------------------------------------
     print("\n=== CLEANUP ===", flush=True)

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -36,8 +36,8 @@ What is tested (covers PRs #37, #41, #50, #52, #53, core):
   EC17 PR#52: combined offline_entities list contains the offline entity
   EC18 PR#52: combined offline_count drops to baseline after recovery
   EC19 PR#53: combined config entry has non-empty entry_id (event payload source)
-  EC20 PR#53: individual group offline_count also rises when entity goes offline (fan-out parity)
-  EC21 PR#53: combined and individual group offline_entities agree on the offline entity
+  EC20 PR#53: individual group offline_count sensor rises when entity in combined group goes offline
+  EC21 PR#53: individual and combined offline_entities sensors both reflect the offline entity
 """
 
 import json
@@ -969,7 +969,9 @@ for e in cfg['data']['entries']:
         if combined_prefix:
             target = ctx["entities"][0]
             c_offline_eid = f"{combined_prefix}_offline_count"
+            c_entities_eid = f"{combined_prefix}_offline_entities"
             i_offline_eid = f"{prefix}_offline_count"
+            i_entities_eid = f"{prefix}_offline_entities"
 
             if ec_enabled(19):
                 # EC19: combined config entry has a non-empty entry_id
@@ -1008,9 +1010,13 @@ for e in cfg['data']['entries']:
                 if not ec_enabled(20):
                     ss(target, "unavailable", {"friendly_name": "smoke test device"})
                     wait()
-                # EC21: combined and individual offline_entities both contain the entity
-                c_entities = gs(c_offline_eid).get("attributes", {}).get("entities", [])
-                i_entities = gs(i_offline_eid).get("attributes", {}).get("entities", [])
+                # EC21: combined and individual offline_entities sensors both contain the entity
+                c_entities = (
+                    gs(c_entities_eid).get("attributes", {}).get("entities", [])
+                )
+                i_entities = (
+                    gs(i_entities_eid).get("attributes", {}).get("entities", [])
+                )
                 chk(
                     "EC21 individual offline_entities contains the offline entity",
                     target in i_entities,

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -757,6 +757,7 @@ class TestCombinedGroupSensor:
 
         assert len(events) == 1
         data = events[0].data
+        assert data["entity_id"] == "binary_sensor.a2"
         assert data["group"] == "Combined"
         assert data["entry_id"] == "combined_1"
         assert "binary_sensor.a2" in data["offline_entities"]
@@ -784,9 +785,9 @@ class TestCombinedGroupSensor:
 
         assert len(events) == 1
         data = events[0].data
+        assert data["entity_id"] == "binary_sensor.a2"
         assert data["offline_count"] == 0
         assert data["offline_entities"] == []
-        assert data["recovered_entities"] == ["binary_sensor.a2"]
 
     async def test_no_event_when_offline_set_unchanged(
         self, mock_hass, combined_entry, coordinators
@@ -864,10 +865,10 @@ class TestCombinedGroupSensor:
 
         assert len(offline_events) == 1
         assert len(recovered_events) == 1
+        assert offline_events[0].data["entity_id"] == "binary_sensor.b1"
         assert offline_events[0].data["offline_entities"] == ["binary_sensor.b1"]
-        assert offline_events[0].data["newly_offline"] == ["binary_sensor.b1"]
+        assert recovered_events[0].data["entity_id"] == "binary_sensor.a2"
         assert recovered_events[0].data["offline_count"] == 1
-        assert recovered_events[0].data["recovered_entities"] == ["binary_sensor.a2"]
 
     async def test_no_spurious_event_on_startup_for_pre_existing_offline(
         self, mock_hass, combined_entry, coordinators
@@ -898,6 +899,66 @@ class TestCombinedGroupSensor:
         assert events == [], (
             "Spurious event fired for pre-existing offline entity on startup"
         )
+
+    async def test_fan_out_two_entities_offline_simultaneously(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Two entities going offline in one tick fires two separate events."""
+        sensor, fired_cbs = self._setup_event_sensor(
+            mock_hass, combined_entry, coordinators
+        )
+        await sensor.async_added_to_hass()
+        sensor._prev_offline_set = frozenset()
+
+        # Make b1 also offline so both a2 and b1 are newly offline
+        coordinators[1]._device_states["binary_sensor.b1"].is_offline = True
+
+        events = []
+        mock_hass.bus.async_listen(
+            "entity_availability_offline", lambda e: events.append(e)
+        )
+
+        fired_cbs[0]()
+        await mock_hass.async_block_till_done()
+
+        assert len(events) == 2
+        entity_ids = {e.data["entity_id"] for e in events}
+        assert entity_ids == {"binary_sensor.a2", "binary_sensor.b1"}
+        # Each event carries the same aggregate snapshot
+        for e in events:
+            assert e.data["offline_count"] == 2
+            assert set(e.data["offline_entities"]) == {
+                "binary_sensor.a2",
+                "binary_sensor.b1",
+            }
+
+    async def test_combined_event_payload_matches_individual_group_shape(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Combined offline event has entity_id, group, entry_id, offline_count, offline_entities."""
+        sensor, fired_cbs = self._setup_event_sensor(
+            mock_hass, combined_entry, coordinators
+        )
+        await sensor.async_added_to_hass()
+        sensor._prev_offline_set = frozenset()
+
+        events = []
+        mock_hass.bus.async_listen(
+            "entity_availability_offline", lambda e: events.append(e)
+        )
+
+        fired_cbs[0]()
+        await mock_hass.async_block_till_done()
+
+        assert len(events) == 1
+        data = events[0].data
+        # Same fields as individual group events
+        assert "entity_id" in data
+        assert "group" in data
+        assert "entry_id" in data
+        assert "offline_count" in data
+        assert "offline_entities" in data
+        assert "offline_since" in data
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -118,6 +118,7 @@ def coordinator_a(mock_hass: HomeAssistant, group_entry_a: MockConfigEntry):
             "binary_sensor.a2": DeviceState(
                 entity_id="binary_sensor.a2",
                 is_offline=True,
+                offline_since=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
             ),
         }
     return coord
@@ -952,13 +953,15 @@ class TestCombinedGroupSensor:
 
         assert len(events) == 1
         data = events[0].data
-        # Same fields as individual group events
-        assert "entity_id" in data
-        assert "group" in data
-        assert "entry_id" in data
-        assert "offline_count" in data
-        assert "offline_entities" in data
-        assert "offline_since" in data
+        # Same fields as individual group events — values not just keys
+        assert data["entity_id"] == "binary_sensor.a2"
+        assert data["group"] == "Combined"
+        assert data["entry_id"] == "combined_1"
+        assert data["offline_count"] == 1
+        assert "binary_sensor.a2" in data["offline_entities"]
+        # offline_since must be a non-None ISO string (fixture sets it)
+        assert data["offline_since"] is not None
+        assert isinstance(data["offline_since"], str)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Combined groups previously fired one batch event per tick with `newly_offline`/`recovered_entities` lists — automations written for individual groups (which expect `entity_id` and `offline_since`) broke silently
- Combined groups now fire **one event per affected entity** using the same payload shape as individual group events
- Individual group events gain `entry_id` (was missing)
- Automations work identically on both group types — only the `group` name in the trigger filter differs

## Behaviour

**Before:** 3 entities go offline in a combined group → 1 event with `newly_offline: ["a", "b", "c"]`, no `entity_id`, no `offline_since`

**After:** 3 entities go offline in a combined group → 3 events, each with `entity_id`, `group`, `entry_id`, `offline_since`, `offline_count`, `offline_entities`

Existing individual-group automation works unchanged on a combined group:
```yaml
trigger:
  platform: event
  event_type: entity_availability_offline
  event_data:
    group: All Home   # was: Security Devices — only this line changes
```

## Changes

| File | What changed |
|---|---|
| `combined_sensor.py` | `_make_update_callback` loops over `current - prev` / `prev - current`, fires one event per entity with individual-group payload shape |
| `coordinator.py` | `entry_id` added to both individual group event payloads |
| `tests/test_combined_sensor.py` | Updated event tests for new shape; added fan-out test (2 entities → 2 events) and payload-shape parity test |
| `tests/integration/smoke.py` | EC19-21: combined entry_id non-empty, individual+combined offline_count parity, offline_entities cross-check |
| `CHANGELOG.md` | Documented under `[0.3.14]` |
| `README.md` / `AUTOMATION_EXAMPLES.md` | Event table updated with `entry_id`; combined groups section updated with event-based examples |

## Breaking change

`newly_offline` and `recovered_entities` fields removed from combined group events (replaced by per-entity fan-out). These fields were introduced in 0.3.14 (PR #52, just merged) — no known automations depend on them yet.

## Test plan

- [x] `python3 -m pytest tests/ --ignore=tests/integration` — 614 passed
- [x] `combined_sensor.py` coverage: 100%
- [x] `coordinator.py` coverage: 99% (2 pre-existing uncovered exception handler lines)
- [x] `ruff format` — clean
- [ ] Integration smoke EC16-21 — running