### PR TITLE
fix: binary_sensor battery, signal network inference, card sort + layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.4.0] - 2026-08-03
+## [0.4.0-beta.2] - 2026-08-05
+
+### Added
+- **Signal network type auto-inferred** — when the signal sensor name ends in `_linkquality` or `_lqi`, the wizard now pre-selects "Zigbee (LQI)" instead of "Generic/RSSI". Eliminates a manual step for every Z2MQTT device.
+- **Battery mapping accepts `binary_sensor`** — devices that expose battery status as a binary sensor (e.g. `binary_sensor.device_battery_low`) can now be mapped. `on` = low (0%), `off` = ok (100%).
+
+### Fixed
+- **Card: entity list height cap removed** — groups with more than ~50 entities had the Suppress/Unsuppress buttons overlapping the last visible rows (CSS `max-height: 2000px` was too small). Cap removed; list grows to full height.
+- **Card: Suppress/Unsuppress buttons move above entity list for large groups** — when a group has more than 50 entities the action buttons are rendered above the list so they're always visible without scrolling.
+- **Card: `Signal: OK` status removed** — entities with a monitored-but-healthy signal now show `Online` (green dot) instead of `Signal: OK` (yellow dot). Yellow dot is reserved for degraded states only.
+- **Card: status sort — stale entities now sort above online** — stale entities (grey dot) were sorting alongside online (green) entities because the sort only checked `dotColor === "yellow"`. Fixed to check `isStale` directly.
+- **Diagnostics: new schema** — `counts`, `entities`, and `config` are now sub-dicts instead of flat keys. Old flat keys (`entity_count`, `essential_count`, etc.) removed. `entities` block exposes `essential`, `non_essential`, `battery_entity_map`, `signal_entity_map`. `config` block adds `bad_states`, `signal_enabled`, `use_device_names`, `staleness_use_last_updated`. Combined entry now exposes full group list instead of a count.
+
+
 
 ### Added
 - **Signal strength monitoring** — optional feature (disabled by default, no migration required). Enable per group in Advanced settings → Enable signal strength monitoring. A new wizard step binds a signal sensor and network type to each entity. Supported protocols: Wi-Fi, Zigbee, Z-Wave, Bluetooth, Thread, LTE/4G, 5G, LoRaWAN, Percentage (0–100%), Generic/RSSI. Thresholds are validated against real-world engineering references per protocol.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If you enable battery monitoring, a confirmation step appears showing each monit
 
 Auto-detection checks battery sensors linked to the same device in Home Assistant, or sensors named `sensor.{entity_name}_battery`.
 
-Battery sensors that report `low` (text) are supported in addition to numeric percentages.
+Battery sensors that report `low` (text) are supported in addition to numeric percentages. **Binary sensors** (`binary_sensor.*`) are also supported — `on` = low battery, `off` = normal (e.g. `binary_sensor.device_battery_low`).
 
 ![Step 5: Battery Entity Mapping](assets/04_battery_entity_mapping.png)
 
@@ -124,8 +124,8 @@ Battery sensors that report `low` (text) are supported in addition to numeric pe
 
 When signal strength monitoring is enabled, a mapping step appears for each monitored entity. For each entity you can:
 
-- **Select a signal sensor** — supports `sensor`, `input_number`, and `number` domains. Auto-detects sensors via `SIGNAL_STRENGTH` device class or naming conventions (`*_linkquality` for Zigbee2MQTT, `*_signal_strength` for Bluetooth, `*_rssi`, `*_lqi`, `*_signal`).
-- **Choose the network type** — selects the correct quality thresholds (good / ok / poor).
+- **Select a signal sensor** — supports `sensor`, `input_number`, and `number` domains. Auto-detects sensors via `SIGNAL_STRENGTH` device class or naming conventions (`*_linkquality` for Zigbee2MQTT, `*_signal_strength` for Bluetooth, `*_rssi`, `*_lqi`, `*_signal`). Also strips known HA suffixes (`_last_seen`, `_last_updated`) before matching — so `sensor.device_last_seen` correctly suggests `sensor.device_linkquality`.
+- **Choose the network type** — selects the correct quality thresholds (good / ok / poor). **Auto-inferred**: sensors ending in `_linkquality` or `_lqi` default to "Zigbee (LQI)" automatically — no manual selection needed for Z2MQTT devices.
 - **Leave the sensor empty** — skips signal monitoring for that entity.
 
 Supported network types and thresholds:

