### PR TITLE
feat: fire low-battery / battery-ok events on battery transitions

### DIFF
--- a/AUTOMATION_EXAMPLES.md
+++ b/AUTOMATION_EXAMPLES.md
@@ -8,21 +8,25 @@ Ready-to-adapt automations for every feature. Replace `security_devices` with yo
 
 ## Bus events
 
-The integration fires two events on the Home Assistant event bus at each transition (after the group's cooldown, outside the 60 s startup grace period). These are the cleanest automation triggers — no template polling of sensor attributes.
+The integration fires four events on the Home Assistant event bus at each transition (after the group's cooldown, outside the 60 s startup grace period). These are the cleanest automation triggers — no template polling of sensor attributes.
 
 | Event | Fired when | Data |
 |-------|-----------|------|
 | `entity_availability_offline` | An entity is confirmed offline | `entity_id`, `group`, `entry_id`, `offline_since`, `offline_count`, `offline_entities` |
 | `entity_availability_recovered` | An offline entity returns online | `entity_id`, `group`, `entry_id`, `downtime_seconds`, `offline_count`, `offline_entities` |
+| `entity_availability_low_battery` | An entity's battery drops below threshold | `entity_id`, `group`, `entry_id`, `battery_level`, `low_battery_count`, `low_battery_entities` |
+| `entity_availability_battery_ok` | A low-battery entity's level rises above threshold | `entity_id`, `group`, `entry_id`, `battery_level`, `low_battery_count`, `low_battery_entities` |
 
 `offline_count` and `offline_entities` reflect the group's offline state at the moment the entity transitions. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is already excluded. Use `trigger.event.data.offline_count` in automations instead of querying the `offline_count` sensor — the sensor state is written asynchronously and may not yet reflect the transition.
+
+`low_battery_count` and `low_battery_entities` follow the same snapshot rule: for `entity_availability_low_battery` the newly-low entity is included; for `entity_availability_battery_ok` it is already excluded.
 
 **`offline_since`** is always an ISO timestamp string for individual group events. For combined group events it may be `null` if the coordinator has not yet recorded the transition time — guard with `| default(none)` before passing to `as_datetime()`:
 ```yaml
 {{ as_local(as_datetime(trigger.event.data.offline_since | default(none))) if trigger.event.data.offline_since else "unknown" }}
 ```
 
-**Combined groups fire the same events with the same payload shape** — one event per affected entity. An automation written for an individual group works unchanged on a combined group; just change the `group` name in the trigger filter.
+**Combined groups fire all four events with the same payload shape** — one event per affected entity. An automation written for an individual group works unchanged on a combined group; just change the `group` name in the trigger filter.
 
 ### Notify when any monitored entity goes offline
 
@@ -158,6 +162,77 @@ automation:
         message: >
           {{ trigger.event.data.entity_id }} was offline for
           {{ (trigger.event.data.downtime_seconds | float / 60) | round }} minutes.
+```
+
+### Notify when a battery drops below threshold
+
+```yaml
+automation:
+  alias: EA — low battery alert
+  trigger:
+    - platform: event
+      event_type: entity_availability_low_battery
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        title: "Low battery ({{ trigger.event.data.low_battery_count }} device(s))"
+        message: >
+          {{ trigger.event.data.entity_id }} in {{ trigger.event.data.group }}
+          has {{ trigger.event.data.battery_level }}% battery.
+          {{ trigger.event.data.low_battery_count }} device(s) now low:
+          {{ trigger.event.data.low_battery_entities | join(', ') }}
+```
+
+### Notify only for a specific group's battery events
+
+```yaml
+automation:
+  alias: EA — security group low battery
+  trigger:
+    - platform: event
+      event_type: entity_availability_low_battery
+      event_data:
+        group: Security Devices
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        message: "Security device low battery: {{ trigger.event.data.entity_id }} at {{ trigger.event.data.battery_level }}%"
+```
+
+### Alert only when battery is critically low (below 10%)
+
+```yaml
+automation:
+  alias: EA — critical battery
+  trigger:
+    - platform: event
+      event_type: entity_availability_low_battery
+  condition:
+    - "{{ trigger.event.data.battery_level | int(100) < 10 }}"
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        title: Critical battery
+        message: >
+          {{ trigger.event.data.entity_id }} is at {{ trigger.event.data.battery_level }}% —
+          replace battery soon.
+```
+
+### Confirm battery replaced (battery_ok event)
+
+```yaml
+automation:
+  alias: EA — battery replaced
+  trigger:
+    - platform: event
+      event_type: entity_availability_battery_ok
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        message: >
+          {{ trigger.event.data.entity_id }} battery OK
+          ({{ trigger.event.data.battery_level }}%).
+          {{ trigger.event.data.low_battery_count }} device(s) still low.
 ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [0.3.14] - 2026-07-30
 
 ### Added
+- New bus events `entity_availability_low_battery` and `entity_availability_battery_ok` fired on battery threshold transitions. Payload: `entity_id`, `group`, `entry_id`, `battery_level`, `low_battery_count`, `low_battery_entities`. Full parity with offline/recovered event shape. Both individual groups and combined groups fire events; combined group uses the same `_prev_low_battery_set` diff pattern as offline events.
 - Combined groups now fire `entity_availability_offline` and `entity_availability_recovered` events. One event fires per affected entity using the same payload shape as individual group events: `entity_id`, `group`, `entry_id`, `offline_since`, `offline_count`, `offline_entities`. Automations written for individual groups work unchanged on combined groups — only the `group` name in the trigger filter differs. Events fire only on set changes; no spurious fires on startup. Duplicate entities deduplicated across all combined sensor outputs.
 - Individual group events now include `entry_id` in the payload.
 - Card: per-entity suppress toggle (`show_suppress_toggle`, opt-in, default `false`).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Monitor entity availability in Home Assistant. Track offline entities, availabil
 - **Cooldown timer** -- ignore brief blips before marking an entity offline
 - **Availability % sensors** -- track uptime over today, 3-day, 5-day, and 7-day windows
 - **Reliability sensors (MTBF + MTTR)** -- flag devices that keep flaking out: separate diagnostic sensors for how *often* each device breaks (MTBF) and how *long* each outage lasts (MTTR), so a genuinely flaky device is distinguishable from one that had a single long outage at the same uptime %
-- **Bus events** -- fires `entity_availability_offline` / `entity_availability_recovered` on the HA event bus for use as native automation triggers
+- **Bus events** -- fires `entity_availability_offline` / `entity_availability_recovered` / `entity_availability_low_battery` / `entity_availability_battery_ok` on the HA event bus for use as native automation triggers
 - **Battery monitoring** -- auto-detect or manually map battery entities; supports numeric (%) and text states (`low`)
 - **Degraded entity detection** -- flag entities with low battery or stale data
 - **Recently offline / recovered sensors** -- track which entities went offline or recovered within a configurable time window

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -237,132 +237,121 @@ class CombinedGroupSensor(CombinedSensorBase):
             prev = self._prev_offline_set
             self._prev_offline_set = current
 
-            if current != prev:
-                # Build device_map only when needed for per-entity payload fields.
-                device_map: dict[str, Any] = {}
-                for coord in coords:
-                    for d in coord.device_states.values():
-                        if d.entity_id not in device_map:
-                            device_map[d.entity_id] = d
-
-                group_name = self._entry.data.get(CONF_GROUP_NAME, "")
-                entry_id = self._entry.entry_id
-                offline_list = sorted(current)
-                offline_count = len(current)
-
-                for eid in sorted(current - prev):
-                    d = device_map.get(eid)
-                    self.hass.bus.async_fire(
-                        EVENT_OFFLINE,
-                        {
-                            "entity_id": eid,
-                            "group": group_name,
-                            "entry_id": entry_id,
-                            "offline_since": d.offline_since.isoformat()
-                            if d and d.offline_since
-                            else None,
-                            "offline_count": offline_count,
-                            "offline_entities": offline_list,
-                        },
-                    )
-                for eid in sorted(prev - current):
-                    # d may be None if the coordinator that owned this entity was
-                    # removed between ticks; fire the event with null downtime rather
-                    # than silently dropping it.
-                    d = device_map.get(eid)
-                    self.hass.bus.async_fire(
-                        EVENT_RECOVERED,
-                        {
-                            "entity_id": eid,
-                            "group": group_name,
-                            "entry_id": entry_id,
-                            "downtime_seconds": d.last_downtime_seconds if d else None,
-                            "offline_count": offline_count,
-                            "offline_entities": offline_list,
-                        },
-                    )
-
             current_lb = self._current_low_battery_set(coords)
             prev_lb = self._prev_low_battery_set
             self._prev_low_battery_set = current_lb
 
-            if current_lb != prev_lb:
-                if not (current != prev):
-                    # Build device_map if not already built above.
-                    device_map = {}
-                    for coord in coords:
-                        for d in coord.device_states.values():
-                            if d.entity_id not in device_map:
-                                device_map[d.entity_id] = d
-
+            if current != prev or current_lb != prev_lb:
+                device_map = self._build_device_map(coords)
                 group_name = self._entry.data.get(CONF_GROUP_NAME, "")
                 entry_id = self._entry.entry_id
-                low_battery_list = sorted(current_lb)
-                low_battery_count = len(current_lb)
 
-                for eid in sorted(current_lb - prev_lb):
-                    d = device_map.get(eid)
-                    self.hass.bus.async_fire(
-                        EVENT_LOW_BATTERY,
-                        {
-                            "entity_id": eid,
-                            "group": group_name,
-                            "entry_id": entry_id,
-                            "battery_level": d.battery_level if d else None,
-                            "low_battery_count": low_battery_count,
-                            "low_battery_entities": low_battery_list,
-                        },
-                    )
-                for eid in sorted(prev_lb - current_lb):
-                    d = device_map.get(eid)
-                    self.hass.bus.async_fire(
-                        EVENT_BATTERY_OK,
-                        {
-                            "entity_id": eid,
-                            "group": group_name,
-                            "entry_id": entry_id,
-                            "battery_level": d.battery_level if d else None,
-                            "low_battery_count": low_battery_count,
-                            "low_battery_entities": low_battery_list,
-                        },
-                    )
+                if current != prev:
+                    offline_list = sorted(current)
+                    offline_count = len(current)
+                    for eid in sorted(current - prev):
+                        d = device_map.get(eid)
+                        self.hass.bus.async_fire(
+                            EVENT_OFFLINE,
+                            {
+                                "entity_id": eid,
+                                "group": group_name,
+                                "entry_id": entry_id,
+                                "offline_since": d.offline_since.isoformat()
+                                if d and d.offline_since
+                                else None,
+                                "offline_count": offline_count,
+                                "offline_entities": offline_list,
+                            },
+                        )
+                    for eid in sorted(prev - current):
+                        # d may be None if the coordinator that owned this entity was
+                        # removed between ticks; fire the event with null downtime rather
+                        # than silently dropping it.
+                        d = device_map.get(eid)
+                        self.hass.bus.async_fire(
+                            EVENT_RECOVERED,
+                            {
+                                "entity_id": eid,
+                                "group": group_name,
+                                "entry_id": entry_id,
+                                "downtime_seconds": d.last_downtime_seconds
+                                if d
+                                else None,
+                                "offline_count": offline_count,
+                                "offline_entities": offline_list,
+                            },
+                        )
+
+                if current_lb != prev_lb:
+                    low_battery_list = sorted(current_lb)
+                    low_battery_count = len(current_lb)
+                    for eid in sorted(current_lb - prev_lb):
+                        d = device_map.get(eid)
+                        self.hass.bus.async_fire(
+                            EVENT_LOW_BATTERY,
+                            {
+                                "entity_id": eid,
+                                "group": group_name,
+                                "entry_id": entry_id,
+                                "battery_level": d.battery_level if d else None,
+                                "low_battery_count": low_battery_count,
+                                "low_battery_entities": low_battery_list,
+                            },
+                        )
+                    for eid in sorted(prev_lb - current_lb):
+                        d = device_map.get(eid)
+                        self.hass.bus.async_fire(
+                            EVENT_BATTERY_OK,
+                            {
+                                "entity_id": eid,
+                                "group": group_name,
+                                "entry_id": entry_id,
+                                "battery_level": d.battery_level if d else None,
+                                "low_battery_count": low_battery_count,
+                                "low_battery_entities": low_battery_list,
+                            },
+                        )
 
             if self._ea_should_write():
                 self.async_write_ha_state()
 
         return _on_update
 
+    @staticmethod
+    def _build_device_map(
+        coords: list[EntityAvailabilityCoordinator],
+    ) -> dict[str, Any]:
+        """Return first-wins dedup map of entity_id → DeviceState across coordinators."""
+        device_map: dict[str, Any] = {}
+        for coord in coords:
+            for d in coord.device_states.values():
+                if d.entity_id not in device_map:
+                    device_map[d.entity_id] = d
+        return device_map
+
     def _current_offline_set(
         self, coords: list[EntityAvailabilityCoordinator]
     ) -> frozenset[str]:
         """Return deduplicated set of offline, non-suppressed entity IDs."""
-        seen: dict[str, Any] = {}
-        for coord in coords:
-            for d in coord.device_states.values():
-                if d.entity_id not in seen:
-                    seen[d.entity_id] = d
+        dm = self._build_device_map(coords)
         return frozenset(
-            eid for eid, d in seen.items() if d.is_offline and not d.is_suppressed
+            eid for eid, d in dm.items() if d.is_offline and not d.is_suppressed
         )
 
     def _current_low_battery_set(
         self, coords: list[EntityAvailabilityCoordinator]
     ) -> frozenset[str]:
         """Return deduplicated set of low-battery, non-suppressed entity IDs."""
-        seen: dict[str, Any] = {}
-        for coord in coords:
-            for d in coord.device_states.values():
-                if d.entity_id not in seen:
-                    seen[d.entity_id] = d
+        dm = self._build_device_map(coords)
         return frozenset(
-            eid for eid, d in seen.items() if d.is_low_battery and not d.is_suppressed
+            eid for eid, d in dm.items() if d.is_low_battery and not d.is_suppressed
         )
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-        # Prime _prev_offline_set using the same dedup logic as _on_update so the
-        # two code paths can't diverge. Must happen after super() subscribes so
-        # _active_coordinators() returns the full list.
+        # Prime both prev sets after super() subscribes so _active_coordinators()
+        # returns the full list — prevents spurious events on first tick.
         coords = self._active_coordinators()
         self._prev_offline_set = self._current_offline_set(coords)
         self._prev_low_battery_set = self._current_low_battery_set(coords)

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -21,6 +21,8 @@ from .const import (
     CONF_GROUP_NAME,
     CONF_USE_DEVICE_NAMES,
     DOMAIN,
+    EVENT_BATTERY_OK,
+    EVENT_LOW_BATTERY,
     EVENT_OFFLINE,
     EVENT_RECOVERED,
     NO_AREA_SENTINEL,
@@ -220,6 +222,7 @@ class CombinedGroupSensor(CombinedSensorBase):
         )
         self._attr_translation_key = "combined_summary"
         self._prev_offline_set: frozenset[str] = frozenset()
+        self._prev_low_battery_set: frozenset[str] = frozenset()
 
     def _make_update_callback(self) -> Callable[[], None]:
         """Return event-aware coordinator update callback."""
@@ -279,6 +282,51 @@ class CombinedGroupSensor(CombinedSensorBase):
                         },
                     )
 
