### PR TITLE
fix(card): stats order, responsive columns, header separator alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Added
-- **Card: combined table `show_group_total` config** (default on) — toggle to hide the Total column in the combined groups breakdown table
-- **Card: combined table `show_group_health` config** (default on) — toggle to hide the Bat. and Stale columns in the combined groups breakdown table
-
-### Fixed
-- Card: combined groups table — groups with battery/staleness feature disabled now show `—` instead of `0` in Bat./Stale columns (consistent with NE sub-row behaviour)
-- Card: combined groups table — stats row Low Battery / Stale order now matches table column order (Bat. before Stale)
-- Card: combined groups table — group name column uses `minmax(60px, 1fr)` and value columns use `minmax(36px, 56px)` so all columns stay visible on narrow screens (iPhone portrait/landscape)
-- Card: combined groups table — header separator borders now span full cell height (display: block), fixing misalignment vs data rows on narrow viewports
-
 ## [0.3.14] - 2026-08-02
 
 ### Added
@@ -23,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - **Card: Non-Essential stats row** (`show_non_essential_stats`, default off) — opt-in row for NE Online/Offline/Stale/Low Battery counts; NE entities sorted to bottom of entity list
 - **Card: Stale count chip** in stats row; hidden when zero
 - **Card: per-entity suppress toggle** (`show_suppress_toggle`, default off)
-- **Card: combined groups table** — Total column (entities per group), conditional Bat. and Stale columns (shown only when feature is enabled and count > 0)
+- **Card: combined groups table** — Total column (entities per group), conditional Bat. and Stale columns (shown only when feature is enabled and count > 0); `show_group_total` and `show_group_health` toggles to hide those columns
 - **Card: combined groups NE sub-row** (`show_non_essential_stats`, default off) — opt-in `↳ Non-Essential` sub-row per group showing NE total, Online/Offline and (when feature enabled) Bat./Stale counts; `show_non_essential_stats` toggle now available for combined card in config editor
 - **Combined sensor: per-group NE breakdown** — `groups` dict now includes `non_essential_online`, `non_essential_offline`, `non_essential_stale`, `non_essential_low_battery`, `battery_enabled`, `staleness_enabled` per group; `total` now excludes non-essential entities (matches Online/Offline scope)
 - **Sensor: `battery_enabled` / `staleness_enabled` attrs** — group summary and combined summary sensors now expose these boolean flags so the card hides battery/stale indicators when the feature is disabled (`threshold=0`), even if stale battery levels exist in entity state
@@ -43,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - Card: Lovelace resource URL now updates on HACS upgrade without requiring a full HA restart
 - **Card: "last seen" time resets to boot time after HA restart** — coordinator now seeds `last_changed` on first poll for all entities regardless of staleness config, persists it to storage, and the card hides the battery column when `battery_threshold=0`. Resolves #34.
 - **Card: battery/stale columns hidden when feature disabled** — setting `battery_threshold=0` or `staleness_threshold=0` now correctly suppresses those columns in both the entity list and combined groups table, even when battery levels exist in entity state.
+- Card: combined groups table — groups with feature disabled show `—` instead of `0` in Bat./Stale columns; stats row order now matches table (Low Battery before Stale); columns stay visible on narrow screens; header separator borders aligned with data rows
 
 ### Changed
 - Card entity rows and combined group rows are clickable (opens more-info dialog)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Card: combined table `show_group_total` config** (default on) — toggle to hide the Total column in the combined groups breakdown table
+- **Card: combined table `show_group_health` config** (default on) — toggle to hide the Bat. and Stale columns in the combined groups breakdown table
+
+### Fixed
+- Card: combined groups table — groups with battery/staleness feature disabled now show `—` instead of `0` in Bat./Stale columns (consistent with NE sub-row behaviour)
+- Card: combined groups table — stats row Low Battery / Stale order now matches table column order (Bat. before Stale)
+- Card: combined groups table — group name column uses `minmax(60px, 1fr)` and value columns use `minmax(36px, 56px)` so all columns stay visible on narrow screens (iPhone portrait/landscape)
+- Card: combined groups table — header separator borders now span full cell height (display: block), fixing misalignment vs data rows on narrow viewports
+
 ## [0.3.14] - 2026-08-02
 
 ### Added

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -679,6 +679,8 @@ class EntityAvailabilityCard extends LitElement {
       entity_filter: "all",
       show_affected_areas: false,
       show_non_essential_stats: false,
+      show_group_total: true,
+      show_group_health: true,
       ...config,
     };
     // backwards compat: show_entity_tooltips: true → entity_detail: "tooltip"
