### PR TITLE
fix(coordinator): track battery sensor state changes + smoke test improvements

### DIFF
--- a/custom_components/entity_availability/coordinator.py
+++ b/custom_components/entity_availability/coordinator.py
@@ -430,6 +430,10 @@ class EntityAvailabilityCoordinator(DataUpdateCoordinator[EntityAvailabilityData
                 m["sensor"] for m in self._signal_map.values() if m.get("sensor")
             ]
             tracked = list(dict.fromkeys(tracked + signal_sensors))
+        battery_map = self.entry.data.get(CONF_BATTERY_ENTITY_MAP, {})
+        battery_sensors = [v for v in battery_map.values() if v]
+        if battery_sensors:
+            tracked = list(dict.fromkeys(tracked + battery_sensors))
         self._unsub_state_change = async_track_state_change_event(
             self.hass, tracked, self._handle_state_change
         )

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -1247,14 +1247,18 @@ def _run_ne_tests(ne_ctx: dict) -> None:
             ss(target, "unavailable", {"friendly_name": "smoke test"})
             # Poll until entity appears in recently_offline list
             wait_for(
-                lambda: target
-                in gs(f"{prefix}_recently_offline")
-                .get("attributes", {})
-                .get("entities", []),
+                lambda: (
+                    target
+                    in gs(f"{prefix}_recently_offline")
+                    .get("attributes", {})
+                    .get("entities", [])
+                ),
                 True,
             )
             recent_entities = (
-                gs(f"{prefix}_recently_offline").get("attributes", {}).get("entities", [])
+                gs(f"{prefix}_recently_offline")
+                .get("attributes", {})
+                .get("entities", [])
             )
             chk(
                 "EC41 recently_offline lists entity",
@@ -1276,18 +1280,22 @@ def _run_ne_tests(ne_ctx: dict) -> None:
             target = essential_entities[0] if essential_entities else ne_entities[0]
             ss(target, "unavailable", {"friendly_name": "smoke test"})
             wait_for(
-                lambda: target
-                in gs(f"{prefix}_recently_offline")
-                .get("attributes", {})
-                .get("entities", []),
+                lambda: (
+                    target
+                    in gs(f"{prefix}_recently_offline")
+                    .get("attributes", {})
+                    .get("entities", [])
+                ),
                 True,
             )
             ss(target, "on", {"friendly_name": target.split(".")[-1]})
             wait_for(
-                lambda: target
-                in gs(f"{prefix}_recently_recovered")
-                .get("attributes", {})
-                .get("entities", []),
+                lambda: (
+                    target
+                    in gs(f"{prefix}_recently_recovered")
+                    .get("attributes", {})
+                    .get("entities", [])
+                ),
                 True,
             )
             recent_entities = (

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -646,7 +646,11 @@ def _run_ne_tests(ne_ctx: dict) -> None:
         )
         baseline = gs(f"{prefix}_offline_count").get("state", "0")
         ss(ne_target, "unavailable", {"friendly_name": "ne test"})
-        wait(12)
+        # Poll NE offline count to confirm coordinator processed the state change
+        wait_for(
+            lambda: gs(f"{prefix}_offline_count_non_essential").get("state"),
+            "1",
+        )
         chk(
             "EC25 offline_count unchanged",
             gs(f"{prefix}_offline_count").get("state"),
@@ -663,7 +667,9 @@ def _run_ne_tests(ne_ctx: dict) -> None:
         # ne_target already offline from EC25 or restored
         if not ec_enabled(25):
             ss(ne_target, "unavailable", {"friendly_name": "ne test"})
-            wait(12)
+            wait_for(
+                lambda: gs(f"{prefix}_offline_count_non_essential").get("state"), "1"
+            )
         chk(
             "EC26 offline_count_non_essential=1",
             wait_for(
@@ -682,7 +688,9 @@ def _run_ne_tests(ne_ctx: dict) -> None:
         )
         if not ec_enabled(25) and not ec_enabled(26):
             ss(ne_target, "unavailable", {"friendly_name": "ne test"})
-            wait(12)
+            wait_for(
+                lambda: gs(f"{prefix}_offline_count_non_essential").get("state"), "1"
+            )
         chk(
             "EC27 any_offline=off (NE excluded)",
             gs(f"{ne_bs_prefix}_any_offline").get("state"),
@@ -698,7 +706,9 @@ def _run_ne_tests(ne_ctx: dict) -> None:
         )
         if not any(ec_enabled(n) for n in [25, 26, 27]):
             ss(ne_target, "unavailable", {"friendly_name": "ne test"})
-            wait(12)
+            wait_for(
+                lambda: gs(f"{prefix}_offline_count_non_essential").get("state"), "1"
+            )
         chk(
             "EC28 any_offline_non_essential=on",
             wait_for(
@@ -716,11 +726,20 @@ def _run_ne_tests(ne_ctx: dict) -> None:
         )
         if not any(ec_enabled(n) for n in [25, 26, 27, 28]):
             ss(ne_target, "unavailable", {"friendly_name": "ne test"})
-            wait(12)
+            wait_for(
+                lambda: gs(f"{prefix}_offline_count_non_essential").get("state"), "1"
+            )
         attrs = gs(f"{prefix}_group_summary").get("attributes", {})
         chk(
             "EC29 non_essential_offline=1",
-            str(attrs.get("non_essential_offline")),
+            wait_for(
+                lambda: str(
+                    gs(f"{prefix}_group_summary")
+                    .get("attributes", {})
+                    .get("non_essential_offline")
+                ),
+                "1",
+            ),
             "1",
         )
 
@@ -731,7 +750,9 @@ def _run_ne_tests(ne_ctx: dict) -> None:
         )
         if not any(ec_enabled(n) for n in range(25, 30)):
             ss(ne_target, "unavailable", {"friendly_name": "ne test"})
-            wait(12)
+            wait_for(
+                lambda: gs(f"{prefix}_offline_count_non_essential").get("state"), "1"
+            )
         expected_online = len(essential_entities)
         attrs = gs(f"{prefix}_group_summary").get("attributes", {})
         chk(
@@ -1184,15 +1205,23 @@ def _run_ne_tests(ne_ctx: dict) -> None:
                 )
             else:
                 low_val = str(int(threshold) - 5)
+                # Ensure essential batteries are clear before asserting any_low_battery=off
+                ne_restore()
+                wait_for(
+                    lambda: gs(f"{ne_bs_prefix}_any_low_battery").get("state"), "off"
+                )
                 ss(
                     ne_bat,
                     low_val,
                     {"device_class": "battery", "unit_of_measurement": "%"},
                 )
-                wait(12)
                 chk(
                     "EC40 any_low_battery=off (NE battery low, essential ok)",
-                    gs(f"{ne_bs_prefix}_any_low_battery").get("state"),
+                    wait_for(
+                        lambda: gs(f"{ne_bs_prefix}_any_low_battery").get("state"),
+                        "off",
+                        interval=3,
+                    ),
                     "off",
                     f"ne_bat={ne_bat} low_val={low_val}",
                 )
@@ -1201,7 +1230,9 @@ def _run_ne_tests(ne_ctx: dict) -> None:
                     "90",
                     {"device_class": "battery", "unit_of_measurement": "%"},
                 )
-                wait(8)
+                wait_for(
+                    lambda: gs(f"{ne_bs_prefix}_any_low_battery").get("state"), "off"
+                )
 
     # EC41: recently_offline sensor lists entity after it goes offline
     if ec_enabled(41):
@@ -1214,11 +1245,16 @@ def _run_ne_tests(ne_ctx: dict) -> None:
         else:
             target = essential_entities[0] if essential_entities else ne_entities[0]
             ss(target, "unavailable", {"friendly_name": "smoke test"})
-            wait(12)
-            recent_entities = (
-                gs(f"{prefix}_recently_offline")
+            # Poll until entity appears in recently_offline list
+            wait_for(
+                lambda: target
+                in gs(f"{prefix}_recently_offline")
                 .get("attributes", {})
-                .get("entities", [])
+                .get("entities", []),
+                True,
+            )
+            recent_entities = (
+                gs(f"{prefix}_recently_offline").get("attributes", {}).get("entities", [])
             )
             chk(
                 "EC41 recently_offline lists entity",
@@ -1239,9 +1275,21 @@ def _run_ne_tests(ne_ctx: dict) -> None:
         else:
             target = essential_entities[0] if essential_entities else ne_entities[0]
             ss(target, "unavailable", {"friendly_name": "smoke test"})
-            wait(12)
+            wait_for(
+                lambda: target
+                in gs(f"{prefix}_recently_offline")
+                .get("attributes", {})
+                .get("entities", []),
+                True,
+            )
             ss(target, "on", {"friendly_name": target.split(".")[-1]})
-            wait(12)
+            wait_for(
+                lambda: target
+                in gs(f"{prefix}_recently_recovered")
+                .get("attributes", {})
+                .get("entities", []),
+                True,
+            )
             recent_entities = (
                 gs(f"{prefix}_recently_recovered")
                 .get("attributes", {})
@@ -1402,7 +1450,10 @@ def main():
         )
         chk(
             "low_battery_count=0 (offline excluded)",
-            gs(f"{prefix}_low_battery_count").get("state"),
+            wait_for(
+                lambda: gs(f"{prefix}_low_battery_count").get("state"),
+                "0",
+            ),
             "0",
         )
         gs_attrs = gs(f"{prefix}_group_summary").get("attributes", {})
@@ -1469,6 +1520,20 @@ def main():
                     gs(f"{combined_prefix}_combined_summary")
                     .get("attributes", {})
                     .get("offline")
+                ),
+                0,
+            )
+            wait_for(
+                lambda: (
+                    gs(f"{combined_prefix}_combined_summary")
+                    .get("attributes", {})
+                    .get("low_battery")
+                ),
+                0,
+            )
+            wait_for(
+                lambda: int(
+                    gs(f"{combined_prefix}_low_battery_count").get("state", "-1")
                 ),
                 0,
             )
@@ -1638,10 +1703,12 @@ def main():
             "1",
         )
         ss(suppressed_entity, "unavailable", {"friendly_name": "test"})
-        wait()
         chk(
             "offline_count=0 (suppressed not counted)",
-            gs(f"{prefix}_offline_count").get("state"),
+            wait_for(
+                lambda: gs(f"{prefix}_offline_count").get("state"),
+                "0",
+            ),
             "0",
         )
         chk(
@@ -1663,23 +1730,31 @@ def main():
             "/api/services/entity_availability/suppress_indefinitely",
             {"entity_id": indef_entity, "group": ctx["title"]},
         )
-        wait()
-        summary_attrs = gs(f"{prefix}_group_summary").get("attributes", {})
         chk(
             "EC11 suppressed=1 after suppress_indefinitely",
-            str(summary_attrs.get("suppressed")),
+            wait_for(
+                lambda: str(
+                    gs(f"{prefix}_group_summary")
+                    .get("attributes", {})
+                    .get("suppressed")
+                ),
+                "1",
+            ),
             "1",
         )
+        summary_attrs = gs(f"{prefix}_group_summary").get("attributes", {})
         chk(
             "EC11 suppressed_until[entity]=null (indefinite)",
             summary_attrs.get("suppressed_until", {}).get(indef_entity),
             None,
         )
         ss(indef_entity, "unavailable", {"friendly_name": "test"})
-        wait()
         chk(
             "EC11 offline_count=0 (indefinitely suppressed not counted)",
-            gs(f"{prefix}_offline_count").get("state"),
+            wait_for(
+                lambda: gs(f"{prefix}_offline_count").get("state"),
+                "0",
+            ),
             "0",
         )
         api(
@@ -1687,10 +1762,16 @@ def main():
             "/api/services/entity_availability/unsuppress",
             {"entity_id": indef_entity, "group": ctx["title"]},
         )
-        wait()
         chk(
             "EC11 suppressed=0 after unsuppress",
-            str(gs(f"{prefix}_group_summary").get("attributes", {}).get("suppressed")),
+            wait_for(
+                lambda: str(
+                    gs(f"{prefix}_group_summary")
+                    .get("attributes", {})
+                    .get("suppressed")
+                ),
+                "0",
+            ),
             "0",
         )
 
@@ -1913,13 +1994,26 @@ def main():
             if ec_enabled(16):
                 # EC16: member entity goes offline → combined offline_count rises
                 ss(target, "unavailable", {"friendly_name": "smoke test device"})
-                wait()
-                after_offline = int(gs(c_offline_eid).get("state", "0"))
+                after_offline = wait_for(
+                    lambda: int(gs(c_offline_eid).get("state", "0")),
+                    baseline + 1,
+                )
                 chk(
                     "EC16 combined offline_count rises when member entity goes offline",
                     after_offline,
                     baseline + 1,
                     f"sensor={c_offline_eid} baseline={baseline} after={after_offline}",
+                )
+                c_entities_after = (
+                    gs(f"{combined_prefix}_offline_count")
+                    .get("attributes", {})
+                    .get("entities", [])
+                )
+                chk(
+                    "EC16 offline entity in combined offline_entities",
+                    target in c_entities_after,
+                    True,
+                    f"target={target} entities={c_entities_after}",
                 )
 
             if ec_enabled(17):
@@ -1949,8 +2043,9 @@ def main():
                     wait()
                 # EC18: recovery → combined offline_count drops back to baseline
                 restore_and_wait(ctx)
-                wait_for(lambda: int(gs(c_offline_eid).get("state", "0")), baseline)
-                after_recovery = int(gs(c_offline_eid).get("state", "0"))
+                after_recovery = wait_for(
+                    lambda: int(gs(c_offline_eid).get("state", "0")), baseline
+                )
                 chk(
                     "EC18 combined offline_count returns to baseline after recovery",
                     after_recovery,
@@ -2275,9 +2370,11 @@ def main():
                     f"source_groups={ev.get('source_groups')}",
                 )
             else:
-                print(
-                    f"  EC24: no combined event captured (combined_entry_id={combined_entry_id}, total={len(events)})",
-                    flush=True,
+                chk(
+                    "EC24 combined offline event captured",
+                    False,
+                    True,
+                    f"combined_entry_id={combined_entry_id} total_events={len(events)}",
                 )
             restore_and_wait(ctx)
         else:

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -3058,7 +3058,10 @@ for e in cfg['data']['entries']:
         )
         chk(
             "EC65 low_battery cleared after suppress",
-            gs(f"{prefix}_low_battery_count").get("state"),
+            wait_for(
+                lambda: gs(f"{prefix}_low_battery_count").get("state"),
+                "0",
+            ),
             "0",
             f"target={target}",
         )

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -59,6 +59,8 @@ What is tested (covers PRs #37, #41, #50, #52, #53, #54, #68, core, feat/non-ess
   EC53 diagnostics new schema: counts/entities/config sub-dicts present and correct (replaces flat keys)
   EC54 group_summary new attrs: essential count, stale/poor_signal count aliases
   EC55 group_summary large attrs excluded from recorder (_unrecorded_attributes) but present in state machine
+  EC59 battery level retained in battery_levels when entity goes unavailable (not wiped to None)
+  EC65 low_battery count cleared when entity is suppressed (stale/degraded flags reset)
 
   Non-Essential tier (EC25-EC42, require a group with NE entities — set EA_SMOKE_NE_GROUP):
   EC25 NE entity offline → offline_count unchanged (KPI exclusion)
@@ -2964,6 +2966,108 @@ for e in cfg['data']['entries']:
                 attr in attrs,
                 True,
             )
+
+    # ------------------------------------------------------------------
+    # EC59: battery level retained when entity goes unavailable (not wiped)
+    # ------------------------------------------------------------------
+    if ec_enabled(59) and battery_entity and battery_sensor:
+        print(
+            "\n=== EC59: battery level retained when entity goes unavailable ===",
+            flush=True,
+        )
+        restore_and_wait(ctx)
+        # Set battery to a known level
+        ss(
+            battery_sensor,
+            "75",
+            {
+                "friendly_name": "Test Battery",
+                "device_class": "battery",
+                "unit_of_measurement": "%",
+            },
+        )
+        wait_for(
+            lambda: str(
+                gs(f"{prefix}_group_summary")
+                .get("attributes", {})
+                .get("battery_levels", {})
+                .get(battery_entity)
+            ),
+            "75",
+        )
+        # Make entity unavailable (battery sensor stays at 75)
+        ss(battery_entity, "unavailable", {"friendly_name": "test"})
+        wait_for(lambda: gs(f"{prefix}_offline_count").get("state"), "1")
+        retained = (
+            gs(f"{prefix}_group_summary")
+            .get("attributes", {})
+            .get("battery_levels", {})
+            .get(battery_entity)
+        )
+        chk(
+            "EC59 battery_level retained when entity offline",
+            retained,
+            75,
+            f"battery_entity={battery_entity} retained={retained}",
+        )
+        restore_and_wait(ctx)
+
+    # ------------------------------------------------------------------
+    # EC65: stale flag cleared when entity is suppressed
+    # ------------------------------------------------------------------
+    if ec_enabled(65) and battery_entity:
+        print(
+            "\n=== EC65: stale_count and low_battery cleared when entity suppressed ===",
+            flush=True,
+        )
+        restore_and_wait(ctx)
+        target = ctx["entities"][0]
+        # Give entity low battery then suppress it
+        if battery_sensor:
+            ss(
+                battery_sensor,
+                str(int(threshold) - 5),
+                {
+                    "friendly_name": "Test Battery",
+                    "device_class": "battery",
+                    "unit_of_measurement": "%",
+                },
+            )
+            wait_for(lambda: gs(f"{prefix}_low_battery_count").get("state"), "1")
+        api(
+            "POST",
+            "/api/services/entity_availability/suppress",
+            {"entity_id": target, "group": ctx["title"]},
+        )
+        wait_for(
+            lambda: str(
+                gs(f"{prefix}_group_summary").get("attributes", {}).get("suppressed")
+            ),
+            "1",
+        )
+        chk(
+            "EC65 low_battery cleared after suppress",
+            gs(f"{prefix}_low_battery_count").get("state"),
+            "0",
+            f"target={target}",
+        )
+        # Unsuppress and restore battery
+        api(
+            "POST",
+            "/api/services/entity_availability/unsuppress",
+            {"entity_id": target, "group": ctx["title"]},
+        )
+        if battery_sensor:
+            ss(
+                battery_sensor,
+                "90",
+                {
+                    "friendly_name": "Test Battery",
+                    "device_class": "battery",
+                    "unit_of_measurement": "%",
+                },
+            )
+        restore_and_wait(ctx)
 
     # ------------------------------------------------------------------
     restore_all(ctx)

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -1880,6 +1880,17 @@ def main():
         ec_target = ctx["entities"][0]
 
         # ------------------------------------------------------------------
+    else:
+        # EC12 skipped — still need avail_eid/ec_target for EC13-EC15
+        avail_states = [
+            s
+            for s in api("GET", "/api/states")
+            if s["entity_id"].startswith(prefix + "_availability")
+        ]
+        avail_eid = avail_states[0]["entity_id"] if avail_states else None
+        ec_target = ctx["entities"][0]
+
+    # ------------------------------------------------------------------
     if ec_enabled(13):
         print(
             "\n=== EC13: suppress offline entity — availability % must not change ===",

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -3032,7 +3032,7 @@ for e in cfg['data']['entries']:
             flush=True,
         )
         restore_and_wait(ctx)
-        target = ctx["entities"][0]
+        target = battery_entity  # suppress the entity whose battery is mapped, not entities[0]
         # Give entity low battery then suppress it
         if battery_sensor:
             ss(


### PR DESCRIPTION
## Summary

- **Bug**: Battery sensor entities were not subscribed to HA state change events. Changing a mapped battery sensor (e.g. `sensor.kitchen_1_battery` 90%→15%) would not trigger a coordinator refresh — `is_low_battery` stayed stale until next poll or until the monitored entity itself changed.
- **Fix**: Add non-empty mapped battery sensors to the `tracked` list in `_setup_state_listeners`, alongside signal sensors. Existing `_handle_state_change` handles non-monitored entity IDs correctly (skips `last_changed` update, still debounces + triggers `async_refresh()`).
- **Smoke tests**: 119 passed, 0 failed (was 116). 6-agent review applied.

## Changes

### `coordinator.py`
- Add `CONF_BATTERY_ENTITY_MAP` values to state change listener tracking

### `tests/integration/smoke.py`
- **EC59** (new): battery level retained in `battery_levels` when entity goes unavailable
- **EC65** (new): `low_battery` count cleared when entity is suppressed
- **EC5, EC10, EC11, EC25–30, EC40–42**: replace fixed `wait()`/`wait(12)` sleeps with `wait_for()` polling
- **EC16**: assert entity present in combined `offline_entities`, not just count
- **EC18**: use `wait_for()` return value directly (remove redundant re-read)
- **EC24**: `chk()` fail instead of silent skip when no combined event captured
- **EC40**: restore essential batteries before asserting `any_low_battery=off`
- **EC6 baseline**: wait for `low_battery_count→0` before EC7 snapshot (was root cause of intermittent EC7 failure)
- **EC12/13–15**: initialize `avail_eid`/`ec_target` in `else` branch so EC13–15 don't NameError when EC12 skipped via `EA_SMOKE_EC` filter

## Test plan
- [x] Deployed to `serene_booth` devcontainer, killed stale boot-time HA process
- [x] Manual: `sensor.ea_test_kitchen_1_battery` 90%→15% with entity staying `on` → `low_battery_count` increments immediately (was stuck at 0 before fix)
- [x] Full smoke suite: **119 passed, 0 failed** (`--fast` mode)