### PR TITLE
fix(coordinator): skip battery lookup when threshold is zero

### DIFF
--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -498,7 +498,7 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
             is_bad = state is None or state.state in self._bad_states
 
             # Battery check — retain last-known level when entity is unavailable
-            fresh_level = self._get_battery_level(entity_id)
+            fresh_level = self._get_battery_level(entity_id) if self._battery_threshold > 0 else None
             if fresh_level is not None:
                 device.battery_level = fresh_level
             battery_low = (

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -498,7 +498,11 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
             is_bad = state is None or state.state in self._bad_states
 
             # Battery check — retain last-known level when entity is unavailable
-            fresh_level = self._get_battery_level(entity_id) if self._battery_threshold > 0 else None
+            fresh_level = (
+                self._get_battery_level(entity_id)
+                if self._battery_threshold > 0
+                else None
+            )
             if fresh_level is not None:
                 device.battery_level = fresh_level
             battery_low = (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1954,6 +1954,41 @@ async def test_debounced_refresh_callback_creates_task(
 
 
 # ---------------------------------------------------------------------------
+# battery_threshold == 0 — battery lookup skipped entirely
+# ---------------------------------------------------------------------------
+
+
+async def test_battery_not_populated_when_threshold_zero(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """When battery_threshold=0, battery_level stays None even if HA has battery state."""
+    from custom_components.entity_availability.const import CONF_BATTERY_THRESHOLD
+
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", "on", {"friendly_name": "Device A"})
+    # Z-Wave style auto-discovered battery
+    hass.states.async_set("sensor.device_a_battery", "42")
+
+    config = dict(mock_config_data)
+    config[CONF_BATTERY_THRESHOLD] = 0
+    entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Test Group",
+        data=config,
+        entry_id="bat_threshold_zero_entry",
+    )
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+    assert coord.device_states["binary_sensor.device_a"].battery_level is None
+
+
 # _get_battery_level — battery map entity present with valid state (lines 509-520)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,6 +14,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.entity_availability.const import (
     CONF_BATTERY_ENTITY_MAP,
+    CONF_BATTERY_THRESHOLD,
     CONF_ENTITIES,
     CONF_NON_ESSENTIAL_ENTITIES,
     CONF_STALENESS_THRESHOLD,
@@ -1961,9 +1962,7 @@ async def test_debounced_refresh_callback_creates_task(
 async def test_battery_not_populated_when_threshold_zero(
     mock_hass: HomeAssistant, mock_config_data
 ) -> None:
-    """When battery_threshold=0, battery_level stays None even if HA has battery state."""
-    from custom_components.entity_availability.const import CONF_BATTERY_THRESHOLD
-
+    """When battery_threshold=0, _get_battery_level is never called and battery_level stays None."""
     hass = mock_hass
     hass.states.async_set("binary_sensor.device_a", "on", {"friendly_name": "Device A"})
     # Z-Wave style auto-discovered battery
@@ -1984,8 +1983,12 @@ async def test_battery_not_populated_when_threshold_zero(
     ):
         coord = EntityAvailabilityCoordinator(hass, entry)
         coord._last_update = None
-        await coord._async_update_data()
+        with patch.object(
+            coord, "_get_battery_level", wraps=coord._get_battery_level
+        ) as mock_get:
+            await coord._async_update_data()
 
+    assert mock_get.call_count == 0
     assert coord.device_states["binary_sensor.device_a"].battery_level is None
 
 


### PR DESCRIPTION
## Summary

- When `battery_threshold=0` (feature disabled), coordinator still called `_get_battery_level` on every poll
- Z-Wave and other devices auto-expose battery sensors in HA, so `battery_level` got populated even though user never configured battery monitoring
- This caused the card to show a BAT column the user never asked for

**Fix:** gate `_get_battery_level` on `_battery_threshold > 0` — one line change in coordinator.

## Test plan

- [ ] New test `test_battery_not_populated_when_threshold_zero` — verifies `battery_level` stays `None` when threshold=0 even if HA has a battery sensor for the device
- [ ] 702 tests passing, 100% coverage on changed files