### PR TITLE
fix(card): non-essential indicator, stale/offline overlap, compact stale, cache-bust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to this project will be documented in this file.
 - Battery mapping no longer re-populates cleared entries on edit
 - Low battery flag preserved when device also goes offline
 - Card: space key no longer scrolls page when entity row is focused
+- Card: non-essential entity indicator icon (◌) now renders correctly when `show_non_essential_stats` is off (default) — entities appeared in list without the icon
+- Card: compact render stale count now correctly reads `stale_entities` array length for regular groups (was always 0, so stale entities never triggered "Degraded" status in compact mode)
+- Sensor: `stale_entities` / `stale_entities_non_essential` attributes now exclude offline entities — offline entities with old timestamps were incorrectly included, causing them to show "just now" on the card instead of their actual offline duration
+- Card: Lovelace resource URL now updates on HACS upgrade without requiring a full HA restart
 
 ### Changed
 - Card entity rows and combined group rows are clickable (opens more-info dialog)

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ Selecting a combined group hides editor controls that don't apply (availability 
 ┌───────────────────────────────────────────────┐
 │ ✓ Security Devices                    All OK  │
 ├───────────────────────────────────────────────┤
-│   Online: 4   Offline: 1   Stale: 1   Low Battery: 1     │
+│   Online: 4   Offline: 1   Stale: 1   Low Bat: 1  │
 ├───────────────────────────────────────────────┤
 │  Today   ██████████████████████░░░░   98.2%   │
 │  7 Days  ████████████████████░░░░░░   95.1%   │

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ Selecting a combined group hides editor controls that don't apply (availability 
 ┌───────────────────────────────────────────────┐
 │ ✓ Security Devices                    All OK  │
 ├───────────────────────────────────────────────┤
-│   Online: 4  Offline: 1  Stale: 1  Bat: 1   │
+│    Online: 4  Offline: 1  Stale: 1  Bat: 1    │
 ├───────────────────────────────────────────────┤
 │  Today   ██████████████████████░░░░   98.2%   │
 │  7 Days  ████████████████████░░░░░░   95.1%   │

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ Selecting a combined group hides editor controls that don't apply (availability 
 ┌───────────────────────────────────────────────┐
 │ ✓ Security Devices                    All OK  │
 ├───────────────────────────────────────────────┤
-│   Online: 4   Offline: 1   Stale: 1   Low Bat: 1  │
+│   Online: 4  Offline: 1  Stale: 1  Bat: 1   │
 ├───────────────────────────────────────────────┤
 │  Today   ██████████████████████░░░░   98.2%   │
 │  7 Days  ████████████████████░░░░░░   95.1%   │

--- a/custom_components/entity_availability/__init__.py
+++ b/custom_components/entity_availability/__init__.py
@@ -79,8 +79,10 @@ async def _async_install_card(hass: HomeAssistant) -> None:
     if domain_data.get(_CARD_INSTALLED_KEY) == version:
         return
 
-    # Claim the slot before first await to prevent TOCTOU race when multiple
-    # entries finish setup concurrently — only one proceeds past this point.
+    # Claim the slot before proceeding so concurrent entry setups skip this
+    # block. Two racing callers may both read version before either claims, but
+    # static-path registration and Lovelace resource update are both idempotent
+    # so a duplicate run is harmless.
     domain_data[_CARD_INSTALLED_KEY] = version
 
     source = Path(__file__).parent / "frontend" / CARD_FILENAME

--- a/custom_components/entity_availability/__init__.py
+++ b/custom_components/entity_availability/__init__.py
@@ -75,20 +75,19 @@ async def _async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None
 async def _async_install_card(hass: HomeAssistant) -> None:
     """Serve card JS from component dir and register as Lovelace resource."""
     domain_data = hass.data.setdefault(DOMAIN, {})
-    if domain_data.get(_CARD_INSTALLED_KEY):
+    version = await hass.async_add_executor_job(_get_version)
+    if domain_data.get(_CARD_INSTALLED_KEY) == version:
         return
 
     # Claim the slot before first await to prevent TOCTOU race when multiple
     # entries finish setup concurrently — only one proceeds past this point.
-    domain_data[_CARD_INSTALLED_KEY] = True
+    domain_data[_CARD_INSTALLED_KEY] = version
 
     source = Path(__file__).parent / "frontend" / CARD_FILENAME
     if not source.exists():
         _LOGGER.warning("Card JS not found at %s", source)
         domain_data.pop(_CARD_INSTALLED_KEY, None)
         return
