### PR TITLE
fix(recorder): exclude large attrs from HA recorder (16KB limit)

### DIFF
--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -219,6 +219,7 @@ class CombinedGroupSensor(CombinedSensorBase):
     # Per-entity list/dict attrs: large, no historical value.
     _unrecorded_attributes = frozenset(
         {
+            "display_names",
             "entities",
             "groups",
             "offline_entities",

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -216,6 +216,17 @@ class CombinedGroupSensor(CombinedSensorBase):
     _attr_icon = "mdi:format-list-group"
     # No state_class: see GroupSummarySensor.
 
+    # Per-entity list/dict attrs: large, no historical value.
+    _unrecorded_attributes = frozenset(
+        {
+            "entities",
+            "groups",
+            "offline_entities",
+            "low_battery_entities",
+            "non_essential_entities",
+        }
+    )
+
     def __init__(self, hass, entry, group_name, group_slug, combined_entry_ids):
         super().__init__(hass, entry, group_name, group_slug, combined_entry_ids)
         self._attr_unique_id = f"{entry.entry_id}_combined_summary"

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -949,6 +949,28 @@ class GroupSummarySensor(DedupCoordinatorSensor):
     # so the sensor only writes when monitoring data actually changes.
     _EA_SKIP_DEDUP_KEYS = frozenset({"last_seen"})
 
+    # Large dict/list attrs: live state machine access is fine but no value in
+    # recording per-entity snapshots historically. Keeps recorder rows small.
+    _unrecorded_attributes = frozenset(
+        {
+            "display_names",
+            "battery_levels",
+            "signal_levels",
+            "signal_units",
+            "last_seen",
+            "ok_signal_entities",
+            "entities",
+            "offline_since",
+            "suppressed_until",
+            "stale_entities",
+            "stale_entities_non_essential",
+            "poor_signal_entities",
+            "poor_signal_entities_non_essential",
+            "offline_entities_non_essential",
+            "non_essential_entities",
+        }
+    )
+
     def _ea_should_write(self) -> bool:
         """Write only when attrs excluding last_seen change."""
         value = self._ea_current_value()

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -955,6 +955,7 @@ class GroupSummarySensor(DedupCoordinatorSensor):
         {
             "display_names",
             "battery_levels",
+            "low_battery_entities",
             "signal_levels",
             "signal_units",
             "last_seen",

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -58,6 +58,7 @@ What is tested (covers PRs #37, #41, #50, #52, #53, #54, #68, core, feat/non-ess
   EC52 _detect_signal_entity suffix strip: sensor.xxx_last_seen → suggests sensor.xxx_linkquality
   EC53 diagnostics new schema: counts/entities/config sub-dicts present and correct (replaces flat keys)
   EC54 group_summary new attrs: essential count, stale/poor_signal count aliases
+  EC55 group_summary large attrs excluded from recorder (_unrecorded_attributes) but present in state machine
 
   Non-Essential tier (EC25-EC42, require a group with NE entities — set EA_SMOKE_NE_GROUP):
   EC25 NE entity offline → offline_count unchanged (KPI exclusion)
@@ -2817,6 +2818,44 @@ for e in cfg['data']['entries']:
             attrs.get("poor_signal_non_essential"),
             len(attrs.get("poor_signal_entities_non_essential", [])),
         )
+
+    # EC55: _unrecorded_attributes — large attrs excluded from recorder but present in state machine
+    if ec_enabled(55):
+        print(
+            "\n=== EC55: group_summary large attrs excluded from recorder but present in state ===",
+            flush=True,
+        )
+        attrs = gs(f"{prefix}_group_summary").get("attributes", {})
+        # These attrs must be PRESENT in the live state (available to templates/card)
+        for attr in [
+            "entities",
+            "display_names",
+            "battery_levels",
+            "last_seen",
+            "stale_entities",
+            "poor_signal_entities",
+            "offline_since",
+        ]:
+            chk(
+                f"EC55 {attr} present in live state",
+                attr in attrs,
+                True,
+                f"attrs keys (sample)={list(attrs.keys())[:10]}",
+            )
+        # KPI counts must also be present (these ARE recorded)
+        for attr in [
+            "online",
+            "offline",
+            "essential",
+            "stale",
+            "poor_signal",
+            "battery_enabled",
+        ]:
+            chk(
+                f"EC55 {attr} present (KPI, recorded)",
+                attr in attrs,
+                True,
+            )
 
     # ------------------------------------------------------------------
     restore_all(ctx)

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -2831,10 +2831,13 @@ for e in cfg['data']['entries']:
             "entities",
             "display_names",
             "battery_levels",
+            "low_battery_entities",
             "last_seen",
             "stale_entities",
             "poor_signal_entities",
             "offline_since",
+            "suppressed_until",
+            "non_essential_entities",
         ]:
             chk(
                 f"EC55 {attr} present in live state",


### PR DESCRIPTION
## Problem

`group_summary` sensor attributes exceed HA's 16KB recorder limit for groups with 50+ entities. HA logs:

> State attributes for sensor.entity_availability_zigbee_devices_group_summary exceed maximum size of 16384 bytes. Attributes will not be stored.

## Solution

Add `_unrecorded_attributes` (HA 2023.9+) to `GroupSummarySensor` and `CombinedGroupSensor`. Excludes large per-entity dicts/lists from the recorder while keeping them fully accessible in templates, cards, and automations.

**Excluded from recording:**
- `display_names`, `battery_levels`, `signal_levels`, `signal_units`, `last_seen`
- `ok_signal_entities`, `entities`, `offline_since`, `suppressed_until`
- `stale_entities`, `stale_entities_non_essential`
- `poor_signal_entities`, `poor_signal_entities_non_essential`
- `offline_entities_non_essential`, `non_essential_entities`
- Combined: `entities`, `groups`, `offline_entities`, `low_battery_entities`, `non_essential_entities`

**Still recorded (KPIs + flags):**
- `online`, `offline`, `essential`, `non_essential`, `suppressed`, `stale`, `poor_signal`
- `battery_enabled`, `staleness_enabled`, `signal_enabled`, `battery_powered`
- `low_battery`, `low_battery_non_essential`, `total_entities`, `entry_id`

## Test plan
- [ ] `pytest tests/` — 791 passing
- [ ] Deploy to HAOS — no more 16KB warning in logs
- [ ] Templates and card still work with full attrs