+            current_lb = self._current_low_battery_set(coords)
+            prev_lb = self._prev_low_battery_set
+            self._prev_low_battery_set = current_lb
+
+            if current_lb != prev_lb:
+                if not (current != prev):
+                    # Build device_map if not already built above.
+                    device_map = {}
+                    for coord in coords:
+                        for d in coord.device_states.values():
+                            if d.entity_id not in device_map:
+                                device_map[d.entity_id] = d
+
+                group_name = self._entry.data.get(CONF_GROUP_NAME, "")
+                entry_id = self._entry.entry_id
+                low_battery_list = sorted(current_lb)
+                low_battery_count = len(current_lb)
+
+                for eid in sorted(current_lb - prev_lb):
+                    d = device_map.get(eid)
+                    self.hass.bus.async_fire(
+                        EVENT_LOW_BATTERY,
+                        {
+                            "entity_id": eid,
+                            "group": group_name,
+                            "entry_id": entry_id,
+                            "battery_level": d.battery_level if d else None,
+                            "low_battery_count": low_battery_count,
+                            "low_battery_entities": low_battery_list,
+                        },
+                    )
+                for eid in sorted(prev_lb - current_lb):
+                    d = device_map.get(eid)
+                    self.hass.bus.async_fire(
+                        EVENT_BATTERY_OK,
+                        {
+                            "entity_id": eid,
+                            "group": group_name,
+                            "entry_id": entry_id,
+                            "battery_level": d.battery_level if d else None,
+                            "low_battery_count": low_battery_count,
+                            "low_battery_entities": low_battery_list,
+                        },
+                    )
+
             if self._ea_should_write():
                 self.async_write_ha_state()
 