@@ -1005,14 +1007,16 @@ class EntityAvailabilityCard extends LitElement {
 
     const expanded = this._entitiesExpanded;
     const showNEStats = this._config.show_non_essential_stats === true;
+    const showTotal = this._config.show_group_total !== false;
+    const showHealth = this._config.show_group_health !== false;
     // Feature-enabled flags guard: battery/stale columns must NEVER appear when
     // the feature is disabled (threshold=0), even if counts are non-zero.
-    const hasBattery = batteryEnabled && entries.some(([, g]) => (g.low_battery ?? 0) > 0 || (showNEStats && g.battery_enabled && (g.non_essential_low_battery ?? 0) > 0));
-    const hasStale = stalenessEnabled && entries.some(([, g]) => (g.stale ?? 0) > 0 || (showNEStats && g.staleness_enabled && (g.non_essential_stale ?? 0) > 0));
+    const hasBattery = showHealth && batteryEnabled && entries.some(([, g]) => (g.low_battery ?? 0) > 0 || (showNEStats && g.battery_enabled && (g.non_essential_low_battery ?? 0) > 0));
+    const hasStale = showHealth && stalenessEnabled && entries.some(([, g]) => (g.stale ?? 0) > 0 || (showNEStats && g.staleness_enabled && (g.non_essential_stale ?? 0) > 0));
     // NE battery/stale columns: only show if at least one group has the feature enabled and NE counts > 0.
     const hasNEBattery = showNEStats && entries.some(([, g]) => g.battery_enabled && (g.non_essential_low_battery ?? 0) > 0);
     const hasNEStale = showNEStats && entries.some(([, g]) => g.staleness_enabled && (g.non_essential_stale ?? 0) > 0);
-    const extraCols = 3 + (hasBattery ? 1 : 0) + (hasStale ? 1 : 0);
+    const extraCols = (showTotal ? 1 : 0) + 2 + (hasBattery ? 1 : 0) + (hasStale ? 1 : 0);
     const gridStyle = `grid-template-columns: minmax(60px, 1fr) repeat(${extraCols}, minmax(36px, 56px))`;
 
     return html`
@@ -1024,8 +1028,8 @@ class EntityAvailabilityCard extends LitElement {
       <div class="group-breakdown ${expanded ? "expanded" : "collapsed"}">
         <div class="group-breakdown-row group-breakdown-header" style="${gridStyle}">
           <span>Group</span>
-          <span>Total</span>
-          <span class="sep">Online</span>
+          ${showTotal ? html`<span>Total</span>` : nothing}
+          <span class="${showTotal ? "sep" : ""}">Online</span>
           <span>Offline</span>
           ${hasBattery ? html`<span class="sep">Bat.</span>` : nothing}
           ${hasStale ? html`<span class="${!hasBattery ? "sep" : ""}">Stale</span>` : nothing}
@@ -1037,17 +1041,17 @@ class EntityAvailabilityCard extends LitElement {
             <div class="group-breakdown-row ${g.entity_id ? "clickable" : ""}" style="${gridStyle}"
                  @click=${g.entity_id ? (e) => this._handleEntityClick(e, g.entity_id) : nothing}>
               <span class="group-breakdown-name">${g.name ?? ""}</span>
-              <span class="group-breakdown-count neutral">${g.total ?? 0}</span>
-              <span class="group-breakdown-count sep online">${g.online ?? 0}</span>
+              ${showTotal ? html`<span class="group-breakdown-count neutral">${g.total ?? 0}</span>` : nothing}
+              <span class="group-breakdown-count ${showTotal ? "sep " : ""}online">${g.online ?? 0}</span>
               <span class="group-breakdown-count ${g.offline > 0 ? "offline" : "neutral"}">${g.offline ?? 0}</span>
-              ${hasBattery ? html`<span class="group-breakdown-count sep ${g.low_battery > 0 ? "battery" : "neutral"}">${g.low_battery ?? 0}</span>` : nothing}
-              ${hasStale ? html`<span class="group-breakdown-count ${!hasBattery ? "sep " : ""}${g.stale > 0 ? "stale" : "neutral"}">${g.stale ?? 0}</span>` : nothing}
+              ${hasBattery ? html`<span class="group-breakdown-count sep ${g.battery_enabled && (g.low_battery ?? 0) > 0 ? "battery" : "neutral"}">${g.battery_enabled ? (g.low_battery ?? 0) : "—"}</span>` : nothing}
+              ${hasStale ? html`<span class="group-breakdown-count ${!hasBattery ? "sep " : ""}${g.staleness_enabled && (g.stale ?? 0) > 0 ? "stale" : "neutral"}">${g.staleness_enabled ? (g.stale ?? 0) : "—"}</span>` : nothing}
             </div>
             ${showNERow ? html`
               <div class="group-breakdown-row group-breakdown-ne-row" style="${gridStyle}">
                 <span class="group-breakdown-name group-breakdown-ne-label">↳ Non-Essential</span>
-                <span class="group-breakdown-count neutral">${neCount}</span>
-                <span class="group-breakdown-count sep neutral">${g.non_essential_online ?? 0}</span>
+                ${showTotal ? html`<span class="group-breakdown-count neutral">${neCount}</span>` : nothing}
+                <span class="group-breakdown-count ${showTotal ? "sep " : ""}neutral">${g.non_essential_online ?? 0}</span>
                 <span class="group-breakdown-count ${(g.non_essential_offline ?? 0) > 0 ? "offline" : "neutral"}">${g.non_essential_offline ?? 0}</span>
                 ${hasBattery ? html`<span class="group-breakdown-count sep ${g.battery_enabled && hasNEBattery && (g.non_essential_low_battery ?? 0) > 0 ? "battery" : "neutral"}">${g.battery_enabled ? (g.non_essential_low_battery ?? 0) : "—"}</span>` : nothing}
                 ${hasStale ? html`<span class="group-breakdown-count ${!hasBattery ? "sep " : ""}${g.staleness_enabled && hasNEStale && (g.non_essential_stale ?? 0) > 0 ? "stale" : "neutral"}">${g.staleness_enabled ? (g.non_essential_stale ?? 0) : "—"}</span>` : nothing}
@@ -1679,6 +1683,28 @@ class EntityAvailabilityCardEditor extends LitElement {
             Show Non-Essential Stats Row &amp; Entities
           </label>
         </div>
+        ${this._isSelectedGroupCombined() ? html`
+        <div class="editor-row checkbox">
+          <label>
+            <input
+              type="checkbox"
+              .checked=${this._config.show_group_total !== false}
+              @change=${(e) => this._updateConfig("show_group_total", e.target.checked)}
+            />
+            Show Total Column
+          </label>
+        </div>
+        <div class="editor-row checkbox">
+          <label>
+            <input
+              type="checkbox"
+              .checked=${this._config.show_group_health !== false}
+              @change=${(e) => this._updateConfig("show_group_health", e.target.checked)}
+            />
+            Show Battery &amp; Stale Columns
+          </label>
+        </div>
+        ` : nothing}
         ${!this._isSelectedGroupCombined() ? html`
         <div class="editor-row">
           <label>Filter Entities (requires Show Entity List)</label>

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1699,7 +1699,7 @@ class EntityAvailabilityCardEditor extends LitElement {
               .checked=${this._config.show_group_health !== false}
               @change=${(e) => this._updateConfig("show_group_health", e.target.checked)}
             />
-            Show Battery &amp; Stale Columns
+            Show Health Columns (Bat. &amp; Stale, when active)
           </label>
         </div>
         ` : nothing}

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -283,7 +283,7 @@ const cardStyles = css`
 
   .group-breakdown-row {
     display: grid;
-    grid-template-columns: 1fr repeat(3, 56px);
+    grid-template-columns: minmax(60px, 1fr) repeat(3, minmax(36px, 56px));
     align-items: center;
     padding: 5px 0;
     border-bottom: 1px solid var(--eac-divider);
@@ -302,6 +302,15 @@ const cardStyles = css`
     font-weight: 500;
     color: var(--eac-text-secondary);
     font-size: 12px;
+  }
+
+  .group-breakdown-header span {
+    display: block;
+    text-align: center;
+  }
+
+  .group-breakdown-header span:first-child {
+    text-align: left;
   }
 
   .group-breakdown-name {
@@ -842,8 +851,8 @@ class EntityAvailabilityCard extends LitElement {
       <div class="stats-row">
         <span class="stat-item ${online > 0 ? "online" : "neutral"}">Online: ${online}</span>
         <span class="stat-item ${offline > 0 ? "offline" : "neutral"}">Offline: ${offline}</span>
-        ${stale > 0 ? html`<span class="stat-item battery">Stale: ${stale}</span>` : nothing}
         ${lowBattery > 0 ? html`<span class="stat-item battery">Low Battery: ${lowBattery}</span>` : nothing}
+        ${stale > 0 ? html`<span class="stat-item battery">Stale: ${stale}</span>` : nothing}
       </div>
     `;
   }
@@ -867,8 +876,8 @@ class EntityAvailabilityCard extends LitElement {
         <span class="non-essential-stats-label">↳ Non-Essential</span>
         <span class="non-essential-stat ${online > 0 ? "online" : "neutral"}">Online: ${online}</span>
         <span class="non-essential-stat ${offline > 0 ? "offline" : "neutral"}">Offline: ${offline}</span>
-        ${stale > 0 ? html`<span class="non-essential-stat battery">Stale: ${stale}</span>` : nothing}
         ${lowBattery > 0 ? html`<span class="non-essential-stat battery">Low Battery: ${lowBattery}</span>` : nothing}
+        ${stale > 0 ? html`<span class="non-essential-stat battery">Stale: ${stale}</span>` : nothing}
       </div>
     `;
   }
@@ -1004,7 +1013,7 @@ class EntityAvailabilityCard extends LitElement {
     const hasNEBattery = showNEStats && entries.some(([, g]) => g.battery_enabled && (g.non_essential_low_battery ?? 0) > 0);
     const hasNEStale = showNEStats && entries.some(([, g]) => g.staleness_enabled && (g.non_essential_stale ?? 0) > 0);
     const extraCols = 3 + (hasBattery ? 1 : 0) + (hasStale ? 1 : 0);
-    const gridStyle = `grid-template-columns: 1fr repeat(${extraCols}, 56px)`;
+    const gridStyle = `grid-template-columns: minmax(60px, 1fr) repeat(${extraCols}, minmax(36px, 56px))`;
 
     return html`
       <div class="divider"></div>
@@ -1015,11 +1024,11 @@ class EntityAvailabilityCard extends LitElement {
       <div class="group-breakdown ${expanded ? "expanded" : "collapsed"}">
         <div class="group-breakdown-row group-breakdown-header" style="${gridStyle}">
           <span>Group</span>
-          <span style="text-align:center">Total</span>
-          <span class="sep" style="text-align:center">Online</span>
-          <span style="text-align:center">Offline</span>
-          ${hasBattery ? html`<span class="sep" style="text-align:center">Bat.</span>` : nothing}
-          ${hasStale ? html`<span class="${!hasBattery ? "sep" : ""}" style="text-align:center">Stale</span>` : nothing}
+          <span>Total</span>
+          <span class="sep">Online</span>
+          <span>Offline</span>
+          ${hasBattery ? html`<span class="sep">Bat.</span>` : nothing}
+          ${hasStale ? html`<span class="${!hasBattery ? "sep" : ""}">Stale</span>` : nothing}
         </div>
         ${entries.map(([, g]) => {
           const neCount = g.non_essential ?? 0;

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -679,8 +679,6 @@ class EntityAvailabilityCard extends LitElement {
       entity_filter: "all",
       show_affected_areas: false,
       show_non_essential_stats: false,
-      show_group_total: true,
-      show_group_health: true,
       ...config,
     };
     // backwards compat: show_entity_tooltips: true → entity_detail: "tooltip"
@@ -1014,8 +1012,8 @@ class EntityAvailabilityCard extends LitElement {
     const hasBattery = showHealth && batteryEnabled && entries.some(([, g]) => (g.low_battery ?? 0) > 0 || (showNEStats && g.battery_enabled && (g.non_essential_low_battery ?? 0) > 0));
     const hasStale = showHealth && stalenessEnabled && entries.some(([, g]) => (g.stale ?? 0) > 0 || (showNEStats && g.staleness_enabled && (g.non_essential_stale ?? 0) > 0));
     // NE battery/stale columns: only show if at least one group has the feature enabled and NE counts > 0.
-    const hasNEBattery = showNEStats && entries.some(([, g]) => g.battery_enabled && (g.non_essential_low_battery ?? 0) > 0);
-    const hasNEStale = showNEStats && entries.some(([, g]) => g.staleness_enabled && (g.non_essential_stale ?? 0) > 0);
+    const hasNEBattery = showHealth && showNEStats && entries.some(([, g]) => g.battery_enabled && (g.non_essential_low_battery ?? 0) > 0);
+    const hasNEStale = showHealth && showNEStats && entries.some(([, g]) => g.staleness_enabled && (g.non_essential_stale ?? 0) > 0);
     const extraCols = (showTotal ? 1 : 0) + 2 + (hasBattery ? 1 : 0) + (hasStale ? 1 : 0);
     const gridStyle = `grid-template-columns: minmax(60px, 1fr) repeat(${extraCols}, minmax(36px, 56px))`;
 


### PR DESCRIPTION
## Summary

- Stats row now shows **Low Battery** before **Stale** — matches combined table column order (Bat. | Stale)
- Combined groups table uses `minmax(60px,1fr)` for group name column and `minmax(36px,56px)` for value columns — all columns stay visible on narrow screens (iPhone portrait, landscape); fixes truncated "St" column
- Header separator `border-left` now spans full cell height via `display:block` on header spans — fixes misalignment vs data rows on iPhone 14 Pro landscape; removes redundant inline `style="text-align:center"`

Closes #34 (partial — layout issues from beta.13 feedback)

## Test plan

- [ ] Verify combined table shows all columns on iPhone portrait (~375px)
- [ ] Verify header separators align with data row separators
- [ ] Verify stats row order: Online | Offline | Low Battery | Stale
- [ ] 721 unit tests pass