### PR TITLE
feat(sensor): add essential + stale/poor_signal count attrs to group_summary

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install ruff
-        run: pip install ruff==0.15.12
+        run: pip install ruff==0.16.1
       - name: Run ruff check
         run: ruff check .
       - name: Run ruff format check

--- a/AUTOMATION_EXAMPLES.md
+++ b/AUTOMATION_EXAMPLES.md
@@ -218,6 +218,86 @@ automation:
 
 ---
 
+## Signal quality events
+
+Signal events fire when an entity's signal quality transitions between tiers. Only poor ↔ non-poor transitions fire events — transitions between "ok" and "good" do not.
+
+| Event | Fired when | Key data |
+|-------|-----------|----------|
+| `entity_availability_poor_signal` | Signal drops into "poor" tier | `entity_id`, `group`, `entry_id`, `signal_level`, `signal_quality`, `poor_signal_count`, `poor_signal_entities` |
+| `entity_availability_signal_ok` | Signal recovers from "poor" | same — `poor_signal_count` already excludes the recovered entity |
+
+---
+
+### Automation 8a — Alert when signal degrades
+
+```yaml
+automation:
+  alias: EA — poor signal alert
+  trigger:
+    - platform: event
+      event_type: entity_availability_poor_signal
+      event_data:
+        group: Zigbee Devices
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        title: "Poor signal ({{ trigger.event.data.poor_signal_count }} device(s))"
+        message: >-
+          {{ trigger.event.data.entity_id }} has poor signal:
+          {{ trigger.event.data.signal_level }} {{ trigger.event.data.signal_quality }}.
+          All poor signal: {{ trigger.event.data.poor_signal_entities | join(', ') }}
+```
+
+---
+
+### Automation 8b — Log signal recovery
+
+```yaml
+automation:
+  alias: EA — signal recovered
+  trigger:
+    - platform: event
+      event_type: entity_availability_signal_ok
+      event_data:
+        group: Zigbee Devices
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        message: >-
+          {{ trigger.event.data.entity_id }} signal recovered
+          (now {{ trigger.event.data.signal_quality }}: {{ trigger.event.data.signal_level }}).
+          {% if trigger.event.data.poor_signal_count | int > 0 %}
+          Still poor: {{ trigger.event.data.poor_signal_entities | join(', ') }}
+          {% else %}
+          All devices have acceptable signal.
+          {% endif %}
+```
+
+---
+
+### Automation 8c — Sensor-based trigger (alternative to events)
+
+If you prefer polling over events, use the `poor_signal_count` sensor or the `poor_signal` attr on `group_summary`:
+
+```yaml
+automation:
+  alias: EA — poor signal sensor trigger
+  trigger:
+    - platform: numeric_state
+      entity_id: sensor.entity_availability_zigbee_devices_poor_signal_count
+      above: 0
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        message: >-
+          {% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
+          {{ s.poor_signal }} device(s) with poor signal:
+          {{ s.poor_signal_entities | join(', ') }}
+```
+
+---
+
 ## Offline / recovery sensors
 
 Use state-based triggers when you want `for:` delays or want to react to the current sensor value rather than a per-entity transition.