-
-    version = await hass.async_add_executor_job(_get_version)
 
     try:
         await hass.http.async_register_static_paths(

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -704,7 +704,7 @@ class EntityAvailabilityCard extends LitElement {
       const lowBattery = attrs.low_battery || 0;
       const suppressed = attrs.suppressed || 0;
       const nonEssential = attrs.non_essential || 0;
-      const staleCount = attrs.stale || 0;
+      const staleCount = (attrs.stale_entities || []).length || attrs.stale || 0;
       const groups = attrs.groups || {};
 
       const statusColor = offline > 0 ? "red" : (lowBattery > 0 || staleCount > 0) ? "yellow" : "green";
@@ -785,7 +785,7 @@ class EntityAvailabilityCard extends LitElement {
         ${this._config.show_affected_areas ? this._renderAffectedAreas(prefix) : nothing}
         ${this._renderSuppressedBanner(suppressed, showNEStats ? nonEssentialSuppressed : 0)}
         ${this._config.show_availability ? this._renderAvailability(prefix) : nothing}
-        ${this._config.show_entities ? this._renderEntityList(entities.filter(e => showNEStats || !nonEssentialEntities.includes(e)), batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames, showNEStats ? nonEssentialEntities : [], showNEStats ? nonEssentialOfflineEntities : [], showNEStats ? staleEntitiesNonEssential : []) : nothing}
+        ${this._config.show_entities ? this._renderEntityList(entities.filter(e => showNEStats || !nonEssentialEntities.includes(e)), batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames, nonEssentialEntities, showNEStats ? nonEssentialOfflineEntities : [], showNEStats ? staleEntitiesNonEssential : []) : nothing}
         ${this._config.show_actions ? this._renderActions(prefix) : nothing}
       </ha-card>
     `;

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -774,7 +774,6 @@ class EntityAvailabilityCard extends LitElement {
       : "All OK";
 
     const showNEStats = this._config.show_non_essential_stats === true && nonEssential > 0;
-    const visibleNonEssentialEntities = showNEStats ? nonEssentialEntities : [];
 
     return html`
       <ha-card class="${compactClass}">

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -1046,12 +1046,18 @@ class GroupSummarySensor(DedupCoordinatorSensor):
             "stale_entities": [
                 eid
                 for eid, d in states.items()
-                if d.is_stale and not d.is_suppressed and not d.is_non_essential
+                if d.is_stale
+                and not d.is_suppressed
+                and not d.is_non_essential
+                and not d.is_offline
             ],
             "stale_entities_non_essential": [
                 eid
                 for eid, d in states.items()
-                if d.is_stale and not d.is_suppressed and d.is_non_essential
+                if d.is_stale
+                and not d.is_suppressed
+                and d.is_non_essential
+                and not d.is_offline
             ],
             "offline_since": {
                 eid: d.offline_since.isoformat()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -321,21 +321,53 @@ async def test_async_update_options_reloads_entry(
 async def test_async_install_card_skips_when_already_installed(
     mock_hass: HomeAssistant,
 ) -> None:
-    """_async_install_card returns early when the card is already installed."""
+    """_async_install_card returns early when the card is already installed (same version)."""
     from custom_components.entity_availability import (
         _CARD_INSTALLED_KEY,
         _async_install_card,
     )
 
     hass = mock_hass
-    hass.data.setdefault(DOMAIN, {})[_CARD_INSTALLED_KEY] = True
+    hass.data.setdefault(DOMAIN, {})[_CARD_INSTALLED_KEY] = "0.3.14"
 
-    with patch(
-        "custom_components.entity_availability._async_register_lovelace_resource",
-        new_callable=AsyncMock,
-    ) as mock_register:
+    with (
+        patch(
+            "custom_components.entity_availability._get_version", return_value="0.3.14"
+        ),
+        patch(
+            "custom_components.entity_availability._async_register_lovelace_resource",
+            new_callable=AsyncMock,
+        ) as mock_register,
+    ):
         await _async_install_card(hass)
         mock_register.assert_not_called()
+
+
+async def test_async_install_card_reruns_on_version_change(
+    mock_hass: HomeAssistant,
+) -> None:
+    """_async_install_card re-registers the resource when the version changes (HACS upgrade)."""
+    from custom_components.entity_availability import (
+        _CARD_INSTALLED_KEY,
+        _async_install_card,
+    )
+
+    hass = mock_hass
+    hass.data.setdefault(DOMAIN, {})[_CARD_INSTALLED_KEY] = "0.3.13"
+
+    with (
+        patch(
+            "custom_components.entity_availability._get_version", return_value="0.3.14"
+        ),
+        patch(
+            "custom_components.entity_availability._async_register_lovelace_resource",
+            new_callable=AsyncMock,
+        ) as mock_register,
+        patch("custom_components.entity_availability.Path.exists", return_value=True),
+    ):
+        await _async_install_card(hass)
+        mock_register.assert_called_once()
+        assert hass.data[DOMAIN][_CARD_INSTALLED_KEY] == "0.3.14"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2981,6 +2981,31 @@ class TestNonEssentialKpiExclusion:
         attrs = sensor.extra_state_attributes
         assert "binary_sensor.device_a" not in attrs["stale_entities_non_essential"]
 
+    def test_stale_entities_includes_stale_online(self, mock_coordinator, mock_hass):
+        """GroupSummarySensor: stale+not-offline essential entity appears in stale_entities."""
+        mock_coordinator.device_states["binary_sensor.device_a"].is_stale = True
+        mock_coordinator.device_states["binary_sensor.device_a"].is_offline = False
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert "binary_sensor.device_a" in attrs["stale_entities"]
+
+    def test_stale_entities_non_essential_includes_stale_online(
+        self, mock_coordinator, mock_hass
+    ):
+        """GroupSummarySensor: stale+not-offline NE entity appears in stale_entities_non_essential."""
+        mock_coordinator.device_states["binary_sensor.device_a"].is_stale = True
+        mock_coordinator.device_states["binary_sensor.device_a"].is_offline = False
+        mock_coordinator.device_states["binary_sensor.device_a"].is_non_essential = True
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert "binary_sensor.device_a" in attrs["stale_entities_non_essential"]
+
 
 class TestNonEssentialAndStaleSensors:
     """Tests for the dedicated non-essential and stale sensor entities."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2956,6 +2956,31 @@ class TestNonEssentialKpiExclusion:
         attrs = sensor.extra_state_attributes
         assert "binary_sensor.device_a" not in attrs["stale_entities"]
 
+    def test_stale_entities_excludes_offline(self, mock_coordinator, mock_hass):
+        """GroupSummarySensor: stale_entities excludes entities that are also offline."""
+        mock_coordinator.device_states["binary_sensor.device_a"].is_stale = True
+        mock_coordinator.device_states["binary_sensor.device_a"].is_offline = True
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert "binary_sensor.device_a" not in attrs["stale_entities"]
+
+    def test_stale_entities_non_essential_excludes_offline(
+        self, mock_coordinator, mock_hass
+    ):
+        """GroupSummarySensor: stale_entities_non_essential excludes offline entities."""
+        mock_coordinator.device_states["binary_sensor.device_a"].is_stale = True
+        mock_coordinator.device_states["binary_sensor.device_a"].is_offline = True
+        mock_coordinator.device_states["binary_sensor.device_a"].is_non_essential = True
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert "binary_sensor.device_a" not in attrs["stale_entities_non_essential"]
+
 
 class TestNonEssentialAndStaleSensors:
     """Tests for the dedicated non-essential and stale sensor entities."""


### PR DESCRIPTION
Fixes four bugs reported in #34 after upgrading from 0.3.14-beta.8 → 0.3.14 stable.

## Bugs fixed

**Non-essential indicator missing** (`card.js:788`)
`_renderEntityList` received `[]` for `nonEssentialEntities` when `show_non_essential_stats` is off (default). `isNonEssential` was never set true, so the ◌ icon never rendered and non-essential entities appeared as normal entities in the list.

**Stale entities showing "just now"** (`sensor.py:1046-1055`)
`stale_entities` / `stale_entities_non_essential` attributes included offline entities that also had old timestamps. The card hits the `isOffline` branch first → shows "just now" instead of the actual offline duration. Pattern now matches `low_battery_entities` which already excluded offline.

**Compact stale count always 0** (`card.js:707`)
Compact/combined render read `attrs.stale` — regular group sensors expose `stale_entities` (array), not `stale`. Stale entities never triggered "Degraded" status/color in compact mode. Reads `stale_entities.length` with `attrs.stale` as fallback for combined groups.

**Card not updated after HACS upgrade without restart** (`__init__.py:75`)
`_CARD_INSTALLED_KEY` stored `True`; after a HACS upgrade without HA restart the guard prevented re-registration, browser continued serving cached old card JS. Now stores the version string — guard skips only when installed version matches current.

## Tests

- `test_stale_entities_excludes_offline` — new
- `test_stale_entities_non_essential_excludes_offline` — new
- `test_async_install_card_skips_when_already_installed` — updated (guard now version string)
- `test_async_install_card_reruns_on_version_change` — new
- 699 unit tests pass, `sensor.py` 100% branch + line coverage