### PR TITLE
fix(combined-sensor): reduce recorder payload and fix unrecorded attrs

### DIFF
--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -230,7 +230,15 @@ class CombinedGroupSensor(CombinedSensorBase):
             "stale_entities_non_essential",
             "poor_signal_entities_non_essential",
             "low_battery_entities",
+            "low_battery_entities_non_essential",
             "non_essential_entities",
+            "battery_levels",
+            "signal_levels",
+            "signal_units",
+            "ok_signal_entities",
+            "suppressed_until",
+            "offline_since",
+            "last_seen",
         }
     )
 
@@ -480,11 +488,6 @@ class CombinedGroupSensor(CombinedSensorBase):
                 _LOGGER.warning(
                     "Could not find group summary entity for %s", coord.entry.entry_id
                 )
-            g_non_essential_entities = [
-                d.entity_id
-                for d in states.values()
-                if d.is_non_essential and not d.is_suppressed
-            ]
             g_offline_entities_ne = [
                 d.entity_id
                 for d in states.values()
@@ -523,7 +526,6 @@ class CombinedGroupSensor(CombinedSensorBase):
                 "suppressed": g_suppressed,
                 "non_essential": g_non_essential,
                 "non_essential_suppressed": g_non_essential_suppressed,
-                "non_essential_entities": g_non_essential_entities,
                 "non_essential_offline": g_non_essential_offline,
                 "non_essential_online": g_non_essential_online,
                 "non_essential_stale": g_non_essential_stale,

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -1320,6 +1320,33 @@ class TestCombinedGroupSensor:
             "source_groups",
         }
 
+    def test_unrecorded_attributes_covers_all_per_entity_keys(
+        self, mock_hass, combined_entry, coordinator_a, coordinator_b, coordinators
+    ):
+        """All large per-entity keys must be excluded from recorder."""
+        expected_unrecorded = {
+            "display_names",
+            "entities",
+            "groups",
+            "offline_entities",
+            "stale_entities",
+            "poor_signal_entities",
+            "offline_entities_non_essential",
+            "stale_entities_non_essential",
+            "poor_signal_entities_non_essential",
+            "low_battery_entities",
+            "low_battery_entities_non_essential",
+            "non_essential_entities",
+            "battery_levels",
+            "signal_levels",
+            "signal_units",
+            "ok_signal_entities",
+            "suppressed_until",
+            "offline_since",
+            "last_seen",
+        }
+        assert expected_unrecorded <= CombinedGroupSensor._unrecorded_attributes
+
 
 # ---------------------------------------------------------------------------
 # CombinedOfflineCountSensor

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -1320,9 +1320,7 @@ class TestCombinedGroupSensor:
             "source_groups",
         }
 
-    def test_unrecorded_attributes_covers_all_per_entity_keys(
-        self, mock_hass, combined_entry, coordinator_a, coordinator_b, coordinators
-    ):
+    def test_unrecorded_attributes_covers_all_per_entity_keys(self):
         """All large per-entity keys must be excluded from recorder."""
         expected_unrecorded = {
             "display_names",

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -3032,10 +3032,10 @@ class TestCombinedNonEssential:
         assert attrs["non_essential"] >= 1
         assert "binary_sensor.a1" in attrs["non_essential_entities"]
 
-    def test_per_group_breakdown_includes_non_essential_entities_list(
+    def test_per_group_breakdown_non_essential_count(
         self, mock_hass, combined_entry, coordinator_a, coordinator_b, coordinators
     ):
-        """Per-group breakdown in CombinedGroupSensor includes non_essential_entities list."""
+        """Per-group breakdown in CombinedGroupSensor tracks non_essential count (list removed to reduce payload)."""
         mock_hass.data[DOMAIN] = {c.entry.entry_id: c for c in coordinators}
         coordinator_a.device_states["binary_sensor.a1"].is_non_essential = True
         sensor = CombinedGroupSensor(
@@ -3048,8 +3048,8 @@ class TestCombinedNonEssential:
         attrs = sensor.extra_state_attributes
         groups = attrs["groups"]
         entry_a_id = coordinator_a.entry.entry_id
-        assert "non_essential_entities" in groups[entry_a_id]
-        assert "binary_sensor.a1" in groups[entry_a_id]["non_essential_entities"]
+        assert "non_essential_entities" not in groups[entry_a_id]
+        assert groups[entry_a_id]["non_essential"] >= 1
 
     def test_per_group_breakdown_ne_online_offline_stale_low_battery(
         self, mock_hass, combined_entry, coordinator_a, coordinator_b, coordinators


### PR DESCRIPTION
## Problem

`sensor.*_combined_summary` sensors were hitting HA's 16 KB recorder attribute limit, causing this warning 60K+ times:

> State attributes exceed maximum size of 16384 bytes. This can cause database performance issues; Attributes will not be stored

## Root cause

Three issues found via analysis:

1. **`low_battery_entities_non_essential` was missing from `_unrecorded_attributes`** — this entity-ID list was being written to history DB on every state change (unintentional).

2. **`battery_levels`, `signal_levels`, `signal_units`, `ok_signal_entities`, `suppressed_until`, `offline_since`, `last_seen` were all recorded** — per-entity dicts/lists (3–5 KB for large groups) with no historical value. Needed for current state display only.

3. **`non_essential_entities` list was included in each group entry of the `groups` dict** — the card only reads the scalar `non_essential` count from groups, not the entity list. Extra list payload in every coordinator poll.

## Changes

- Add `low_battery_entities_non_essential` to `_unrecorded_attributes` (bug fix)
- Add `battery_levels`, `signal_levels`, `signal_units`, `ok_signal_entities`, `suppressed_until`, `offline_since`, `last_seen` to `_unrecorded_attributes` — cuts recorded payload from ~5 KB to ~500 B (scalars only)
- Remove `non_essential_entities` list from per-group `groups` dict entries — only scalar count `non_essential` remains
- Update test to assert `non_essential_entities` absent from groups and verify count is correct

## Test plan

- [ ] 799/799 tests pass
- [ ] HA recorder warning stops appearing after reload
- [ ] Combined card still renders group breakdown correctly (uses `non_essential` count, not list)
- [ ] Suppress-all still works (uses `offline_entities`/`stale_entities`/`poor_signal_entities` in groups, unchanged)