@@ -297,12 +345,27 @@ class CombinedGroupSensor(CombinedSensorBase):
             eid for eid, d in seen.items() if d.is_offline and not d.is_suppressed
         )
 
+    def _current_low_battery_set(
+        self, coords: list[EntityAvailabilityCoordinator]
+    ) -> frozenset[str]:
+        """Return deduplicated set of low-battery, non-suppressed entity IDs."""
+        seen: dict[str, Any] = {}
+        for coord in coords:
+            for d in coord.device_states.values():
+                if d.entity_id not in seen:
+                    seen[d.entity_id] = d
+        return frozenset(
+            eid for eid, d in seen.items() if d.is_low_battery and not d.is_suppressed
+        )
+
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         # Prime _prev_offline_set using the same dedup logic as _on_update so the
         # two code paths can't diverge. Must happen after super() subscribes so
         # _active_coordinators() returns the full list.
-        self._prev_offline_set = self._current_offline_set(self._active_coordinators())
+        coords = self._active_coordinators()
+        self._prev_offline_set = self._current_offline_set(coords)
+        self._prev_low_battery_set = self._current_low_battery_set(coords)
 
     @property
     def native_value(self) -> int:

--- a/custom_components/entity_availability/const.py
+++ b/custom_components/entity_availability/const.py
@@ -53,6 +53,8 @@ SERVICE_RESET_STATISTICS = "reset_statistics"
 # Bus events fired on entity availability transitions
 EVENT_OFFLINE = "entity_availability_offline"
 EVENT_RECOVERED = "entity_availability_recovered"