--- a/AUTOMATION_EXAMPLES.md
+++ b/AUTOMATION_EXAMPLES.md
@@ -780,3 +780,74 @@ automation:
           Non-essential stale ({{ states('sensor.entity_availability_security_devices_stale_count_non_essential') }}):
           {{ state_attr('sensor.entity_availability_security_devices_stale_entities_non_essential', 'entities') | join(', ') }}
 ```
+
+---
+
+## group_summary templates
+
+The `group_summary` sensor exposes rich attributes for templates and automations. Replace `zigbee_devices` with your group slug.
+
+### Summary message
+
+```yaml
+{% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
+Total {{ s.total_entities }} | Essential {{ s.essential }}: {{ s.online }} online, {{ s.offline }} offline | NE {{ s.non_essential }}: {{ s.non_essential_online }} online, {{ s.non_essential_offline }} offline
+```
+
+### Status line with degraded indicators
+
+```yaml
+{% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
+{% if s.offline > 0 %}⚠️ {{ s.offline }} offline{% if s.stale > 0 %}, {{ s.stale }} stale{% endif %}{% if s.poor_signal > 0 %}, {{ s.poor_signal }} poor signal{% endif %}
+{% else %}✅ All {{ s.essential }} essential online{% if s.stale > 0 %} ({{ s.stale }} stale){% endif %}{% endif %}
+```
+
+### Automation trigger on any degraded state
+
+```yaml
+automation:
+  alias: EA — any degraded essential device
+  trigger:
+    - platform: template
+      value_template: >
+        {% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
+        {{ s.offline > 0 or s.stale > 0 or s.poor_signal > 0 }}
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        message: >
+          {% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
+          Degraded: {{ s.offline }} offline, {{ s.stale }} stale, {{ s.poor_signal }} poor signal
+          ({{ s.online }}/{{ s.essential }} essential online)
+```
+
+### Low battery list with levels
+
+```yaml
+{% set lvls = state_attr('sensor.entity_availability_zigbee_devices_group_summary', 'battery_levels') %}
+{% set names = state_attr('sensor.entity_availability_zigbee_devices_group_summary', 'display_names') %}
+Low battery devices:
+{% for eid, pct in lvls.items() if pct < 30 %}
+- {{ names.get(eid, eid) }}: {{ pct }}%
+{% endfor %}
+```
+
+### Essential vs non-essential count in a notification
+
+```yaml
+automation:
+  alias: EA — daily health summary
+  trigger:
+    - platform: time
+      at: "08:00:00"
+  action:
+    - service: notify.mobile_app_my_phone
+      data:
+        title: Zigbee daily summary
+        message: >
+          {% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
+          Essential: {{ s.essential }} ({{ s.online }} online)
+          Non-essential: {{ s.non_essential }} ({{ s.non_essential_online }} online)
+          {% if s.stale > 0 %}Stale: {{ s.stale }}{% endif %}
+          {% if s.poor_signal > 0 %}Poor signal: {{ s.poor_signal }}{% endif %}
+```

--- a/AUTOMATION_EXAMPLES.md
+++ b/AUTOMATION_EXAMPLES.md
@@ -30,7 +30,7 @@ The integration fires six events on the Home Assistant event bus at each transit
 {{ as_local(as_datetime(trigger.event.data.offline_since | default(none))) if trigger.event.data.offline_since else "unknown" }}
 ```
 
-**Combined groups fire all six events with the same payload shape** — one event per affected entity. An automation written for an individual group works unchanged on a combined group; just change the `group` name in the trigger filter.
+**Combined groups fire 4 events** (`offline`, `recovered`, `low_battery`, `battery_ok`) **with the same payload shape plus `source_groups`** — one event per affected entity. Stale and signal events are only fired by individual groups.
 
 ---
 
@@ -528,9 +528,7 @@ automation:
 
 ## Combined groups
 
-**Combined groups fire all six events with the same payload shape** — one event per affected entity. An automation written for an individual group works unchanged on a combined group; just change the `group` name in the trigger filter.
-
-**`source_groups` (combined group events only):** a list of the home group name(s) that contain the entity. Single-membership entities yield `["Security Devices"]`; entities shared across multiple home groups list all names.
+**Combined groups fire 4 events** (`offline`, `recovered`, `low_battery`, `battery_ok`) **with the same payload shape plus `source_groups`** — one event per affected entity. Stale and signal events are only fired by individual groups. An automation written for an individual group works unchanged on a combined group for these four event types; just change the `group` name in the trigger filter.
 
 **Avoiding double-fires:** combined groups fire their own event *and* each constituent home group fires its own. To respond only to the combined group, filter on `entry_id` (Settings → Integrations → entry ID in URL) or on the combined group name.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.4.0-beta.2] - 2026-08-05
+## [0.4.0-beta.3] - 2026-08-05
+
+### Added
+- **`group_summary` new count attributes** — `essential` (total essential entities), `stale` (count alias for `stale_entities | length`), `stale_non_essential`, `poor_signal` (count alias for `poor_signal_entities | length`), `poor_signal_non_essential`. Eliminates the need for `| length` in templates and makes automations simpler.
+
+
 
 ### Added
 - **Signal network type auto-inferred** — when the signal sensor name ends in `_linkquality` or `_lqi`, the wizard now pre-selects "Zigbee (LQI)" instead of "Generic/RSSI". Eliminates a manual step for every Z2MQTT device.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file.
 ## [0.4.0-beta.3] - 2026-08-05
 
 ### Added
-- **`group_summary` new count attributes** — `essential` (total essential entities), `stale` (count alias for `stale_entities | length`), `stale_non_essential`, `poor_signal` (count alias for `poor_signal_entities | length`), `poor_signal_non_essential`. Eliminates the need for `| length` in templates and makes automations simpler.
+- **`group_summary` new count attributes** — `essential` (total essential entities = `total_entities - non_essential`), `stale` (count, replaces `stale_entities | length`), `stale_non_essential`, `poor_signal` (count, replaces `poor_signal_entities | length`), `poor_signal_non_essential`. Eliminates boilerplate in templates and automations.
+- **Automation examples**: new `group_summary` template section in `AUTOMATION_EXAMPLES.md` — summary message, status line, degraded trigger, low-battery list, daily health summary.
 
 
 

--- a/README.md
+++ b/README.md
@@ -507,14 +507,16 @@ The integration fires events on the Home Assistant event bus when a monitored en
 |-------|-----------|------|
 | `entity_availability_offline` | An essential entity is confirmed offline | `entity_id`, `group`, `entry_id`, `offline_since`, `offline_count`, `offline_entities`, `source_groups` *(combined only)* |
 | `entity_availability_recovered` | An offline essential entity returns online | `entity_id`, `group`, `entry_id`, `downtime_seconds`, `offline_count`, `offline_entities`, `source_groups` *(combined only)* |
-| `entity_availability_low_battery` | An essential entity's battery drops below threshold | `entity_id`, `group`, `entry_id`, `battery_level`, `low_battery_count`, `low_battery_entities` |
-| `entity_availability_battery_ok` | An essential entity's battery recovers above threshold | `entity_id`, `group`, `entry_id`, `battery_level`, `low_battery_count`, `low_battery_entities` |
-| `entity_availability_stale` | An essential entity stops reporting state changes | `entity_id`, `group`, `entry_id`, `stale_since`, `stale_count`, `stale_entities` |
-| `entity_availability_stale_recovered` | A stale essential entity resumes reporting | `entity_id`, `group`, `entry_id`, `stale_count`, `stale_entities` |
+| `entity_availability_low_battery` | An essential entity's battery drops below threshold | `entity_id`, `group`, `entry_id`, `battery_level`, `low_battery_count`, `low_battery_entities`, `source_groups` *(combined only)* |
+| `entity_availability_battery_ok` | An essential entity's battery recovers above threshold | `entity_id`, `group`, `entry_id`, `battery_level`, `low_battery_count`, `low_battery_entities`, `source_groups` *(combined only)* |
+| `entity_availability_stale` | An essential entity stops reporting state changes *(individual groups only)* | `entity_id`, `group`, `entry_id`, `stale_since`, `stale_count`, `stale_entities` |
+| `entity_availability_stale_recovered` | A stale essential entity resumes reporting *(individual groups only)* | `entity_id`, `group`, `entry_id`, `stale_since`, `stale_count`, `stale_entities` |
+| `entity_availability_poor_signal` | An entity's signal drops to poor quality *(individual groups only)* | `entity_id`, `group`, `entry_id`, `signal_level`, `signal_quality`, `poor_signal_count`, `poor_signal_entities` |
+| `entity_availability_signal_ok` | An entity's signal recovers from poor quality *(individual groups only)* | `entity_id`, `group`, `entry_id`, `signal_level`, `signal_quality`, `poor_signal_count`, `poor_signal_entities` |
 
-`offline_count` and `offline_entities` reflect the group's offline state at the moment of the event. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is already excluded. `offline_since` is always set for individual group events; for combined groups it may be `null` if the coordinator has not yet recorded the transition — guard with `if trigger.event.data.offline_since` before using `as_datetime()`.
+`offline_count` and `offline_entities` reflect the group's offline state at the moment of the event. For `entity_availability_offline` the newly-offline entity is included; for `entity_availability_recovered` it is already excluded. The same snapshot rule applies to all paired events (`low_battery`/`battery_ok`, `stale`/`stale_recovered`, `poor_signal`/`signal_ok`). `offline_since` is always set for individual group events; for combined groups it may be `null` — guard with `if trigger.event.data.offline_since` before using `as_datetime()`.
 
-**Combined groups fire the same events with the same payload shape** — one event per affected entity. An automation written for an individual group works unchanged on a combined group; just change the `group` name in the trigger filter.
+**Combined groups** fire `offline`, `recovered`, `low_battery`, and `battery_ok` events with the same payload plus `source_groups`. Stale and signal events are only fired by individual groups.
 
 **`source_groups` (combined groups only):** a list of the home group names that own the entity. For most entities this is a one-element list (e.g. `["Switches"]`); entities shared across multiple home groups list all names. Use it to include the originating group in notifications:
 

--- a/README.md
+++ b/README.md
@@ -216,30 +216,97 @@ The Group Summary sensor provides a complete overview in its attributes:
 | Attribute | Description |
 |-----------|-------------|
 | `total_entities` | Total number of entities in the group (includes non-essential) |
-| `online` | Entities currently online (excludes suppressed and non-essential) |
-| `offline` | Entities currently offline (excludes suppressed and non-essential) |
-| `suppressed` | Number of suppressed entities |
+| `essential` | Number of essential entities (= `total_entities - non_essential`) |
+| `online` | Essential entities currently online (excludes suppressed) |
+| `offline` | Essential entities currently offline (excludes suppressed) |
+| `suppressed` | Number of suppressed essential entities |
+| `stale` | Number of stale essential entities (count alias for `stale_entities \| length`) |
+| `poor_signal` | Number of essential entities with poor signal (count alias for `poor_signal_entities \| length`) |
 | `non_essential` | Total number of non-essential entities (including suppressed) |
 | `non_essential_entities` | List of unsuppressed non-essential entity IDs (note: `len(non_essential_entities)` < `non_essential` when any NE entities are suppressed) |
-| `battery_powered` | Number of entities with a mapped battery sensor |
-| `low_battery` | Number of entities with battery below threshold (excludes non-essential) |
-| `entities` | List of all monitored entity IDs in this group |
-| `battery_levels` | Dict of `{entity_id: battery_level}` for entities with battery sensors |
-| `suppressed_until` | Which entities are suppressed and when the suppression expires |
-| `stale_entities` | Entities that haven't reported a state change longer than the staleness threshold (excludes non-essential and suppressed) |
-| `stale_entities_non_essential` | Non-essential entities that haven't reported a state change longer than the staleness threshold |
-| `offline_since` | When each currently offline entity first went offline (includes both essential and non-essential entities) |
-| `offline_entities_non_essential` | List of non-essential entity IDs currently offline |
-| `non_essential_suppressed` | Number of non-essential entities currently suppressed |
 | `non_essential_online` | Number of non-essential entities currently online (unsuppressed, not offline) |
 | `non_essential_offline` | Number of non-essential entities currently offline (unsuppressed) |
+| `non_essential_suppressed` | Number of non-essential entities currently suppressed |
+| `stale_non_essential` | Number of stale non-essential entities |
+| `poor_signal_non_essential` | Number of non-essential entities with poor signal |
+| `battery_powered` | Number of entities with a mapped battery sensor |
+| `low_battery` | Number of essential entities with battery below threshold |
 | `low_battery_non_essential` | Number of non-essential entities with battery below threshold |
+| `entities` | List of all monitored entity IDs in this group |
+| `battery_levels` | Dict of `{entity_id: battery_level}` for entities with battery sensors |
+| `signal_levels` | Dict of `{entity_id: signal_value}` for entities with signal sensors (when signal enabled) |
+| `signal_units` | Dict of `{entity_id: unit}` — "LQI", "dBm", or "%" per entity |
+| `suppressed_until` | Which entities are suppressed and when the suppression expires |
+| `stale_entities` | List of stale essential entity IDs (excludes suppressed and offline) |
+| `stale_entities_non_essential` | List of stale non-essential entity IDs |
+| `poor_signal_entities` | List of essential entity IDs with poor signal |
+| `poor_signal_entities_non_essential` | List of non-essential entity IDs with poor signal |
+| `offline_entities_non_essential` | List of non-essential entity IDs currently offline |
+| `offline_since` | When each currently offline entity first went offline |
+| `last_seen` | Last state-change timestamp per entity |
 
 Access these in templates:
 
 ```yaml
-{{ state_attr('sensor.entity_availability_security_devices_group_summary', 'battery_powered') }}
+{{ state_attr('sensor.entity_availability_security_devices_group_summary', 'essential') }}
+{{ state_attr('sensor.entity_availability_security_devices_group_summary', 'online') }}
 {{ state_attr('sensor.entity_availability_security_devices_group_summary', 'offline') }}
+{{ state_attr('sensor.entity_availability_security_devices_group_summary', 'stale') }}
+{{ state_attr('sensor.entity_availability_security_devices_group_summary', 'poor_signal') }}
+```
+
+**Template examples:**
+
+```yaml
+# Summary message
+{% set e = state_attr('sensor.entity_availability_zigbee_devices_group_summary', '') %}
+{% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
+Total {{ s.total_entities }} | Essential {{ s.essential }} ({{ s.online }} online, {{ s.offline }} offline) | NE {{ s.non_essential }} ({{ s.non_essential_online }} online)
+```
+
+```yaml
+# Alert message when devices are offline
+{% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
+{% if s.offline > 0 %}
+⚠️ {{ s.offline }} essential device(s) offline{% if s.stale > 0 %}, {{ s.stale }} stale{% endif %}
+{% else %}
+✅ All {{ s.essential }} essential devices online
+{% endif %}
+```
+
+**Automation example — notify when essential devices go offline:**
+
+```yaml
+automation:
+  - alias: "Notify on Zigbee device offline"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.entity_availability_zigbee_devices_offline_count
+        above: 0
+    action:
+      - service: notify.mobile_app
+        data:
+          message: >
+            {% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
+            {{ s.offline }} device(s) offline.
+            {% for eid in s.offline_entities_non_essential + [] %}{% endfor %}
+```
+
+**Automation example — notify on low battery:**
+
+```yaml
+automation:
+  - alias: "Zigbee low battery alert"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.entity_availability_zigbee_devices_low_battery_count
+        above: 0
+    action:
+      - service: notify.mobile_app
+        data:
+          message: >
+            {% set lvls = state_attr('sensor.entity_availability_zigbee_devices_group_summary', 'battery_levels') %}
+            Low battery: {% for eid, pct in lvls.items() if pct < 30 %}{{ eid.split('.')[-1] }} ({{ pct }}%) {% endfor %}
 ```
 
 ![Sensor Details & Attributes](assets/06_sensor_details_attributes.png)

--- a/README.md
+++ b/README.md
@@ -255,59 +255,7 @@ Access these in templates:
 {{ state_attr('sensor.entity_availability_security_devices_group_summary', 'poor_signal') }}
 ```
 
-**Template examples:**
-
-```yaml
-# Summary message
-{% set e = state_attr('sensor.entity_availability_zigbee_devices_group_summary', '') %}
-{% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
-Total {{ s.total_entities }} | Essential {{ s.essential }} ({{ s.online }} online, {{ s.offline }} offline) | NE {{ s.non_essential }} ({{ s.non_essential_online }} online)
-```
-
-```yaml
-# Alert message when devices are offline
-{% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
-{% if s.offline > 0 %}
-⚠️ {{ s.offline }} essential device(s) offline{% if s.stale > 0 %}, {{ s.stale }} stale{% endif %}
-{% else %}
-✅ All {{ s.essential }} essential devices online
-{% endif %}
-```
-
-**Automation example — notify when essential devices go offline:**
-
-```yaml
-automation:
-  - alias: "Notify on Zigbee device offline"
-    trigger:
-      - platform: numeric_state
-        entity_id: sensor.entity_availability_zigbee_devices_offline_count
-        above: 0
-    action:
-      - service: notify.mobile_app
-        data:
-          message: >
-            {% set s = states['sensor.entity_availability_zigbee_devices_group_summary'].attributes %}
-            {{ s.offline }} device(s) offline.
-            {% for eid in s.offline_entities_non_essential + [] %}{% endfor %}
-```
-
-**Automation example — notify on low battery:**
-
-```yaml
-automation:
-  - alias: "Zigbee low battery alert"
-    trigger:
-      - platform: numeric_state
-        entity_id: sensor.entity_availability_zigbee_devices_low_battery_count
-        above: 0
-    action:
-      - service: notify.mobile_app
-        data:
-          message: >
-            {% set lvls = state_attr('sensor.entity_availability_zigbee_devices_group_summary', 'battery_levels') %}
-            Low battery: {% for eid, pct in lvls.items() if pct < 30 %}{{ eid.split('.')[-1] }} ({{ pct }}%) {% endfor %}
-```
+See [AUTOMATION_EXAMPLES.md](AUTOMATION_EXAMPLES.md) for full template and automation examples.
 
 ![Sensor Details & Attributes](assets/06_sensor_details_attributes.png)
 
@@ -648,18 +596,22 @@ The card works with both regular groups and combined groups. It auto-detects the
 
 ```yaml
 type: custom:entity-availability-card
-group: Security Devices
+group: security_devices        # group slug (lowercase, underscores)
+# title: "My Devices"         # optional override
 show_affected_areas: false
 show_availability: true
 show_entities: true
 show_non_essential_stats: false
 entities_expanded: false
 show_actions: false
+show_suppress_toggle: false
+show_stat_icons: false
+show_table_icons: false
 compact: false
-entity_detail: "off"
-entity_filter: "all"
-sort_by: status
-group_sort_by: name_asc
+entity_detail: "off"           # "off" | "tooltip" | "inline"
+entity_filter: "all"           # "all" | "offline" | "online"
+sort_by: status                # status | name_asc | name_desc | battery_asc | battery_desc
+group_sort_by: name_asc        # name_asc | name_desc | offline_desc (combined groups)
 availability_thresholds:
   high: 99
   mid: 95

--- a/custom_components/entity_availability/__init__.py
+++ b/custom_components/entity_availability/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN, CONF_ENTRY_TYPE, ENTRY_TYPE_COMBINED, ENTRY_TYPE_GROUP
+from .const import CONF_ENTRY_TYPE, DOMAIN, ENTRY_TYPE_COMBINED, ENTRY_TYPE_GROUP
 from .coordinator import EntityAvailabilityCoordinator
 from .services import async_setup_services, async_unload_services
 

--- a/custom_components/entity_availability/binary_sensor.py
+++ b/custom_components/entity_availability/binary_sensor.py
@@ -8,8 +8,8 @@ from typing import Any
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     CONF_ENTRY_TYPE,

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -11,9 +11,9 @@ from typing import Any
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers import entity_registry as er
 
 from .const import (
     CONF_BATTERY_ENTITY_MAP,
@@ -30,8 +30,8 @@ from .const import (
     NO_AREA_SENTINEL,
 )
 from .coordinator import EntityAvailabilityCoordinator
-from .models import DeviceState
 from .helpers import resolve_area_name, resolve_display_name
+from .models import DeviceState
 from .write_dedup import WriteDedupMixin
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -9,13 +9,13 @@ from typing import Any
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import (
     async_call_later,
     async_track_state_change_event,
 )
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.storage import Store
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_BAD_STATES,
@@ -38,20 +38,20 @@ from .const import (
     DEFAULT_STALENESS_USE_LAST_UPDATED,
     EVENT_BATTERY_OK,
     EVENT_LOW_BATTERY,
+    EVENT_OFFLINE,
     EVENT_POOR_SIGNAL,
+    EVENT_RECOVERED,
     EVENT_SIGNAL_OK,
     EVENT_STALE,
     EVENT_STALE_RECOVERED,
-    EVENT_OFFLINE,
-    EVENT_RECOVERED,
     SCAN_INTERVAL,
     SIGNAL_NETWORK_TYPES,
-    SignalQuality,
     STARTUP_GRACE_PERIOD,
     STORAGE_KEY_PREFIX,
     STORAGE_VERSION,
+    SignalQuality,
 )
-from .models import EntityAvailabilityData, DeviceState
+from .models import DeviceState, EntityAvailabilityData
 from .storage import AvailabilityStorage
 
 _LOGGER = logging.getLogger(__name__)
@@ -512,15 +512,14 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                 device.suppress_until = self._suppressed[entity_id]
 
             # Check suppression expiry
-            if device.is_suppressed and device.suppress_until:
-                if now > device.suppress_until:
-                    _LOGGER.debug(
-                        "[%s] Suppression expired for %s", self.group_name, entity_id
-                    )
-                    device.is_suppressed = False
-                    device.suppress_until = None
-                    self._suppressed.pop(entity_id, None)
-                    self._dirty = True
+            if device.is_suppressed and device.suppress_until and now > device.suppress_until:
+                _LOGGER.debug(
+                    "[%s] Suppression expired for %s", self.group_name, entity_id
+                )
+                device.is_suppressed = False
+                device.suppress_until = None
+                self._suppressed.pop(entity_id, None)
+                self._dirty = True
 
             # Skip suppressed devices for availability tracking;
             # clear degraded/stale flags so suppressed entities don't surface
@@ -857,7 +856,7 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
         try:
             for event_name, payload in pending_events:
                 self.hass.bus.async_fire(event_name, payload)
-        except Exception:  # noqa: BLE001  # pragma: no cover
+        except Exception:  # pragma: no cover
             _LOGGER.warning("[%s] Failed to fire event", self.group_name, exc_info=True)
 
         return EntityAvailabilityData(

--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -512,7 +512,11 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                 device.suppress_until = self._suppressed[entity_id]
 
             # Check suppression expiry
-            if device.is_suppressed and device.suppress_until and now > device.suppress_until:
+            if (
+                device.is_suppressed
+                and device.suppress_until
+                and now > device.suppress_until
+            ):
                 _LOGGER.debug(
                     "[%s] Suppression expired for %s", self.group_name, entity_id
                 )

--- a/custom_components/entity_availability/helpers.py
+++ b/custom_components/entity_availability/helpers.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
     area_registry as ar,
+)
+from homeassistant.helpers import (
     device_registry as dr,
+)
+from homeassistant.helpers import (
     entity_registry as er,
 )
 

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -1069,9 +1069,36 @@ class GroupSummarySensor(DedupCoordinatorSensor):
         battery_enabled = self.coordinator.entry.data.get(CONF_BATTERY_THRESHOLD, 0) > 0
         staleness_enabled = self.coordinator._staleness_threshold > 0
         signal_enabled = self.coordinator._signal_enabled
+        essential = total - non_essential
+        poor_signal_ids = (
+            self.coordinator._poor_signal_entity_ids() if signal_enabled else []
+        )
+        poor_signal_ne_ids = (
+            self.coordinator._poor_signal_ne_entity_ids() if signal_enabled else []
+        )
+        ok_signal_ids = (
+            self.coordinator._ok_signal_entity_ids() if signal_enabled else []
+        )
+        stale_ids = [
+            eid
+            for eid, d in states.items()
+            if d.is_stale
+            and not d.is_suppressed
+            and not d.is_non_essential
+            and not d.is_offline
+        ]
+        stale_ne_ids = [
+            eid
+            for eid, d in states.items()
+            if d.is_stale
+            and not d.is_suppressed
+            and d.is_non_essential
+            and not d.is_offline
+        ]
         return {
             "entry_id": self.coordinator.entry.entry_id,
             "total_entities": total,
+            "essential": essential,
             "online": online,
             "offline": offline,
             "suppressed": suppressed,
@@ -1088,6 +1115,10 @@ class GroupSummarySensor(DedupCoordinatorSensor):
             "low_battery": low_battery,
             "low_battery_non_essential": low_battery_non_essential,
             "low_battery_entities": low_battery_entities,
+            "stale": len(stale_ids),
+            "stale_non_essential": len(stale_ne_ids),
+            "poor_signal": len(poor_signal_ids),
+            "poor_signal_non_essential": len(poor_signal_ne_ids),
             "entities": list(self.coordinator.monitored_entities),
             "display_names": {
                 eid: _resolve_display_name(self.hass, eid, use_device_names)
@@ -1108,15 +1139,9 @@ class GroupSummarySensor(DedupCoordinatorSensor):
                 for eid, d in states.items()
                 if signal_enabled and d.signal_unit is not None
             },
-            "poor_signal_entities": self.coordinator._poor_signal_entity_ids()
-            if signal_enabled
-            else [],
-            "poor_signal_entities_non_essential": self.coordinator._poor_signal_ne_entity_ids()
-            if signal_enabled
-            else [],
-            "ok_signal_entities": self.coordinator._ok_signal_entity_ids()
-            if signal_enabled
-            else [],
+            "poor_signal_entities": poor_signal_ids,
+            "poor_signal_entities_non_essential": poor_signal_ne_ids,
+            "ok_signal_entities": ok_signal_ids,
             "suppressed_until": {
                 eid: d.suppress_until.isoformat()
                 if d.suppress_until is not None
@@ -1124,22 +1149,8 @@ class GroupSummarySensor(DedupCoordinatorSensor):
                 for eid, d in states.items()
                 if d.is_suppressed
             },
-            "stale_entities": [
-                eid
-                for eid, d in states.items()
-                if d.is_stale
-                and not d.is_suppressed
-                and not d.is_non_essential
-                and not d.is_offline
-            ],
-            "stale_entities_non_essential": [
-                eid
-                for eid, d in states.items()
-                if d.is_stale
-                and not d.is_suppressed
-                and d.is_non_essential
-                and not d.is_offline
-            ],
+            "stale_entities": stale_ids,
+            "stale_entities_non_essential": stale_ne_ids,
             "offline_since": {
                 eid: d.offline_since.isoformat()
                 for eid, d in states.items()

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -11,9 +11,9 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     CONF_AVAILABILITY_WINDOWS,

--- a/custom_components/entity_availability/services.py
+++ b/custom_components/entity_availability/services.py
@@ -7,7 +7,6 @@ import re
 from datetime import datetime, timedelta, timezone
 
 import voluptuous as vol
-
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 

--- a/custom_components/entity_availability/storage.py
+++ b/custom_components/entity_availability/storage.py
@@ -157,7 +157,7 @@ class AvailabilityStorage:
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "AvailabilityStorage":
+    def from_dict(cls, data: dict[str, Any]) -> AvailabilityStorage:
         """Deserialize from dict."""
         storage = cls()
         for entity_id, buckets_data in data.items():

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+[lint.per-file-ignores]
+"tests/*" = ["BLE001", "S110", "B018", "RUF059", "RUF015", "PERF102", "SIM117"]
+"tests/integration/smoke.py" = ["BLE001", "S110", "B018"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-
-from homeassistant.core import HomeAssistant
 from homeassistant.const import STATE_ON
-
+from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.entity_availability.const import (

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -57,6 +57,7 @@ What is tested (covers PRs #37, #41, #50, #52, #53, #54, #68, core, feat/non-ess
   EC51 signal mapping options flow round-trip: entity_id / entity_id#network keys accepted and stored
   EC52 _detect_signal_entity suffix strip: sensor.xxx_last_seen → suggests sensor.xxx_linkquality
   EC53 diagnostics new schema: counts/entities/config sub-dicts present and correct (replaces flat keys)
+  EC54 group_summary new attrs: essential count, stale/poor_signal count aliases
 
   Non-Essential tier (EC25-EC42, require a group with NE entities — set EA_SMOKE_NE_GROUP):
   EC25 NE entity offline → offline_count unchanged (KPI exclusion)
@@ -2751,6 +2752,60 @@ for e in cfg['data']['entries']:
             )
         except Exception as e:
             chk("EC53 diagnostics endpoint reachable", False, True, str(e))
+
+    # EC54: group_summary new explicit attrs (essential count, stale/poor_signal counts)
+    if ec_enabled(54):
+        print(
+            "\n=== EC54: group_summary essential + stale/poor_signal count attrs ===",
+            flush=True,
+        )
+        attrs = gs(f"{prefix}_group_summary").get("attributes", {})
+        total = attrs.get("total_entities", 0)
+        non_essential = attrs.get("non_essential", 0)
+        expected_essential = total - non_essential
+        chk(
+            "EC54 essential attr present",
+            "essential" in attrs,
+            True,
+            f"attrs keys={[k for k in attrs if 'essential' in k]}",
+        )
+        chk(
+            "EC54 essential = total - non_essential",
+            attrs.get("essential"),
+            expected_essential,
+            f"total={total} non_essential={non_essential}",
+        )
+        chk(
+            "EC54 stale count attr present",
+            "stale" in attrs,
+            True,
+        )
+        chk(
+            "EC54 stale matches stale_entities length",
+            attrs.get("stale"),
+            len(attrs.get("stale_entities", [])),
+            f"stale={attrs.get('stale')} stale_entities={len(attrs.get('stale_entities', []))}",
+        )
+        chk(
+            "EC54 stale_non_essential attr present",
+            "stale_non_essential" in attrs,
+            True,
+        )
+        chk(
+            "EC54 poor_signal count attr present",
+            "poor_signal" in attrs,
+            True,
+        )
+        chk(
+            "EC54 poor_signal matches poor_signal_entities length",
+            attrs.get("poor_signal"),
+            len(attrs.get("poor_signal_entities", [])),
+        )
+        chk(
+            "EC54 poor_signal_non_essential attr present",
+            "poor_signal_non_essential" in attrs,
+            True,
+        )
 
     # ------------------------------------------------------------------
     restore_all(ctx)

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -2792,6 +2792,12 @@ for e in cfg['data']['entries']:
             True,
         )
         chk(
+            "EC54 stale_non_essential matches stale_entities_non_essential length",
+            attrs.get("stale_non_essential"),
+            len(attrs.get("stale_entities_non_essential", [])),
+            f"stale_non_essential={attrs.get('stale_non_essential')}",
+        )
+        chk(
             "EC54 poor_signal count attr present",
             "poor_signal" in attrs,
             True,
@@ -2805,6 +2811,11 @@ for e in cfg['data']['entries']:
             "EC54 poor_signal_non_essential attr present",
             "poor_signal_non_essential" in attrs,
             True,
+        )
+        chk(
+            "EC54 poor_signal_non_essential matches poor_signal_entities_non_essential length",
+            attrs.get("poor_signal_non_essential"),
+            len(attrs.get("poor_signal_entities_non_essential", [])),
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
 from homeassistant.core import HomeAssistant
-
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.entity_availability.binary_sensor import (
@@ -437,12 +435,13 @@ async def test_any_poor_signal_binary_sensor_on_when_essential_poor(
 ) -> None:
     """AnyPoorSignalBinarySensor is ON when an essential entity has poor signal."""
     from unittest.mock import AsyncMock, patch
+
+    from custom_components.entity_availability.binary_sensor import (
+        AnyPoorSignalBinarySensor,
+    )
     from custom_components.entity_availability.const import (
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
-    )
-    from custom_components.entity_availability.binary_sensor import (
-        AnyPoorSignalBinarySensor,
     )
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
@@ -485,12 +484,13 @@ async def test_any_poor_signal_binary_sensor_off_when_signal_good(
 ) -> None:
     """AnyPoorSignalBinarySensor is OFF when all essential entities have good signal."""
     from unittest.mock import AsyncMock, patch
+
+    from custom_components.entity_availability.binary_sensor import (
+        AnyPoorSignalBinarySensor,
+    )
     from custom_components.entity_availability.const import (
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
-    )
-    from custom_components.entity_availability.binary_sensor import (
-        AnyPoorSignalBinarySensor,
     )
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
@@ -529,13 +529,14 @@ async def test_any_poor_signal_binary_sensor_off_when_only_ne_is_poor(
 ) -> None:
     """AnyPoorSignalBinarySensor stays OFF when only a NE entity has poor signal."""
     from unittest.mock import AsyncMock, patch
+
+    from custom_components.entity_availability.binary_sensor import (
+        AnyPoorSignalBinarySensor,
+    )
     from custom_components.entity_availability.const import (
         CONF_NON_ESSENTIAL_ENTITIES,
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
-    )
-    from custom_components.entity_availability.binary_sensor import (
-        AnyPoorSignalBinarySensor,
     )
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
@@ -574,12 +575,12 @@ async def test_binary_sensor_setup_entry_with_signal_enabled(
     mock_hass: HomeAssistant, mock_config_data
 ) -> None:
     """async_setup_entry adds AnyPoorSignalBinarySensor when signal_enabled=True."""
+    from custom_components.entity_availability.binary_sensor import (
+        AnyPoorSignalBinarySensor,
+    )
     from custom_components.entity_availability.const import (
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
-    )
-    from custom_components.entity_availability.binary_sensor import (
-        AnyPoorSignalBinarySensor,
     )
 
     hass = mock_hass
@@ -618,6 +619,7 @@ async def test_any_low_battery_non_essential_binary_sensor_on(
 ) -> None:
     """AnyLowBatteryNonEssentialBinarySensor is ON when a NE entity has low battery."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.binary_sensor import (
         AnyLowBatteryNonEssentialBinarySensor,
     )
@@ -648,6 +650,7 @@ async def test_any_low_battery_non_essential_binary_sensor_off_when_essential_lo
 ) -> None:
     """AnyLowBatteryNonEssentialBinarySensor stays OFF when only essential has low battery."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.binary_sensor import (
         AnyLowBatteryNonEssentialBinarySensor,
     )
@@ -674,6 +677,7 @@ async def test_any_poor_signal_non_essential_binary_sensor_on(
 ) -> None:
     """AnyPoorSignalNonEssentialBinarySensor is ON when a NE entity has poor signal."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.binary_sensor import (
         AnyPoorSignalNonEssentialBinarySensor,
     )
@@ -701,6 +705,7 @@ async def test_any_poor_signal_non_essential_off_when_essential_poor(
 ) -> None:
     """AnyPoorSignalNonEssentialBinarySensor OFF when only essential has poor signal."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.binary_sensor import (
         AnyPoorSignalNonEssentialBinarySensor,
     )

--- a/tests/test_card_sort.py
+++ b/tests/test_card_sort.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import functools
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
@@ -18,7 +17,7 @@ class EntityItem:
     name: str
     dot_color: str  # "green" | "yellow" | "red"
     status: str
-    battery: Optional[int]
+    battery: int | None
     is_offline: bool
 
 
@@ -61,7 +60,7 @@ def sort_entities(items: list[EntityItem], sort_by: str = "status") -> list[Enti
 # ---------------------------------------------------------------------------
 
 
-def _online(name: str, battery: Optional[int] = None) -> EntityItem:
+def _online(name: str, battery: int | None = None) -> EntityItem:
     dot = "yellow" if battery is not None and battery < 20 else "green"
     status = "Low Battery" if dot == "yellow" else "Online"
     return EntityItem(
@@ -74,7 +73,7 @@ def _online(name: str, battery: Optional[int] = None) -> EntityItem:
     )
 
 
-def _offline(name: str, battery: Optional[int] = None) -> EntityItem:
+def _offline(name: str, battery: int | None = None) -> EntityItem:
     return EntityItem(
         entity_id=f"binary_sensor.{name.lower().replace(' ', '_')}",
         name=name,

--- a/tests/test_combined_binary_sensor.py
+++ b/tests/test_combined_binary_sensor.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.core import HomeAssistant
-
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.entity_availability.combined_binary_sensor import (
@@ -28,7 +26,6 @@ from custom_components.entity_availability.coordinator import (
     EntityAvailabilityCoordinator,
 )
 from custom_components.entity_availability.models import DeviceState
-
 
 # ---------------------------------------------------------------------------
 # Fixtures (mirror those in test_combined_sensor.py)

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -6,10 +6,8 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.entity_availability.combined_sensor import (
@@ -48,7 +46,6 @@ from custom_components.entity_availability.coordinator import (
     EntityAvailabilityCoordinator,
 )
 from custom_components.entity_availability.models import DeviceState
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -2678,8 +2675,9 @@ class TestCombinedAffectedAreasSensors:
         self, mock_hass, combined_entry, coordinators
     ):
         """Per-coordinator window respected — one inside, one outside."""
-        from custom_components.entity_availability.const import CONF_RECOVERY_WINDOW
         from datetime import timedelta
+
+        from custom_components.entity_availability.const import CONF_RECOVERY_WINDOW
 
         mock_hass.data[DOMAIN] = {
             "entry_a": coordinators[0],

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2226,6 +2226,31 @@ async def test_detect_signal_entity_via_naming_convention_linkquality(
     assert result["step_id"] == "signal_mapping"
 
 
+async def test_detect_signal_entity_strips_last_updated_suffix(
+    hass: HomeAssistant,
+) -> None:
+    """_detect_signal_entity strips _last_updated before naming convention fallback."""
+    from unittest.mock import MagicMock, patch
+
+    mock_ent_reg = MagicMock()
+    mock_ent_reg.async_get.return_value = None
+
+    hass.states.async_set("sensor.boiler_high_flood_sensor_linkquality", "120")
+
+    with patch(
+        "custom_components.entity_availability.config_flow.er.async_get",
+        return_value=mock_ent_reg,
+    ):
+        from custom_components.entity_availability.config_flow import (
+            _detect_signal_entity,
+        )
+
+        result = _detect_signal_entity(
+            hass, "sensor.boiler_high_flood_sensor_last_updated"
+        )
+        assert result == "sensor.boiler_high_flood_sensor_linkquality"
+
+
 async def test_detect_signal_entity_no_match_returns_empty(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,10 +6,8 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
-
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.entity_availability.const import (
@@ -4482,6 +4480,7 @@ async def test_handle_state_change_records_last_changed(
 ) -> None:
     """_handle_state_change captures last_changed from the event new_state."""
     from homeassistant.core import Event, EventOrigin
+
     from custom_components.entity_availability.models import DeviceState
 
     hass = mock_hass
@@ -4558,6 +4557,7 @@ async def test_handle_state_change_naive_ts_gets_utc(
 ) -> None:
     """_handle_state_change adds UTC tzinfo to naive last_changed timestamps."""
     from homeassistant.core import Event, EventOrigin
+
     from custom_components.entity_availability.models import DeviceState
 
     hass = mock_hass
@@ -4651,6 +4651,7 @@ async def test_restart_scenario_persisted_last_changed_survives(
 ) -> None:
     """End-to-end: event fires → timestamp stored → coordinator restart → polling doesn't overwrite → stale detection uses persisted value."""
     from homeassistant.core import Event, EventOrigin
+
     from custom_components.entity_availability.models import DeviceState
 
     hass = mock_hass

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 from homeassistant.core import HomeAssistant
-
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.entity_availability import (
@@ -680,8 +678,8 @@ async def test_register_lovelace_resource_single_existing_no_duplicate_loop(
     """
     from custom_components.entity_availability import (
         CARD_URL,
-        _async_register_lovelace_resource,
         ResourceStorageCollection,
+        _async_register_lovelace_resource,
     )
 
     hass = mock_hass

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2935,7 +2935,9 @@ class TestNonEssentialKpiExclusion:
         sensor.hass = mock_hass
         attrs = sensor.extra_state_attributes
         assert attrs["stale"] == len(attrs["stale_entities"])
-        assert attrs["stale_non_essential"] == len(attrs["stale_entities_non_essential"])
+        assert attrs["stale_non_essential"] == len(
+            attrs["stale_entities_non_essential"]
+        )
         assert attrs["stale"] >= 1
         assert attrs["stale_non_essential"] >= 1
 
@@ -2951,7 +2953,9 @@ class TestNonEssentialKpiExclusion:
         sensor.hass = mock_hass
         attrs = sensor.extra_state_attributes
         assert attrs["poor_signal"] == len(attrs["poor_signal_entities"])
-        assert attrs["poor_signal_non_essential"] == len(attrs["poor_signal_entities_non_essential"])
+        assert attrs["poor_signal_non_essential"] == len(
+            attrs["poor_signal_entities_non_essential"]
+        )
         assert attrs["poor_signal"] == 1
 
     def test_group_summary_online_formula_no_overlap(self, mock_coordinator, mock_hass):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2914,6 +2914,46 @@ class TestNonEssentialKpiExclusion:
             == total
         )
 
+    def test_group_summary_essential_attr(self, mock_coordinator, mock_hass):
+        """essential = total_entities - non_essential."""
+        mock_coordinator.device_states["binary_sensor.device_a"].is_non_essential = True
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert attrs["essential"] == attrs["total_entities"] - attrs["non_essential"]
+
+    def test_group_summary_stale_count_attr(self, mock_coordinator, mock_hass):
+        """stale == len(stale_entities); stale_non_essential == len(stale_entities_non_essential)."""
+        mock_coordinator.device_states["binary_sensor.device_a"].is_stale = True
+        mock_coordinator.device_states["binary_sensor.device_c"].is_non_essential = True
+        mock_coordinator.device_states["binary_sensor.device_c"].is_stale = True
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert attrs["stale"] == len(attrs["stale_entities"])
+        assert attrs["stale_non_essential"] == len(attrs["stale_entities_non_essential"])
+        assert attrs["stale"] >= 1
+        assert attrs["stale_non_essential"] >= 1
+
+    def test_group_summary_poor_signal_count_attr(self, mock_coordinator, mock_hass):
+        """poor_signal == len(poor_signal_entities)."""
+        mock_coordinator._poor_signal_entity_ids = lambda: ["binary_sensor.device_a"]
+        mock_coordinator._poor_signal_ne_entity_ids = lambda: []
+        mock_coordinator._ok_signal_entity_ids = lambda: []
+        mock_coordinator._signal_enabled = True
+        sensor = GroupSummarySensor(
+            mock_coordinator, "Test Group", "test_group", "test_entry_id"
+        )
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert attrs["poor_signal"] == len(attrs["poor_signal_entities"])
+        assert attrs["poor_signal_non_essential"] == len(attrs["poor_signal_entities_non_essential"])
+        assert attrs["poor_signal"] == 1
+
     def test_group_summary_online_formula_no_overlap(self, mock_coordinator, mock_hass):
         """online count never includes non-essential entities."""
         mock_coordinator.device_states["binary_sensor.device_a"].is_non_essential = True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,14 +5,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from freezegun import freeze_time
-
 import pytest
-
+from freezegun import freeze_time
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import STATE_UNAVAILABLE, EntityCategory
 from homeassistant.core import HomeAssistant
-
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.entity_availability.const import (
@@ -28,6 +25,7 @@ from custom_components.entity_availability.coordinator import (
 )
 from custom_components.entity_availability.models import DeviceState
 from custom_components.entity_availability.sensor import (
+    MAX_STATE_LENGTH,
     AffectedAreasCountSensor,
     AffectedAreasRecentlyOfflineSensor,
     AffectedAreasRecentlyRecoveredSensor,
@@ -36,7 +34,7 @@ from custom_components.entity_availability.sensor import (
     DegradedDevicesSensor,
     GroupSummarySensor,
     LowBatteryCountSensor,
-    MAX_STATE_LENGTH,
+    MTBFSensor,
     MTTRSensor,
     NonEssentialLowBatteryCountSensor,
     NonEssentialLowBatterySensor,
@@ -50,7 +48,6 @@ from custom_components.entity_availability.sensor import (
     RecentlyRecoveredSensor,
     StaleCountSensor,
     StaleEntitiesSensor,
-    MTBFSensor,
     async_setup_entry,
 )
 
@@ -1623,8 +1620,12 @@ class TestAvailabilitySensorMinuteTruncation:
 # ---------------------------------------------------------------------------
 
 
-from custom_components.entity_availability.sensor import _resolve_display_name  # noqa: E402
-from custom_components.entity_availability.const import CONF_USE_DEVICE_NAMES  # noqa: E402
+from custom_components.entity_availability.const import (
+    CONF_USE_DEVICE_NAMES,
+)
+from custom_components.entity_availability.sensor import (
+    _resolve_display_name,
+)
 
 
 class TestResolveDisplayName:
@@ -2944,8 +2945,8 @@ class TestNonEssentialKpiExclusion:
     def test_group_summary_poor_signal_count_attr(self, mock_coordinator, mock_hass):
         """poor_signal == len(poor_signal_entities)."""
         mock_coordinator._poor_signal_entity_ids = lambda: ["binary_sensor.device_a"]
-        mock_coordinator._poor_signal_ne_entity_ids = lambda: []
-        mock_coordinator._ok_signal_entity_ids = lambda: []
+        mock_coordinator._poor_signal_ne_entity_ids = list
+        mock_coordinator._ok_signal_entity_ids = list
         mock_coordinator._signal_enabled = True
         sensor = GroupSummarySensor(
             mock_coordinator, "Test Group", "test_group", "test_entry_id"
@@ -3030,6 +3031,7 @@ class TestNonEssentialKpiExclusion:
     def test_recently_offline_excludes_non_essential(self, mock_coordinator, mock_hass):
         """RecentlyOfflineSensor does not include non-essential offline entities."""
         from datetime import timezone
+
         from custom_components.entity_availability.sensor import RecentlyOfflineSensor
 
         mock_coordinator.device_states["binary_sensor.device_b"].is_offline = True
@@ -3048,6 +3050,7 @@ class TestNonEssentialKpiExclusion:
     ):
         """RecentlyRecoveredSensor does not include non-essential recovered entities."""
         from datetime import timezone
+
         from custom_components.entity_availability.sensor import RecentlyRecoveredSensor
 
         mock_coordinator.device_states["binary_sensor.device_a"].is_non_essential = True
@@ -3348,14 +3351,15 @@ async def test_poor_signal_sensor_lists_poor_entities(
 ) -> None:
     """PoorSignalSensor shows names of essential entities with poor signal."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.const import (
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
     )
-    from custom_components.entity_availability.sensor import PoorSignalSensor
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
     )
+    from custom_components.entity_availability.sensor import PoorSignalSensor
 
     hass.states.async_set("binary_sensor.device_a", "on", {"friendly_name": "Device A"})
     hass.states.async_set("sensor.device_a_rssi", "-85")
@@ -3398,15 +3402,16 @@ async def test_poor_signal_count_sensor_counts_essential_only(
 ) -> None:
     """PoorSignalCountSensor counts only essential, non-suppressed entities with poor signal."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.const import (
         CONF_NON_ESSENTIAL_ENTITIES,
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
     )
-    from custom_components.entity_availability.sensor import PoorSignalCountSensor
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
     )
+    from custom_components.entity_availability.sensor import PoorSignalCountSensor
 
     hass.states.async_set("binary_sensor.device_a", "on")
     hass.states.async_set("binary_sensor.device_c", "on")
@@ -3446,16 +3451,17 @@ async def test_ne_poor_signal_count_sensor(
 ) -> None:
     """NonEssentialPoorSignalCountSensor counts only NE entities with poor signal."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.const import (
         CONF_NON_ESSENTIAL_ENTITIES,
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
     )
-    from custom_components.entity_availability.sensor import (
-        NonEssentialPoorSignalCountSensor,
-    )
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
+    )
+    from custom_components.entity_availability.sensor import (
+        NonEssentialPoorSignalCountSensor,
     )
 
     hass.states.async_set("binary_sensor.device_c", "on")
@@ -3492,14 +3498,15 @@ async def test_poor_signal_sensor_returns_none_when_signal_good(
 ) -> None:
     """PoorSignalSensor returns 'None' string when all entities have good signal."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.const import (
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
     )
-    from custom_components.entity_availability.sensor import PoorSignalSensor
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
     )
+    from custom_components.entity_availability.sensor import PoorSignalSensor
 
     hass.states.async_set("binary_sensor.device_a", "on")
     hass.states.async_set("sensor.a_rssi", "-40")  # good wifi
@@ -3607,15 +3614,16 @@ async def test_poor_signal_sensor_truncates_long_names(
 ) -> None:
     """PoorSignalSensor truncates value when it exceeds MAX_STATE_LENGTH."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.const import (
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
     )
-    from custom_components.entity_availability.sensor import PoorSignalSensor
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
     )
     from custom_components.entity_availability.models import DeviceState
+    from custom_components.entity_availability.sensor import PoorSignalSensor
 
     # Create a coordinator with many poor-signal entities with long names
     data = dict(mock_config_entry.data)
@@ -3656,15 +3664,16 @@ async def test_poor_signal_sensor_extra_state_attributes(
 ) -> None:
     """PoorSignalSensor.extra_state_attributes returns devices dict with signal info."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.const import (
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
     )
-    from custom_components.entity_availability.sensor import PoorSignalSensor
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
     )
     from custom_components.entity_availability.models import DeviceState
+    from custom_components.entity_availability.sensor import PoorSignalSensor
 
     data = dict(mock_config_entry.data)
     data[CONF_SIGNAL_ENABLED] = True
@@ -3700,17 +3709,18 @@ async def test_ne_poor_signal_sensor_extra_state_attributes(
 ) -> None:
     """NonEssentialPoorSignalSensor.extra_state_attributes returns NE devices."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.const import (
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
-    )
-    from custom_components.entity_availability.sensor import (
-        NonEssentialPoorSignalSensor,
     )
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
     )
     from custom_components.entity_availability.models import DeviceState
+    from custom_components.entity_availability.sensor import (
+        NonEssentialPoorSignalSensor,
+    )
 
     data = dict(mock_config_entry.data)
     data[CONF_SIGNAL_ENABLED] = True
@@ -3760,15 +3770,16 @@ async def test_ne_poor_signal_sensor_returns_none_string_when_empty(
 ) -> None:
     """NonEssentialPoorSignalSensor returns 'None' when no NE entities have poor signal."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.const import (
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
     )
-    from custom_components.entity_availability.sensor import (
-        NonEssentialPoorSignalSensor,
-    )
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
+    )
+    from custom_components.entity_availability.sensor import (
+        NonEssentialPoorSignalSensor,
     )
 
     data = dict(mock_config_entry.data)
@@ -3799,17 +3810,18 @@ async def test_ne_poor_signal_sensor_non_truncated_path(
 ) -> None:
     """NonEssentialPoorSignalSensor returns short non-truncated result."""
     from unittest.mock import AsyncMock, patch
+
     from custom_components.entity_availability.const import (
         CONF_SIGNAL_ENABLED,
         CONF_SIGNAL_ENTITY_MAP,
-    )
-    from custom_components.entity_availability.sensor import (
-        NonEssentialPoorSignalSensor,
     )
     from custom_components.entity_availability.coordinator import (
         EntityAvailabilityCoordinator,
     )
     from custom_components.entity_availability.models import DeviceState
+    from custom_components.entity_availability.sensor import (
+        NonEssentialPoorSignalSensor,
+    )
 
     hass.states.async_set("binary_sensor.ne_a", "on", {"friendly_name": "NE A"})
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
 from homeassistant.core import HomeAssistant
 
 from custom_components.entity_availability.const import DOMAIN
@@ -516,6 +515,7 @@ async def test_suppress_updates_all_coordinators_sharing_entity(
 ) -> None:
     """Suppress service calls suppress_entity on ALL coordinators that monitor the entity."""
     from pytest_homeassistant_custom_component.common import MockConfigEntry
+
     from custom_components.entity_availability.const import CONF_ENTITIES
 
     hass = mock_hass
@@ -650,6 +650,7 @@ async def test_suppress_with_group_scopes_to_that_group(
 ) -> None:
     """suppress with entity_id+group only suppresses in the named group."""
     from pytest_homeassistant_custom_component.common import MockConfigEntry
+
     from custom_components.entity_availability.const import CONF_ENTITIES
 
     hass = mock_hass
@@ -710,6 +711,7 @@ async def test_suppress_indefinitely_with_group_scopes_to_that_group(
 ) -> None:
     """suppress_indefinitely with entity_id+group only suppresses in the named group."""
     from pytest_homeassistant_custom_component.common import MockConfigEntry
+
     from custom_components.entity_availability.const import CONF_ENTITIES
 
     hass = mock_hass
@@ -766,6 +768,7 @@ async def test_unsuppress_with_group_scopes_to_that_group(
 ) -> None:
     """unsuppress with entity_id+group only unsuppresses in the named group."""
     from pytest_homeassistant_custom_component.common import MockConfigEntry
+
     from custom_components.entity_availability.const import CONF_ENTITIES
 
     hass = mock_hass
@@ -826,6 +829,7 @@ async def test_reset_statistics_with_group_scopes_to_that_group(
 ) -> None:
     """reset_statistics with entity_id+group only resets in the named group."""
     from pytest_homeassistant_custom_component.common import MockConfigEntry
+
     from custom_components.entity_availability.const import CONF_ENTITIES
 
     hass = mock_hass
@@ -1046,6 +1050,7 @@ async def test_reset_statistics_with_group_slug(
 ) -> None:
     """reset_statistics with slug form of group name resets only the matching group."""
     from pytest_homeassistant_custom_component.common import MockConfigEntry
+
     from custom_components.entity_availability.const import CONF_ENTITIES
 
     hass = mock_hass
@@ -1105,6 +1110,7 @@ async def test_reset_statistics_group_only_slug(
 ) -> None:
     """reset_statistics with group-only slug (no entity_id) resets all in matched group only."""
     from pytest_homeassistant_custom_component.common import MockConfigEntry
+
     from custom_components.entity_availability.const import CONF_ENTITIES
 
     hass = mock_hass

--- a/tests/test_write_dedup.py
+++ b/tests/test_write_dedup.py
@@ -6,10 +6,8 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.entity_availability.binary_sensor import AnyOfflineBinarySensor
@@ -40,10 +38,10 @@ from custom_components.entity_availability.sensor import (
     RecentlyRecoveredSensor,
 )
 from custom_components.entity_availability.write_dedup import (
+    _UNSET,
     DedupCoordinatorBinarySensor,
     DedupCoordinatorSensor,
     WriteDedupMixin,
-    _UNSET,
 )
 
 


### PR DESCRIPTION
## Summary

Adds explicit count attributes to `group_summary` that were previously only derivable via templates.

### New attributes

| Attribute | Value |
|-----------|-------|
| `essential` | `total_entities - non_essential` — no more manual subtraction |
| `stale` | Count of stale essential entities (= `stale_entities \| length`) |
| `stale_non_essential` | Count of stale non-essential entities |
| `poor_signal` | Count of essential entities with poor signal |
| `poor_signal_non_essential` | Count of NE entities with poor signal |

### Before
```yaml
{% set s = state_attr('sensor.entity_availability_zigbee_devices_group_summary', ...) %}
Essential: {{ s.total_entities - s.non_essential }}
Stale: {{ s.stale_entities | length }}
```

### After
```yaml
Essential: {{ s.essential }}
Stale: {{ s.stale }}
```

### Also
- Refactored `extra_state_attributes` to pre-compute stale/signal lists once instead of three separate list comprehensions
- README updated with full attr table + template and automation examples
- EC54 smoke test added

## Test plan
- [ ] `pytest tests/` — 787 passing
- [ ] EC54 smoke passing on devcontainer