--- a/custom_components/entity_availability/config_flow.py
+++ b/custom_components/entity_availability/config_flow.py
@@ -762,7 +762,8 @@ class EntityAvailabilityOptionsFlow(OptionsFlow):
                 vol.Optional(
                     f"{entity_id}#network",
                     default=existing.get("network_type")
-                    or (_infer_network_type(suggested) if suggested else "generic"),
+                    if existing.get("network_type") is not None
+                    else (_infer_network_type(suggested) if suggested else "generic"),
                 )
             ] = selector.SelectSelector(
                 selector.SelectSelectorConfig(options=_SIGNAL_NETWORK_TYPE_OPTIONS)

--- a/custom_components/entity_availability/config_flow.py
+++ b/custom_components/entity_availability/config_flow.py
@@ -60,6 +60,21 @@ _SIGNAL_NETWORK_TYPE_OPTIONS = [
 ]
 
 
+# Suffix → network type inference. Only unambiguous mappings (LQI = Zigbee).
+_SIGNAL_SUFFIX_NETWORK_TYPE: dict[str, str] = {
+    "_linkquality": "zigbee_lqi",
+    "_lqi": "zigbee_lqi",
+}
+
+
+def _infer_network_type(signal_entity_id: str) -> str:
+    """Infer network type from signal sensor entity_id suffix. Returns 'generic' if unknown."""
+    for suffix, nt in _SIGNAL_SUFFIX_NETWORK_TYPE.items():
+        if signal_entity_id.endswith(suffix):
+            return nt
+    return "generic"
+
+
 def _detect_signal_entity(hass: Any, entity_id: str) -> str:
     """Auto-detect signal sensor for an entity. Returns entity_id or empty string.
 
@@ -423,7 +438,9 @@ class EntityAvailabilityConfigFlow(ConfigFlow, domain=DOMAIN):
                     entity_id,
                     description={"suggested_value": detected} if detected else None,
                 )
-            ] = selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor"))
+            ] = selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["sensor", "binary_sensor"])
+            )
 
         return self.async_show_form(
             step_id="battery_mapping",
@@ -477,10 +494,13 @@ class EntityAvailabilityConfigFlow(ConfigFlow, domain=DOMAIN):
                     domain=["sensor", "input_number", "number"]
                 )
             )
-            schema_dict[vol.Optional(f"{entity_id}#network", default="generic")] = (
-                selector.SelectSelector(
-                    selector.SelectSelectorConfig(options=_SIGNAL_NETWORK_TYPE_OPTIONS)
+            schema_dict[
+                vol.Optional(
+                    f"{entity_id}#network",
+                    default=_infer_network_type(detected) if detected else "generic",
                 )
+            ] = selector.SelectSelector(
+                selector.SelectSelectorConfig(options=_SIGNAL_NETWORK_TYPE_OPTIONS)
             )
 
         return self.async_show_form(
@@ -687,7 +707,9 @@ class EntityAvailabilityOptionsFlow(OptionsFlow):
                     entity_id,
                     description={"suggested_value": default} if default else None,
                 )
-            ] = selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor"))
+            ] = selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["sensor", "binary_sensor"])
+            )
 
         return self.async_show_form(
             step_id="battery_mapping",
@@ -739,7 +761,8 @@ class EntityAvailabilityOptionsFlow(OptionsFlow):
             schema_dict[
                 vol.Optional(
                     f"{entity_id}#network",
-                    default=existing.get("network_type", "generic"),
+                    default=existing.get("network_type")
+                    or (_infer_network_type(suggested) if suggested else "generic"),
                 )
             ] = selector.SelectSelector(
                 selector.SelectSelectorConfig(options=_SIGNAL_NETWORK_TYPE_OPTIONS)

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -913,7 +913,11 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                 return None
             bat_state = self.hass.states.get(mapped)
             if bat_state and bat_state.state not in ("unavailable", "unknown", None):
-                level = self._parse_battery_state(bat_state.state)
+                # binary_sensor battery: "on" = low (0%), "off" = ok (100%)
+                if mapped.startswith("binary_sensor."):
+                    level = 0 if bat_state.state == "on" else 100
+                else:
+                    level = self._parse_battery_state(bat_state.state)
                 _LOGGER.debug(
                     "[%s] Battery for %s via map->%s: %s%%",
                     self.group_name,

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1298,7 +1298,7 @@ class EntityAvailabilityCard extends LitElement {
       { label: "HA State", value: lastChanged ? `${this._formatStateWithUnit(entityState)} · ${lastChanged}` : this._formatStateWithUnit(entityState) },
       { label: "Condition", value: suppressedUntil ? "Suppressed" : item.isOffline ? `Offline for ${item.status}` : item.status },
       item.battery !== null ? { label: "Battery", value: `${item.battery}%` } : null,
-      item.signalLevel !== null && item.signalLevel !== undefined ? { label: "Signal", value: `${item.signalLevel}${item.signalUnit ? " " + item.signalUnit : ""}${item.isPoorSignal ? " (poor)" : item.isOkSignal ? " (ok)" : ""}` } : null,
+      item.signalLevel !== null && item.signalLevel !== undefined ? { label: "Signal", value: `${item.signalLevel}${item.signalUnit ? " " + item.signalUnit : ""}${item.isPoorSignal ? " (poor)" : ""}` } : null,
       suppressedUntil ? { label: "Suppressed", value: suppressedUntil === "indefinitely" ? "Indefinitely" : `until ${suppressedUntil}` } : null,
     ].filter(Boolean);
   }

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -248,7 +248,6 @@ const cardStyles = css`
   .entity-list {
     padding: 0 16px 12px;
     overflow: visible;
-    transition: max-height 0.3s ease, opacity 0.3s ease;
   }
 
   .entity-list.collapsed {
@@ -259,25 +258,23 @@ const cardStyles = css`
   }
 
   .entity-list.expanded {
-    max-height: 2000px;
     opacity: 1;
   }
 
   /* Combined group breakdown */
   .group-breakdown {
     padding: 0 16px 12px;
-    overflow: hidden;
-    transition: max-height 0.3s ease, opacity 0.3s ease;
+    overflow: visible;
   }
 
   .group-breakdown.collapsed {
     max-height: 0;
     opacity: 0;
     padding: 0 16px;
+    overflow: hidden;
   }
 
   .group-breakdown.expanded {
-    max-height: 2000px;
     opacity: 1;
   }
 
@@ -1226,9 +1223,6 @@ class EntityAvailabilityCard extends LitElement {
         } else if (isPoorSignal) {
           dotColor = "yellow";
           status = "Poor Signal";
-        } else if (isOkSignal) {
-          dotColor = "yellow";
-          status = "Signal: OK";
         } else {
           dotColor = "green";
           status = "Online";
@@ -1242,9 +1236,6 @@ class EntityAvailabilityCard extends LitElement {
       } else if (isPoorSignal) {
         dotColor = "yellow";
         status = "Poor Signal";
-      } else if (isOkSignal) {
-        dotColor = "yellow";
-        status = "Signal: OK";
       }
 
       return { entityId, name: friendlyName, dotColor, status, battery, isOffline, isStale, isSuppressed, isNonEssential, signalLevel, signalUnit, isPoorSignal, isOkSignal };
@@ -1271,8 +1262,10 @@ class EntityAvailabilityCard extends LitElement {
       } else {
         if (a.isOffline && !b.isOffline) return -1;
         if (!a.isOffline && b.isOffline) return 1;
-        if (a.dotColor === "yellow" && b.dotColor === "green") return -1;
-        if (a.dotColor === "green" && b.dotColor === "yellow") return 1;
+        const aDegraded = a.dotColor === "yellow" || a.isStale;
+        const bDegraded = b.dotColor === "yellow" || b.isStale;
+        if (aDegraded && !bDegraded) return -1;
+        if (!aDegraded && bDegraded) return 1;
         return a.name.localeCompare(b.name);
       }
     });

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -255,10 +255,12 @@ const cardStyles = css`
     opacity: 0;
     padding: 0 16px;
     overflow: hidden;
+    transition: opacity 0.2s ease;
   }
 
   .entity-list.expanded {
     opacity: 1;
+    transition: opacity 0.2s ease;
   }
 
   /* Combined group breakdown */
@@ -272,10 +274,12 @@ const cardStyles = css`
     opacity: 0;
     padding: 0 16px;
     overflow: hidden;
+    transition: opacity 0.2s ease;
   }
 
   .group-breakdown.expanded {
     opacity: 1;
+    transition: opacity 0.2s ease;
   }
 
   .group-breakdown-row {

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -856,8 +856,9 @@ class EntityAvailabilityCard extends LitElement {
         ${this._config.show_affected_areas ? this._renderAffectedAreas(prefix) : nothing}
         ${this._renderSuppressedBanner(suppressed, showNEStats ? nonEssentialSuppressed : 0)}
         ${this._config.show_availability ? this._renderAvailability(prefix) : nothing}
+        ${this._config.show_actions && entities.length > 50 ? this._renderActions(prefix) : nothing}
         ${this._config.show_entities ? this._renderEntityList(entities.filter(e => showNEStats || !nonEssentialEntities.includes(e)), batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames, nonEssentialEntities, showNEStats ? nonEssentialOfflineEntities : [], showNEStats ? staleEntitiesNonEssential : [], batteryEnabled, signalEnabled, signalLevels, poorSignalEntities, signalUnits, okSignalEntities, this._config.show_table_icons === true) : nothing}
-        ${this._config.show_actions ? this._renderActions(prefix) : nothing}
+        ${this._config.show_actions && entities.length <= 50 ? this._renderActions(prefix) : nothing}
       </ha-card>
     `;
   }

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -1341,6 +1341,14 @@ def main():
             ),
             1,
         )
+        # wait_for low_battery sensor to reflect updated state before reading attrs
+        wait_for(
+            lambda: (
+                gs(f"{prefix}_low_battery").get("state")
+                not in ("None", "", None, "unavailable")
+            ),
+            True,
+        )
         lb = gs(f"{prefix}_low_battery")
         chk(
             "low_battery state non-null",
@@ -1355,7 +1363,7 @@ def main():
         )
         chk(
             "offline_count=0 (device online)",
-            gs(f"{prefix}_offline_count").get("state"),
+            wait_for(lambda: gs(f"{prefix}_offline_count").get("state"), "0"),
             "0",
         )
         if combined_prefix:

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -418,6 +418,9 @@ for e in cfg['data']['entries']:
         "staleness_threshold": data.get("staleness_threshold", 0)
         if "data" in dir()
         else 0,
+        "signal_enabled": data.get("signal_enabled", False)
+        if "data" in dir()
+        else False,
         "mapped_battery_entity": mapped_battery_entity,
         "mapped_battery_sensor": mapped_battery_sensor,
         "combined_prefix": combined_prefix,
@@ -474,6 +477,7 @@ def setup_battery(ctx):
             "availability_windows": ["today", "7d"],
             "use_device_names": False,
             "staleness_use_last_updated": False,
+            "signal_enabled": ctx.get("signal_enabled", False),
         },
     )
     if r2.get("step_id") == "battery_mapping":
@@ -1568,6 +1572,7 @@ def main():
                 "availability_windows": ["today", "7d"],
                 "use_device_names": False,
                 "staleness_use_last_updated": False,
+                "signal_enabled": ctx.get("signal_enabled", False),
             },
         )
         schema = r2.get("data_schema", [])

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -2690,9 +2690,12 @@ for e in cfg['data']['entries']:
                     f"  EC52: skipped (flow did not reach signal_mapping, got step={r2.get('step_id')})",
                     flush=True,
                 )
-            api("DELETE", f"/api/config/config_entries/options/flow/{fid}")
+            try:
+                api("DELETE", f"/api/config/config_entries/options/flow/{fid}")
+            except Exception:
+                pass  # flow may have expired (HA flow TTL)
 
-    # EC53: diagnostics new schema on the main (non-NE) group entry
+ diagnostics new schema on the main (non-NE) group entry
     if ec_enabled(53):
         print(
             "\n=== EC53: diagnostics new schema on main group entry ===",

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -492,7 +492,6 @@ def setup_battery(ctx):
         ctx["mapped_battery_entity"] = target_entity
         ctx["mapped_battery_sensor"] = battery_sensor
         print(f"  Mapped {target_entity} → {battery_sensor}", flush=True)
-        wait(10)
 
 
 def restore_all(ctx):
@@ -1267,6 +1266,8 @@ def main():
     if not SKIP_SETUP:
         setup_battery(ctx)
         restore_and_wait(ctx)
+        # Extra settle time after options flow reload — coordinator needs a full tick
+        wait(15)
     else:
         print(
             "  --skip-setup: assuming clean state, skipping battery setup + restore",

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -18,7 +18,7 @@ The test auto-discovers the first entity_availability group whose title contains
 EA_SMOKE_GROUP, then discovers its monitored entities and battery entity map from
 the live sensor attributes — no hardcoded entity IDs, entry IDs, or device names.
 
-What is tested (covers PRs #37, #41, #50, #52, #53, #54, core, feat/non-essential-level):
+What is tested (covers PRs #37, #41, #50, #52, #53, #54, #68, core, feat/non-essential-level):
   EC1  entity goes unavailable → offline_count increments
   EC4  device online + battery below threshold → low_battery_count=1, list populated
   EC5  device+battery unavailable → offline=1, low_battery=0 (PR#41: no double-count)
@@ -52,6 +52,11 @@ What is tested (covers PRs #37, #41, #50, #52, #53, #54, core, feat/non-essentia
   EC48 signal_levels attr is a dict in group_summary
   EC49 poor_signal_entities attr is a list in group_summary
   EC50 any_poor_signal binary sensor reachable when signal enabled
+
+  PR#68 (EC51-EC53):
+  EC51 signal mapping options flow round-trip: entity_id / entity_id#network keys accepted and stored
+  EC52 _detect_signal_entity suffix strip: sensor.xxx_last_seen → suggests sensor.xxx_linkquality
+  EC53 diagnostics new schema: counts/entities/config sub-dicts present and correct (replaces flat keys)
 
   Non-Essential tier (EC25-EC42, require a group with NE entities — set EA_SMOKE_NE_GROUP):
   EC25 NE entity offline → offline_count unchanged (KPI exclusion)
@@ -976,29 +981,51 @@ def _run_ne_tests(ne_ctx: dict) -> None:
 
     ne_restore()
 
-    # EC36: diagnostics endpoint returns correct shape for group entry
+    # EC36: diagnostics endpoint returns correct shape for group entry (new schema: counts/entities/config)
     if ec_enabled(36):
         print(
-            "\n=== EC36: diagnostics endpoint returns correct shape ===",
+            "\n=== EC36: diagnostics endpoint returns correct shape (new schema) ===",
             flush=True,
         )
         try:
-            # HA wraps integration data under "data" key alongside home_assistant/custom_components
             raw = api("GET", f"/api/diagnostics/config_entry/{ne_ctx['entry_id']}")
             result = raw.get("data", raw)  # unwrap HA envelope
             chk("EC36 diagnostics entry_type=group", result.get("entry_type"), "group")
-            chk("EC36 diagnostics has entity_count", "entity_count" in result, True)
             chk(
-                "EC36 diagnostics essential_count >= 1",
-                int(result.get("essential_count", 0)) >= 1,
+                "EC36 diagnostics has counts dict",
+                isinstance(result.get("counts"), dict),
                 True,
-                f"essential_count={result.get('essential_count')}",
             )
             chk(
-                "EC36 diagnostics non_essential_count >= 1",
-                int(result.get("non_essential_count", 0)) >= 1,
+                "EC36 diagnostics counts.total >= 1",
+                int((result.get("counts") or {}).get("total", 0)) >= 1,
                 True,
-                f"non_essential_count={result.get('non_essential_count')}",
+                f"counts={result.get('counts')}",
+            )
+            chk(
+                "EC36 diagnostics counts.essential >= 1",
+                int((result.get("counts") or {}).get("essential", 0)) >= 1,
+                True,
+            )
+            chk(
+                "EC36 diagnostics counts.non_essential >= 1",
+                int((result.get("counts") or {}).get("non_essential", 0)) >= 1,
+                True,
+            )
+            chk(
+                "EC36 diagnostics has entities dict",
+                isinstance(result.get("entities"), dict),
+                True,
+            )
+            chk(
+                "EC36 diagnostics entities.essential is list",
+                isinstance((result.get("entities") or {}).get("essential"), list),
+                True,
+            )
+            chk(
+                "EC36 diagnostics entities.non_essential is list",
+                isinstance((result.get("entities") or {}).get("non_essential"), list),
+                True,
             )
             chk(
                 "EC36 diagnostics has config dict",
@@ -1007,7 +1034,17 @@ def _run_ne_tests(ne_ctx: dict) -> None:
             )
             chk(
                 "EC36 diagnostics config has cooldown_seconds",
-                "cooldown_seconds" in result.get("config", {}),
+                "cooldown_seconds" in (result.get("config") or {}),
+                True,
+            )
+            chk(
+                "EC36 diagnostics config has signal_enabled",
+                "signal_enabled" in (result.get("config") or {}),
+                True,
+            )
+            chk(
+                "EC36 diagnostics config has bad_states",
+                "bad_states" in (result.get("config") or {}),
                 True,
             )
         except Exception as e:
@@ -2453,7 +2490,246 @@ def main():
                         )
 
     # ------------------------------------------------------------------
-    print("\n=== CLEANUP ===", flush=True)
+    # EC51-EC53: PR#68 — signal mapping key format + diagnostics new schema
+    # ------------------------------------------------------------------
+
+    # EC51: signal mapping options flow round-trip with new key format
+    if ec_enabled(51):
+        print(
+            "\n=== EC51: signal mapping options flow: entity_id / entity_id#network keys ===",
+            flush=True,
+        )
+        target_entity = ctx["entities"][0]
+        signal_sensor = f"sensor.{target_entity.split('.')[-1]}_linkquality"
+        # Create a synthetic signal sensor so the flow can accept it
+        ss(
+            signal_sensor,
+            "120",
+            {"friendly_name": "Smoke signal sensor", "unit_of_measurement": "lqi"},
+        )
+        r = api(
+            "POST",
+            "/api/config/config_entries/options/flow",
+            {"handler": ctx["entry_id"]},
+        )
+        fid = r["flow_id"]
+        # Step 1: main options
+        r2 = api(
+            "POST",
+            f"/api/config/config_entries/options/flow/{fid}",
+            {
+                "entities": ctx["entities"],
+                "bad_states": ["unavailable", "unknown"],
+                "cooldown": 0,
+                "staleness_threshold": 0,
+                "battery_threshold": ctx["battery_threshold"],
+                "availability_windows": ["today", "7d"],
+                "use_device_names": False,
+                "staleness_use_last_updated": False,
+                "signal_enabled": True,
+            },
+        )
+        # Navigate past battery_mapping if present — preserve existing mappings
+        if r2.get("step_id") == "battery_mapping":
+            bmap_input = {}
+            if ctx.get("mapped_battery_entity") and ctx.get("mapped_battery_sensor"):
+                bmap_input[ctx["mapped_battery_entity"]] = ctx["mapped_battery_sensor"]
+            r2 = api(
+                "POST",
+                f"/api/config/config_entries/options/flow/{fid}",
+                bmap_input,
+            )
+        if r2.get("step_id") == "signal_mapping":
+            # Submit using new key format: entity_id as sensor key, entity_id#network for type
+            r3 = api(
+                "POST",
+                f"/api/config/config_entries/options/flow/{fid}",
+                {
+                    target_entity: signal_sensor,
+                    f"{target_entity}#network": "zigbee_lqi",
+                },
+            )
+            chk(
+                "EC51 signal mapping flow completes (CREATE_ENTRY or next step)",
+                r3.get("type") in ("create_entry", "form"),
+                True,
+                f"type={r3.get('type')} step={r3.get('step_id')}",
+            )
+            if r3.get("type") == "create_entry":
+                # Verify stored map via config storage
+                import subprocess as _sp
+
+                eid_val = ctx["entry_id"]
+                try:
+                    raw = _sp.check_output(
+                        [
+                            "python3",
+                            "-c",
+                            f"""
+import json
+cfg = json.load(open('/workspaces/home-assistant-core/config/.storage/core.config_entries'))
+for e in cfg['data']['entries']:
+    if e['entry_id'] == {eid_val!r}:
+        print(json.dumps(e['data'].get('signal_entity_map', {{}})))
+""",
+                        ],
+                        text=True,
+                    )
+                    smap = json.loads(raw.strip())
+                    chk(
+                        "EC51 signal_entity_map stored for target_entity",
+                        target_entity in smap,
+                        True,
+                        f"map={smap}",
+                    )
+                    if target_entity in smap:
+                        chk(
+                            "EC51 stored sensor matches submitted",
+                            smap[target_entity].get("sensor"),
+                            signal_sensor,
+                        )
+                        chk(
+                            "EC51 stored network_type=zigbee_lqi",
+                            smap[target_entity].get("network_type"),
+                            "zigbee_lqi",
+                        )
+                except Exception as e:
+                    chk("EC51 config storage readable", False, True, str(e))
+        else:
+            print(
+                f"  EC51: skipped (flow did not reach signal_mapping step, got step={r2.get('step_id')})",
+                flush=True,
+            )
+            api("DELETE", f"/api/config/config_entries/options/flow/{fid}")
+        # Restore battery mapping in case EC51 flow overwrote it
+        restore_and_wait(ctx)
+
+    # EC52: _detect_signal_entity strips _last_seen suffix before naming convention
+    if ec_enabled(52):
+        print(
+            "\n=== EC52: _detect_signal_entity strips _last_seen → suggests _linkquality ===",
+            flush=True,
+        )
+        # Find an entity with _last_seen suffix — typical zigbee setup
+        last_seen_entities = [e for e in ctx["entities"] if e.endswith("_last_seen")]
+        if not last_seen_entities:
+            print(
+                "  EC52: skipped (no _last_seen entities in test group)",
+                flush=True,
+            )
+        else:
+            ls_entity = last_seen_entities[0]
+            slug = ls_entity.split(".", 1)[1]  # e.g. balcony_light_last_seen
+            base = slug[: -len("_last_seen")]  # e.g. balcony_light
+            lq_sensor = f"sensor.{base}_linkquality"
+            # Ensure the linkquality sensor exists in HA state machine
+            ss(
+                lq_sensor,
+                "200",
+                {"friendly_name": "Smoke linkquality", "unit_of_measurement": "lqi"},
+            )
+            # Open options flow and advance to signal_mapping
+            r = api(
+                "POST",
+                "/api/config/config_entries/options/flow",
+                {"handler": ctx["entry_id"]},
+            )
+            fid = r["flow_id"]
+            r2 = api(
+                "POST",
+                f"/api/config/config_entries/options/flow/{fid}",
+                {
+                    "entities": ctx["entities"],
+                    "bad_states": ["unavailable", "unknown"],
+                    "cooldown": 0,
+                    "staleness_threshold": 0,
+                    "battery_threshold": ctx["battery_threshold"],
+                    "availability_windows": ["today", "7d"],
+                    "use_device_names": False,
+                    "staleness_use_last_updated": False,
+                    "signal_enabled": True,
+                },
+            )
+            if r2.get("step_id") == "battery_mapping":
+                r2 = api("POST", f"/api/config/config_entries/options/flow/{fid}", {})
+            if r2.get("step_id") == "signal_mapping":
+                schema = r2.get("data_schema", [])
+                # Field for ls_entity should have suggested_value = lq_sensor
+                field = next((f for f in schema if f.get("name") == ls_entity), None)
+                suggestion = (
+                    (field or {}).get("description", {}).get("suggested_value", "")
+                )
+                chk(
+                    "EC52 _last_seen entity suggests _linkquality via suffix stripping",
+                    suggestion,
+                    lq_sensor,
+                    f"entity={ls_entity} base={base} suggested={suggestion!r}",
+                )
+            else:
+                print(
+                    f"  EC52: skipped (flow did not reach signal_mapping, got step={r2.get('step_id')})",
+                    flush=True,
+                )
+            api("DELETE", f"/api/config/config_entries/options/flow/{fid}")
+
+    # EC53: diagnostics new schema on the main (non-NE) group entry
+    if ec_enabled(53):
+        print(
+            "\n=== EC53: diagnostics new schema on main group entry ===",
+            flush=True,
+        )
+        try:
+            raw = api("GET", f"/api/diagnostics/config_entry/{ctx['entry_id']}")
+            result = raw.get("data", raw)
+            chk("EC53 entry_type=group", result.get("entry_type"), "group")
+            # counts sub-dict
+            counts = result.get("counts") or {}
+            chk(
+                "EC53 counts.total is int",
+                isinstance(counts.get("total"), int),
+                True,
+                f"counts={counts}",
+            )
+            chk("EC53 counts has offline key", "offline" in counts, True)
+            chk("EC53 counts has suppressed key", "suppressed" in counts, True)
+            # entities sub-dict
+            entities_d = result.get("entities") or {}
+            chk(
+                "EC53 entities.essential is list",
+                isinstance(entities_d.get("essential"), list),
+                True,
+            )
+            chk(
+                "EC53 entities.battery_entity_map is dict",
+                isinstance(entities_d.get("battery_entity_map"), dict),
+                True,
+            )
+            chk(
+                "EC53 entities.signal_entity_map is dict",
+                isinstance(entities_d.get("signal_entity_map"), dict),
+                True,
+            )
+            # config sub-dict — new fields
+            cfg = result.get("config") or {}
+            chk("EC53 config.signal_enabled present", "signal_enabled" in cfg, True)
+            chk("EC53 config.bad_states present", "bad_states" in cfg, True)
+            chk("EC53 config.use_device_names present", "use_device_names" in cfg, True)
+            chk(
+                "EC53 config.staleness_use_last_updated present",
+                "staleness_use_last_updated" in cfg,
+                True,
+            )
+            # old flat keys must NOT be present (schema migration check)
+            chk("EC53 old entity_count key absent", "entity_count" not in result, True)
+            chk(
+                "EC53 old essential_count key absent",
+                "essential_count" not in result,
+                True,
+            )
+        except Exception as e:
+            chk("EC53 diagnostics endpoint reachable", False, True, str(e))
+
+    # ------------------------------------------------------------------
     restore_all(ctx)
     print(
         f"offline_count={gs(f'{prefix}_offline_count').get('state')} (expected 0)",

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -2612,6 +2612,9 @@ for e in cfg['data']['entries']:
                         )
                 except Exception as e:
                     chk("EC51 config storage readable", False, True, str(e))
+            else:
+                # Flow returned another step — clean up orphaned flow
+                api("DELETE", f"/api/config/config_entries/options/flow/{fid}")
         else:
             print(
                 f"  EC51: skipped (flow did not reach signal_mapping step, got step={r2.get('step_id')})",

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -481,11 +481,14 @@ def setup_battery(ctx):
         },
     )
     if r2.get("step_id") == "battery_mapping":
-        api(
+        r3 = api(
             "POST",
             f"/api/config/config_entries/options/flow/{fid}",
             {target_entity: battery_sensor},
         )
+        # Navigate through signal_mapping step if present (submit empty = keep existing map)
+        if r3.get("step_id") == "signal_mapping":
+            api("POST", f"/api/config/config_entries/options/flow/{fid}", {})
         ctx["mapped_battery_entity"] = target_entity
         ctx["mapped_battery_sensor"] = battery_sensor
         print(f"  Mapped {target_entity} → {battery_sensor}", flush=True)

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -2695,7 +2695,7 @@ for e in cfg['data']['entries']:
             except Exception:
                 pass  # flow may have expired (HA flow TTL)
 
- diagnostics new schema on the main (non-NE) group entry
+    # EC53: diagnostics new schema on the main (non-NE) group entry
     if ec_enabled(53):
         print(
             "\n=== EC53: diagnostics new schema on main group entry ===",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2171,6 +2171,17 @@ async def test_detect_signal_entity_via_device_class(hass: HomeAssistant) -> Non
     assert any("#network" in k for k in schema_keys)
 
 
+def test_infer_network_type_linkquality():
+    """_infer_network_type maps _linkquality suffix to zigbee_lqi."""
+    from custom_components.entity_availability.config_flow import _infer_network_type
+
+    assert _infer_network_type("sensor.balcony_light_linkquality") == "zigbee_lqi"
+    assert _infer_network_type("sensor.device_lqi") == "zigbee_lqi"
+    assert _infer_network_type("sensor.device_rssi") == "generic"
+    assert _infer_network_type("sensor.device_signal") == "generic"
+    assert _infer_network_type("sensor.device_signal_strength") == "generic"
+
+
 async def test_detect_signal_entity_via_naming_convention_linkquality(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2063,6 +2063,77 @@ async def test_battery_via_map_entity_unavailable_returns_none(
 
 
 # ---------------------------------------------------------------------------
+# _get_battery_level — binary_sensor battery map (on=low, off=ok)
+# ---------------------------------------------------------------------------
+
+
+async def test_battery_via_binary_sensor_map_on_is_low(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """Mapped binary_sensor in 'on' state → battery_level=0 (low)."""
+    from custom_components.entity_availability.const import CONF_BATTERY_ENTITY_MAP
+
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", "on", {"friendly_name": "Device A"})
+    hass.states.async_set("binary_sensor.device_a_battery_low", "on", {})
+
+    config = dict(mock_config_data)
+    config[CONF_BATTERY_ENTITY_MAP] = {
+        "binary_sensor.device_a": "binary_sensor.device_a_battery_low"
+    }
+    entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Test Group",
+        data=config,
+        entry_id="bat_bs_on_entry",
+    )
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+    assert coord.device_states["binary_sensor.device_a"].battery_level == 0
+    assert coord.device_states["binary_sensor.device_a"].is_low_battery is True
+
+
+async def test_battery_via_binary_sensor_map_off_is_ok(
+    mock_hass: HomeAssistant, mock_config_data
+) -> None:
+    """Mapped binary_sensor in 'off' state → battery_level=100 (normal), not low."""
+    from custom_components.entity_availability.const import CONF_BATTERY_ENTITY_MAP
+
+    hass = mock_hass
+    hass.states.async_set("binary_sensor.device_a", "on", {"friendly_name": "Device A"})
+    hass.states.async_set("binary_sensor.device_a_battery_low", "off", {})
+
+    config = dict(mock_config_data)
+    config[CONF_BATTERY_ENTITY_MAP] = {
+        "binary_sensor.device_a": "binary_sensor.device_a_battery_low"
+    }
+    entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Test Group",
+        data=config,
+        entry_id="bat_bs_off_entry",
+    )
+
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(hass, entry)
+        coord._last_update = None
+        await coord._async_update_data()
+
+    assert coord.device_states["binary_sensor.device_a"].battery_level == 100
+    assert coord.device_states["binary_sensor.device_a"].is_low_battery is False
+
+
+# ---------------------------------------------------------------------------
 # _get_battery_level — guessed battery entity (line 586)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

### Bug fixes
- **Battery mapping accepts `binary_sensor`**: selector was rejecting `binary_sensor.xxx_battery_low` — now allows `binary_sensor` domain alongside `sensor`
- **`binary_sensor` battery logic**: `"on"` = low (0%), `"off"` = ok (100%) — previously returned `None` causing false negatives
- **Signal network type auto-inferred**: `_linkquality`/`_lqi` suffix → `zigbee_lqi` default in mapping wizard (eliminates manual dropdown change for Z2M devices)

### Card fixes
- **Remove `Signal: OK` state**: entities with monitored-but-ok signal now show `Online` (green dot) — `Signal: OK` with yellow dot was confusing since yellow = degraded everywhere else
- **Fix status sort for stale entities**: stale entities have `dotColor="grey"` — the old sort only checked `dotColor==="yellow"`, so stale sorted alongside online. Now checks `isStale` directly
- **Remove `max-height` cap on entity list**: `2000px` cap caused suppress/unsuppress buttons to overlap last entities in large groups (68+ devices). Removed cap entirely; collapsed state still uses `max-height: 0` + `overflow: hidden`

### Tests
- `test_battery_via_binary_sensor_map_on_is_low` / `_off_is_ok`
- `test_infer_network_type_linkquality`
- EC36 updated for new diagnostics schema (`counts`/`entities`/`config` sub-dicts)
- EC51–53: signal mapping round-trip, suffix detection, diagnostics schema

## Test plan
- [ ] `pytest tests/` — 787 tests passing
- [ ] EC51–53 smoke passing on `serene_booth`
- [ ] Battery mapping: `binary_sensor.xxx_battery_low` accepted in UI, `on` triggers low battery alert
- [ ] Z2M group: opening signal mapping wizard shows `Zigbee (LQI)` pre-selected for `_linkquality` sensors
- [ ] 68-entity group: entity list expands fully, suppress buttons below last entity
- [ ] Stale entities sort above online in status sort