+EVENT_LOW_BATTERY = "entity_availability_low_battery"
+EVENT_BATTERY_OK = "entity_availability_battery_ok"
 
 # Sentinel area name for entities with no HA area assigned.
 # Parentheses signal "not a real area" and avoid colliding with user-created area names.

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -32,6 +32,8 @@ from .const import (
     DEFAULT_RECOVERY_WINDOW,
     DEFAULT_STALENESS_THRESHOLD,
     DEFAULT_STALENESS_USE_LAST_UPDATED,
+    EVENT_BATTERY_OK,
+    EVENT_LOW_BATTERY,
     EVENT_OFFLINE,
     EVENT_RECOVERED,
     SCAN_INTERVAL,
@@ -638,7 +640,40 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
 
             # Degraded = not offline but battery low or stale
             device.is_stale = is_stale
-            device.is_low_battery = battery_low
+            if battery_low and not device.is_low_battery:
+                device.is_low_battery = True
+                low_battery_ids = self._low_battery_entity_ids()
+                pending_events.append(
+                    (
+                        EVENT_LOW_BATTERY,
+                        {
+                            "entity_id": entity_id,
+                            "group": self.group_name,
+                            "entry_id": self.entry.entry_id,
+                            "battery_level": device.battery_level,
+                            "low_battery_count": len(low_battery_ids),
+                            "low_battery_entities": low_battery_ids,
+                        },
+                    )
+                )
+            elif not battery_low and device.is_low_battery:
+                device.is_low_battery = False
+                low_battery_ids = self._low_battery_entity_ids()
+                pending_events.append(
+                    (
+                        EVENT_BATTERY_OK,
+                        {
+                            "entity_id": entity_id,
+                            "group": self.group_name,
+                            "entry_id": self.entry.entry_id,
+                            "battery_level": device.battery_level,
+                            "low_battery_count": len(low_battery_ids),
+                            "low_battery_entities": low_battery_ids,
+                        },
+                    )
+                )
+            else:
+                device.is_low_battery = battery_low
             device.is_degraded = (not device.is_offline) and (battery_low or is_stale)
 
         # Mark as dirty; save periodically (every ~5 min)
@@ -672,6 +707,14 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
             eid
             for eid, d in self._device_states.items()
             if d.is_offline and not d.is_suppressed
+        ]
+
+    def _low_battery_entity_ids(self) -> list[str]:
+        """Return entity_ids that are currently low-battery and not suppressed, in insertion order."""
+        return [
+            eid
+            for eid, d in self._device_states.items()
+            if d.is_low_battery and not d.is_suppressed
         ]
 
     def _get_battery_level(self, entity_id: str) -> int | None:

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -38,6 +38,8 @@ What is tested (covers PRs #37, #41, #50, #52, #53, core):
   EC19 PR#53: combined config entry has non-empty entry_id (event payload source)
   EC20 PR#53: individual group offline_count sensor rises when entity in combined group goes offline
   EC21 PR#53: individual and combined offline_entities sensors both reflect the offline entity
+  EC22 PR#54: entity_availability_low_battery event fires when battery drops below threshold
+  EC23 PR#54: entity_availability_battery_ok event fires when battery recovers above threshold
 """
 
 import json
@@ -1033,6 +1035,96 @@ for e in cfg['data']['entries']:
                 wait()
         else:
             print("  EC19-EC21: skipped (no combined group found)", flush=True)
+
+    # ------------------------------------------------------------------
+    # EC22 / EC23: low-battery bus events
+    # Smoke can't subscribe to the event bus via REST, so we verify the
+    # low_battery_count sensor transitions as a proxy — the coordinator only
+    # mutates that state when it fires the event, so a sensor change confirms
+    # the event was fired.
+    # ------------------------------------------------------------------
+    if ec_enabled(22) and battery_sensor and battery_entity:
+        restore_all(ctx)
+        wait()
+        print(
+            "\n=== EC22: entity_availability_low_battery event proxy (sensor transition) ===",
+            flush=True,
+        )
+        baseline = gs(f"{prefix}_low_battery_count").get("state", "0")
+        ss(
+            battery_sensor,
+            low_val,
+            {
+                "friendly_name": "Test Battery",
+                "device_class": "battery",
+                "unit_of_measurement": "%",
+            },
+        )
+        after = wait_for(
+            lambda: gs(f"{prefix}_low_battery_count").get("state"),
+            str(int(baseline) + 1),
+            timeout=90,
+        )
+        chk(
+            "EC22 low_battery_count rose (low_battery event fired)",
+            after,
+            str(int(baseline) + 1),
+            f"baseline={baseline} after={after}",
+        )
+        lb_attrs = gs(f"{prefix}_low_battery").get("attributes", {})
+        chk(
+            "EC22 battery_entity in low_battery_entities",
+            battery_entity in lb_attrs.get("devices", {}),
+            True,
+            f"devices={lb_attrs.get('devices')}",
+        )
+
+    if ec_enabled(23) and battery_sensor and battery_entity:
+        if not ec_enabled(22):
+            # Drive into low-battery state first
+            ss(
+                battery_sensor,
+                low_val,
+                {
+                    "friendly_name": "Test Battery",
+                    "device_class": "battery",
+                    "unit_of_measurement": "%",
+                },
+            )
+            wait_for(
+                lambda: gs(f"{prefix}_low_battery_count").get("state"),
+                "1",
+                timeout=90,
+            )
+        print(
+            "\n=== EC23: entity_availability_battery_ok event proxy (sensor transition) ===",
+            flush=True,
+        )
+        high_val = "90"
+        ss(
+            battery_sensor,
+            high_val,
+            {
+                "friendly_name": "Test Battery",
+                "device_class": "battery",
+                "unit_of_measurement": "%",
+            },
+        )
+        after_ok = wait_for(
+            lambda: gs(f"{prefix}_low_battery_count").get("state"),
+            "0",
+            timeout=90,
+        )
+        chk(
+            "EC23 low_battery_count dropped to 0 (battery_ok event fired)",
+            after_ok,
+            "0",
+            f"after={after_ok}",
+        )
+        restore_all(ctx)
+        wait()
+    elif ec_enabled(22) or ec_enabled(23):
+        print("  EC22-EC23: skipped (no battery sensor configured)", flush=True)
 
     # ------------------------------------------------------------------
     print("\n=== CLEANUP ===", flush=True)

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -39,6 +39,8 @@ from custom_components.entity_availability.const import (
     DOMAIN,
     ENTRY_TYPE_COMBINED,
     ENTRY_TYPE_GROUP,
+    EVENT_BATTERY_OK,
+    EVENT_LOW_BATTERY,
 )
 from custom_components.entity_availability.coordinator import (
     EntityAvailabilityCoordinator,
@@ -962,6 +964,159 @@ class TestCombinedGroupSensor:
         # offline_since must be a non-None ISO string (fixture sets it)
         assert data["offline_since"] is not None
         assert isinstance(data["offline_since"], str)
+
+    async def test_fires_low_battery_event_when_entity_goes_low(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """entity_availability_low_battery fires when low-battery set grows."""
+        sensor, fired_cbs = self._setup_event_sensor(
+            mock_hass, combined_entry, coordinators
+        )
+        await sensor.async_added_to_hass()
+        sensor._prev_low_battery_set = frozenset()
+
+        events = []
+        mock_hass.bus.async_listen(EVENT_LOW_BATTERY, lambda e: events.append(e))
+
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = True
+        coordinators[0]._device_states["binary_sensor.a1"].battery_level = 8
+        fired_cbs[0]()
+        await mock_hass.async_block_till_done()
+
+        assert len(events) == 1
+        data = events[0].data
+        assert data["entity_id"] == "binary_sensor.a1"
+        assert data["group"] == "Combined"
+        assert data["entry_id"] == "combined_1"
+        assert data["battery_level"] == 8
+        assert data["low_battery_count"] == 1
+        assert "binary_sensor.a1" in data["low_battery_entities"]
+
+    async def test_fires_battery_ok_event_when_entity_recovers(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """entity_availability_battery_ok fires when low-battery set shrinks."""
+        sensor, fired_cbs = self._setup_event_sensor(
+            mock_hass, combined_entry, coordinators
+        )
+        await sensor.async_added_to_hass()
+        sensor._prev_low_battery_set = frozenset(["binary_sensor.a1"])
+
+        events = []
+        mock_hass.bus.async_listen(EVENT_BATTERY_OK, lambda e: events.append(e))
+
+        # a1 no longer low battery
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = False
+        coordinators[0]._device_states["binary_sensor.a1"].battery_level = 75
+        fired_cbs[0]()
+        await mock_hass.async_block_till_done()
+
+        assert len(events) == 1
+        data = events[0].data
+        assert data["entity_id"] == "binary_sensor.a1"
+        assert data["battery_level"] == 75
+        assert data["low_battery_count"] == 0
+        assert data["low_battery_entities"] == []
+
+    async def test_no_low_battery_event_when_set_unchanged(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """No event fires when low-battery set is identical across ticks."""
+        sensor, fired_cbs = self._setup_event_sensor(
+            mock_hass, combined_entry, coordinators
+        )
+        await sensor.async_added_to_hass()
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = True
+        # Prime to current state — set unchanged
+        sensor._prev_low_battery_set = frozenset(["binary_sensor.a1"])
+
+        events = []
+        mock_hass.bus.async_listen(EVENT_LOW_BATTERY, lambda e: events.append(e))
+        mock_hass.bus.async_listen(EVENT_BATTERY_OK, lambda e: events.append(e))
+
+        fired_cbs[0]()
+        await mock_hass.async_block_till_done()
+
+        assert events == []
+
+    async def test_no_spurious_low_battery_event_on_startup(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """No event fires on first tick when low-battery entity was already low before subscribe."""
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = True
+        sensor, fired_cbs = self._setup_event_sensor(
+            mock_hass, combined_entry, coordinators
+        )
+        await sensor.async_added_to_hass()
+
+        events = []
+        mock_hass.bus.async_listen(EVENT_LOW_BATTERY, lambda e: events.append(e))
+
+        fired_cbs[0]()
+        await mock_hass.async_block_till_done()
+
+        assert events == [], "Spurious low-battery event fired for pre-existing state"
+
+    async def test_fan_out_two_entities_low_battery_simultaneously(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Two entities going low in one tick fire two separate events."""
+        sensor, fired_cbs = self._setup_event_sensor(
+            mock_hass, combined_entry, coordinators
+        )
+        await sensor.async_added_to_hass()
+        sensor._prev_low_battery_set = frozenset()
+
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = True
+        coordinators[0]._device_states["binary_sensor.a1"].battery_level = 5
+        coordinators[1]._device_states["binary_sensor.b1"].is_low_battery = True
+        coordinators[1]._device_states["binary_sensor.b1"].battery_level = 9
+
+        events = []
+        mock_hass.bus.async_listen(EVENT_LOW_BATTERY, lambda e: events.append(e))
+
+        fired_cbs[0]()
+        await mock_hass.async_block_till_done()
+
+        assert len(events) == 2
+        entity_ids = {e.data["entity_id"] for e in events}
+        assert entity_ids == {"binary_sensor.a1", "binary_sensor.b1"}
+        for e in events:
+            assert e.data["low_battery_count"] == 2
+            assert set(e.data["low_battery_entities"]) == {
+                "binary_sensor.a1",
+                "binary_sensor.b1",
+            }
+
+    async def test_low_battery_payload_matches_offline_shape(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """Low-battery event has entity_id, group, entry_id, battery_level, low_battery_count, low_battery_entities."""
+        sensor, fired_cbs = self._setup_event_sensor(
+            mock_hass, combined_entry, coordinators
+        )
+        await sensor.async_added_to_hass()
+        sensor._prev_low_battery_set = frozenset()
+
+        coordinators[0]._device_states["binary_sensor.a1"].is_low_battery = True
+        coordinators[0]._device_states["binary_sensor.a1"].battery_level = 12
+
+        events = []
+        mock_hass.bus.async_listen(EVENT_LOW_BATTERY, lambda e: events.append(e))
+
+        fired_cbs[0]()
+        await mock_hass.async_block_till_done()
+
+        assert len(events) == 1
+        data = events[0].data
+        assert set(data.keys()) >= {
+            "entity_id",
+            "group",
+            "entry_id",
+            "battery_level",
+            "low_battery_count",
+            "low_battery_entities",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3232,7 +3232,9 @@ async def test_bus_events_low_battery_multi_entity_count(
         await hass.async_block_till_done()
 
         assert len(events) == 2
-        # First event: only device_a was low at fire time (device_b not yet set)
+        # Both battery levels set before the update; device_a fires first because
+        # _device_states preserves insertion order (device_a added first).
+        # When device_a's event fires, device_b's is_low_battery is not yet set.
         first = events[0]
         assert first.data["entity_id"] == "binary_sensor.device_a"
         assert first.data["low_battery_count"] == 1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3084,6 +3084,169 @@ async def test_bus_events_suppressed_entity_excluded(
         assert last_evt.data["offline_entities"] == ["binary_sensor.device_b"]
 
 
+async def test_bus_events_low_battery_transition(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """entity_availability_low_battery fires when battery drops below threshold."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_ON)
+
+    low_battery_events: list = []
+    battery_ok_events: list = []
+    hass.bus.async_listen(
+        "entity_availability_low_battery", lambda e: low_battery_events.append(e)
+    )
+    hass.bus.async_listen(
+        "entity_availability_battery_ok", lambda e: battery_ok_events.append(e)
+    )
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+        device_a = coord.device_states["binary_sensor.device_a"]
+        assert device_a.is_low_battery is False
+
+        # Simulate battery dropping below threshold
+        device_a.battery_level = 10
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+
+        assert device_a.is_low_battery is True
+        assert len(low_battery_events) == 1
+        data = low_battery_events[0].data
+        assert data["entity_id"] == "binary_sensor.device_a"
+        assert data["group"] == "Test Group"
+        assert data["entry_id"] == mock_config_entry.entry_id
+        assert data["battery_level"] == 10
+        assert data["low_battery_count"] == 1
+        assert "binary_sensor.device_a" in data["low_battery_entities"]
+        assert battery_ok_events == []
+
+        # Simulate battery recovering above threshold
+        device_a.battery_level = 80
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+
+        assert device_a.is_low_battery is False
+        assert len(battery_ok_events) == 1
+        ok_data = battery_ok_events[0].data
+        assert ok_data["entity_id"] == "binary_sensor.device_a"
+        assert ok_data["battery_level"] == 80
+        assert ok_data["low_battery_count"] == 0
+        assert ok_data["low_battery_entities"] == []
+
+
+async def test_bus_events_low_battery_no_refire_when_unchanged(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """No low-battery event fires when battery stays low across updates."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_ON)
+
+    events: list = []
+    hass.bus.async_listen("entity_availability_low_battery", lambda e: events.append(e))
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+        device_a = coord.device_states["binary_sensor.device_a"]
+        device_a.battery_level = 10
+        # First update: fires the event
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+        assert len(events) == 1
+        # Second update with same low battery: no second event
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+        assert len(events) == 1
+
+
+async def test_bus_events_low_battery_suppressed_excluded(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Suppressed entities do not appear in low_battery_entities payload."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_ON)
+    hass.states.async_set("binary_sensor.device_b", STATE_ON)
+
+    events: list = []
+    hass.bus.async_listen("entity_availability_low_battery", lambda e: events.append(e))
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+        device_a = coord.device_states["binary_sensor.device_a"]
+        device_b = coord.device_states["binary_sensor.device_b"]
+
+        # Suppress device_a, then both go low battery
+        coord.suppress_entity("binary_sensor.device_a")
+        device_a.battery_level = 5
+        device_b.battery_level = 8
+
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+
+        assert device_b.is_low_battery is True
+        # Only device_b fires an event; suppressed device_a is excluded
+        assert len(events) == 1
+        data = events[0].data
+        assert data["entity_id"] == "binary_sensor.device_b"
+        assert "binary_sensor.device_a" not in data["low_battery_entities"]
+
+
+async def test_bus_events_low_battery_multi_entity_count(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """low_battery_count reflects all low-battery devices at fire time."""
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", STATE_ON)
+    hass.states.async_set("binary_sensor.device_b", STATE_ON)
+
+    events: list = []
+    hass.bus.async_listen("entity_availability_low_battery", lambda e: events.append(e))
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, mock_config_entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+        device_a = coord.device_states["binary_sensor.device_a"]
+        device_b = coord.device_states["binary_sensor.device_b"]
+        device_a.battery_level = 10
+        device_b.battery_level = 12
+
+        await coord._async_update_data()
+        await hass.async_block_till_done()
+
+        assert len(events) == 2
+        # First event: only device_a was low at fire time (device_b not yet set)
+        first = events[0]
+        assert first.data["entity_id"] == "binary_sensor.device_a"
+        assert first.data["low_battery_count"] == 1
+        assert first.data["low_battery_entities"] == ["binary_sensor.device_a"]
+        # Second event: both low
+        second = events[1]
+        assert second.data["entity_id"] == "binary_sensor.device_b"
+        assert second.data["low_battery_count"] == 2
+        assert set(second.data["low_battery_entities"]) == {
+            "binary_sensor.device_a",
+            "binary_sensor.device_b",
+        }
+
+
 async def test_suppressed_entity_clears_offline_while_suppressed(
     mock_hass: HomeAssistant, mock_config_entry
 ) -> None:


### PR DESCRIPTION
## Summary

- Adds `entity_availability_low_battery` and `entity_availability_battery_ok` bus events fired on battery threshold transitions
- Full parity with offline/recovered event shape: `{entity_id, group, entry_id, battery_level, low_battery_count, low_battery_entities}`
- Both individual groups (coordinator) and combined groups (`CombinedGroupSensor`) fire events
- `_prev_low_battery_set` tracks transitions in combined groups, same pattern as `_prev_offline_set`
- Coordinator mutates `is_low_battery` before calling `_low_battery_entity_ids()` so counts are accurate at fire time

## Test plan

- [ ] `test_bus_events_low_battery_transition` — fires on drop, fires battery_ok on recovery, payload correct
- [ ] `test_bus_events_low_battery_no_refire_when_unchanged` — no duplicate events when battery stays low
- [ ] `test_bus_events_low_battery_suppressed_excluded` — suppressed entities excluded from count/list
- [ ] `test_bus_events_low_battery_multi_entity_count` — count/list reflects state at each fire time
- [ ] `test_fires_low_battery_event_when_entity_goes_low` — combined group path
- [ ] `test_fires_battery_ok_event_when_entity_recovers` — combined group path
- [ ] `test_no_low_battery_event_when_set_unchanged` — no spurious events on identical set
- [ ] `test_no_spurious_low_battery_event_on_startup` — priming suppresses first-tick noise
- [ ] `test_fan_out_two_entities_low_battery_simultaneously` — two entities, two events, correct snapshot
- [ ] `test_low_battery_payload_matches_offline_shape` — all required keys present