### PR TITLE
feat(combined-card): split Show Groups / Show Entity List + unified sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,16 @@ All notable changes to this project will be documented in this file.
 - **Card: `show_entity_health` toggle** — hides/shows Bat. & Signal columns in the single-group entity list (default on); mirrors `show_group_health` on combined card
 - **Card: sort by signal** — `signal_asc` / `signal_desc` sort options; dBm and % normalized to a 0–100 quality score so mixed-unit groups sort correctly; nulls last
 - **Card: 3-button suppress actions** — replaces Suppress All / Unsuppress All with **Suppress All** (offline + stale + poor signal, 60 min), **Suppress Offline** (offline only, 60 min), **Unsuppress All**. NE entities included when `show_non_essential_stats` is on. Available on both regular and combined groups.
+- **Card: `show_groups` config key** — independently controls the groups breakdown table on combined cards (previously `show_entities` gated both). Defaults to `true`; set `false` to hide the breakdown while keeping the entity list visible.
 
 ### Changed
 - Signal `signal_enabled` toggle positioned directly below `battery_threshold` in Advanced settings
 - All signal sensor display uses the correct unit for the selected network type (dBm or %)
 - 28 supported languages receive full translations for all new strings
 - Card: `show_actions` checkbox now available for combined group cards in the editor
+- **Card: combined card `show_entities` now controls only the flat entity list** — previously it gated both the groups breakdown table and the entity list; use `show_groups` to control the breakdown independently.
+- **Card: editor "Sort Groups By" renamed to "Sort Groups & Entities By"** — the sort selection now drives both the groups breakdown table order and the flat entity list order on combined cards.
+- **Card: entity list expand/collapse on combined cards is now independent** — the entity list section has its own expand toggle, decoupled from the groups breakdown toggle.
 
 ### Fixed
 - **Battery sensor state changes now trigger live updates** — mapped battery sensors (e.g. `sensor.device_battery`) were not subscribed to HA state change events; updates no longer require waiting for the next poll cycle.
@@ -42,6 +46,8 @@ All notable changes to this project will be documented in this file.
 - **Card: status sort — stale entities now sort above online**
 - **Card: combined group suppress was silently failing** — suppress handlers were passing the combined entry_id as `group=` to the service; each entity is now scoped to its source group's entry_id.
 - **Diagnostics: new schema** — `counts`, `entities`, and `config` sub-dicts replace flat keys
+- **Card: `show_entities` guard consistent across combined and regular render paths** — both now use `!== false`, preventing `show_entities: undefined` from silently hiding the entity list.
+- **Card: "Entity List Expanded by Default" editor toggle now disables when `show_entities` is `false`** — applies to both regular and combined cards.
 
 
 ## [0.3.14] - 2026-08-02

--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ group: security_devices        # group slug (lowercase, underscores)
 # title: "My Devices"         # optional override
 show_affected_areas: false
 show_availability: true
+show_groups: true            # show groups breakdown table (combined cards only)
 show_entities: true
 show_non_essential_stats: false
 entities_expanded: false
@@ -630,7 +631,8 @@ availability_colors:
 | `title` | (auto from group) | Custom card title |
 | `show_affected_areas` | `false` | Show offline area names as pills between stats and availability bars (both regular and combined groups) |
 | `show_availability` | `true` | Show availability progress bars (regular groups only) |
-| `show_entities` | `true` | Show expandable entity list (regular) or group breakdown table (combined) |
+| `show_groups` | `true` | Show groups breakdown table (combined groups only). Independent of `show_entities` — both can be toggled separately. |
+| `show_entities` | `true` | Show expandable entity list (regular groups), or flat per-entity table (combined groups). Independent of `show_groups`. |
 | `show_non_essential_stats` | `false` | Show non-essential stats. For **regular groups**: adds a NE sub-stats row (Online / Offline / Stale / Low Battery) below the main stats row and includes NE entities in the entity list sorted to the bottom. For **combined groups**: adds a `↳ Non-Essential` sub-row per group in the breakdown table showing NE Online / Offline and (when feature enabled) Bat. / Stale counts. When `false`, non-essential entities are hidden from the card entirely. |
 | `entities_expanded` | `false` | Start entity list / group breakdown expanded |
 | `show_actions` | `false` | Show suppress action buttons (regular and combined groups). Shows three buttons: **Suppress All** (offline + stale + poor signal, 60 min), **Suppress Offline** (offline only, 60 min), **Unsuppress All**. When `show_non_essential_stats` is on, NE entities are included. |
@@ -640,7 +642,7 @@ availability_colors:
 | `compact` | `false` | Reduced padding mode |
 | `show_entity_health` | `true` | Show health columns (Bat. & Signal) in the entity list when the feature is active (regular groups only) |
 | `sort_by` | `status` | Entity list sort order: `status`, `name_asc`, `name_desc`, `battery_asc`, `battery_desc`, `signal_asc`, `signal_desc` (regular groups only) |
-| `group_sort_by` | `name_asc` | Group breakdown table sort order: `name_asc`, `name_desc`, `offline_desc` (most offline first). (combined groups only) |
+| `group_sort_by` | `name_asc` | Sort order for both the groups breakdown table and the flat entity list: `name_asc`, `name_desc`, `offline_desc` (most offline first). (combined groups only) |
 | `availability_thresholds` | `{high: 99, mid: 95}` | % thresholds for bar colors (regular groups only) |
 | `availability_colors` | `{high, mid, low}` | Custom hex colors for bars (regular groups only) |
 
@@ -661,7 +663,7 @@ The card editor includes a **Group Slug** dropdown populated from all discovered
 - **Groups** — regular monitored groups
 - **Combined Groups** — aggregated combined groups
 
-Selecting a combined group hides editor controls that don't apply (availability bars, entity filter, entity detail, entity sort order, suppress buttons, color thresholds), and shows the **Sort Groups By** dropdown instead.
+Selecting a combined group hides editor controls that don't apply (availability bars, entity filter, entity detail, entity sort order, suppress buttons, color thresholds), and shows two independent checkboxes — **Show Groups** (breakdown table) and **Show Entity List** (flat entity table) — plus the **Sort Groups & Entities By** dropdown instead.
 
 ### Card Preview — Regular Group
 

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -886,7 +886,7 @@ class EntityAvailabilityCard extends LitElement {
         ${this._renderSuppressedBanner(suppressed, showNEStats ? nonEssentialSuppressed : 0)}
         ${this._config.show_availability ? this._renderAvailability(prefix) : nothing}
         ${this._config.show_actions && (entities.length + (showNEStats ? nonEssentialEntities.length : 0)) > 50 ? this._renderActions(prefix) : nothing}
-        ${this._config.show_entities ? this._renderEntityList(entities.filter(e => showNEStats || !nonEssentialEntities.includes(e)), batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames, nonEssentialEntities, showNEStats ? nonEssentialOfflineEntities : [], showNEStats ? staleEntitiesNonEssential : [], batteryEnabled, signalEnabled, signalLevels, poorSignalEntities, signalUnits, okSignalEntities, this._config.show_table_icons === true) : nothing}
+        ${this._config.show_entities !== false ? this._renderEntityList(entities.filter(e => showNEStats || !nonEssentialEntities.includes(e)), batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames, nonEssentialEntities, showNEStats ? nonEssentialOfflineEntities : [], showNEStats ? staleEntitiesNonEssential : [], batteryEnabled, signalEnabled, signalLevels, poorSignalEntities, signalUnits, okSignalEntities, this._config.show_table_icons === true) : nothing}
         ${this._config.show_actions && (entities.length + (showNEStats ? nonEssentialEntities.length : 0)) <= 50 ? this._renderActions(prefix) : nothing}
       </ha-card>
     `;
@@ -1950,7 +1950,7 @@ class EntityAvailabilityCardEditor extends LitElement {
               type="checkbox"
               .checked=${this._config.entities_expanded === true}
               @change=${(e) => this._updateConfig("entities_expanded", e.target.checked)}
-              ?disabled=${this._isSelectedGroupCombined() && this._config.show_entities === false}
+              ?disabled=${this._config.show_entities === false}
             />
             Entity List Expanded by Default
           </label>

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -803,7 +803,7 @@ class EntityAvailabilityCard extends LitElement {
           ${this._renderSuppressedBanner(suppressed, attrs.non_essential_suppressed || 0, Object.values(groups))}
           ${this._config.show_actions && (allEntities.length + (showNE ? nonEssentialEntities.length : 0)) > 50 ? this._renderActions(prefix) : nothing}
           ${this._config.show_groups !== false ? this._renderCombinedGroupBreakdown(groups, batteryEnabled, stalenessEnabled, this._config.show_table_icons === true) : nothing}
-          ${this._config.show_entities ? this._renderEntityList(allEntities.filter(e => showNE || !nonEssentialEntities.includes(e)), batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames, nonEssentialEntities, showNE ? nonEssentialOfflineEntities : [], showNE ? staleEntitiesNonEssential : [], batteryEnabled, signalEnabledCombined, signalLevels, poorSignalEntities, signalUnits, okSignalEntities, this._config.show_table_icons === true) : nothing}
+          ${this._config.show_entities !== false ? this._renderEntityList(allEntities.filter(e => showNE || !nonEssentialEntities.includes(e)), batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames, nonEssentialEntities, showNE ? nonEssentialOfflineEntities : [], showNE ? staleEntitiesNonEssential : [], batteryEnabled, signalEnabledCombined, signalLevels, poorSignalEntities, signalUnits, okSignalEntities, this._config.show_table_icons === true) : nothing}
           ${this._config.show_actions && (allEntities.length + (showNE ? nonEssentialEntities.length : 0)) <= 50 ? this._renderActions(prefix) : nothing}
         </ha-card>
       `;
@@ -1290,13 +1290,16 @@ class EntityAvailabilityCard extends LitElement {
       return Math.max(0, Math.min(100, (lvl + 110) * (100 / 80)));
     };
 
+    // Hoist sort key — invariant across comparisons.
+    // In combined mode, group_sort_by drives entity order too (one control for both).
+    // "offline_desc" maps to "status" because status-sort puts problems first, matching group sort intent.
+    let sortBy = this._config.sort_by || "status";
+    if (this._isCombinedGroup()) {
+      const g = this._config.group_sort_by || "name_asc";
+      sortBy = g === "name_desc" ? "name_desc" : g === "offline_desc" ? "status" : "name_asc";
+    }
+
     items.sort((a, b) => {
-      const isCombined = this._isCombinedGroup();
-      let sortBy = this._config.sort_by || "status";
-      if (isCombined) {
-        const g = this._config.group_sort_by || "name_asc";
-        sortBy = g === "name_desc" ? "name_desc" : g === "offline_desc" ? "status" : "name_asc";
-      }
       // NE entities always go after essential, but within each tier the same sort applies
       if (a.isNonEssential !== b.isNonEssential) return a.isNonEssential ? 1 : -1;
       if (sortBy === "name_asc") {
@@ -1946,6 +1949,7 @@ class EntityAvailabilityCardEditor extends LitElement {
               type="checkbox"
               .checked=${this._config.entities_expanded === true}
               @change=${(e) => this._updateConfig("entities_expanded", e.target.checked)}
+              ?disabled=${this._isSelectedGroupCombined() && this._config.show_entities === false}
             />
             Entity List Expanded by Default
           </label>

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -670,6 +670,7 @@ class EntityAvailabilityCard extends LitElement {
     return {
       group,
       show_availability: true,
+      show_groups: true,
       show_entities: true,
       entities_expanded: false,
       show_actions: false,
@@ -691,6 +692,7 @@ class EntityAvailabilityCard extends LitElement {
     }
     this._config = {
       show_availability: true,
+      show_groups: true,
       show_entities: true,
       entities_expanded: false,
       show_actions: false,
@@ -800,8 +802,8 @@ class EntityAvailabilityCard extends LitElement {
           ${this._config.show_affected_areas ? this._renderAffectedAreas(`entity_availability_combined_${this._config.group}`) : nothing}
           ${this._renderSuppressedBanner(suppressed, attrs.non_essential_suppressed || 0, Object.values(groups))}
           ${this._config.show_actions && (allEntities.length + (showNE ? nonEssentialEntities.length : 0)) > 50 ? this._renderActions(prefix) : nothing}
-          ${this._config.show_entities ? this._renderCombinedGroupBreakdown(groups, batteryEnabled, stalenessEnabled, this._config.show_table_icons === true) : nothing}
-          ${this._config.show_entities && this._entitiesExpanded ? this._renderEntityList(allEntities.filter(e => showNE || !nonEssentialEntities.includes(e)), batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames, nonEssentialEntities, showNE ? nonEssentialOfflineEntities : [], showNE ? staleEntitiesNonEssential : [], batteryEnabled, signalEnabledCombined, signalLevels, poorSignalEntities, signalUnits, okSignalEntities, this._config.show_table_icons === true) : nothing}
+          ${this._config.show_groups !== false ? this._renderCombinedGroupBreakdown(groups, batteryEnabled, stalenessEnabled, this._config.show_table_icons === true) : nothing}
+          ${this._config.show_entities ? this._renderEntityList(allEntities.filter(e => showNE || !nonEssentialEntities.includes(e)), batteryLevels, suppressedUntil, staleEntities, offlineSince, total, lowBatteryEntities, displayNames, nonEssentialEntities, showNE ? nonEssentialOfflineEntities : [], showNE ? staleEntitiesNonEssential : [], batteryEnabled, signalEnabledCombined, signalLevels, poorSignalEntities, signalUnits, okSignalEntities, this._config.show_table_icons === true) : nothing}
           ${this._config.show_actions && (allEntities.length + (showNE ? nonEssentialEntities.length : 0)) <= 50 ? this._renderActions(prefix) : nothing}
         </ha-card>
       `;
@@ -1289,7 +1291,12 @@ class EntityAvailabilityCard extends LitElement {
     };
 
     items.sort((a, b) => {
-      const sortBy = this._config.sort_by || "status";
+      const isCombined = this._isCombinedGroup();
+      let sortBy = this._config.sort_by || "status";
+      if (isCombined) {
+        const g = this._config.group_sort_by || "name_asc";
+        sortBy = g === "name_desc" ? "name_desc" : g === "offline_desc" ? "status" : "name_asc";
+      }
       // NE entities always go after essential, but within each tier the same sort applies
       if (a.isNonEssential !== b.isNonEssential) return a.isNonEssential ? 1 : -1;
       if (sortBy === "name_asc") {
@@ -1854,6 +1861,17 @@ class EntityAvailabilityCardEditor extends LitElement {
           </label>
         </div>
         ` : nothing}
+        ${this._isSelectedGroupCombined() ? html`
+        <div class="editor-row checkbox">
+          <label>
+            <input
+              type="checkbox"
+              .checked=${this._config.show_groups !== false}
+              @change=${(e) => this._updateConfig("show_groups", e.target.checked)}
+            />
+            Show Groups
+          </label>
+        </div>
         <div class="editor-row checkbox">
           <label>
             <input
@@ -1864,6 +1882,18 @@ class EntityAvailabilityCardEditor extends LitElement {
             Show Entity List
           </label>
         </div>
+        ` : html`
+        <div class="editor-row checkbox">
+          <label>
+            <input
+              type="checkbox"
+              .checked=${this._config.show_entities !== false}
+              @change=${(e) => this._updateConfig("show_entities", e.target.checked)}
+            />
+            Show Entity List
+          </label>
+        </div>
+        `}
         <div class="editor-row checkbox">
           <label>
             <input
@@ -1984,7 +2014,7 @@ class EntityAvailabilityCardEditor extends LitElement {
         </div>
         ${this._isSelectedGroupCombined() ? html`
         <div class="editor-row">
-          <label>Sort Groups By</label>
+          <label>Sort Groups &amp; Entities By</label>
           <select
             .value=${this._config.group_sort_by || "name_asc"}
             @change=${(e) => this._updateConfig("group_sort_by", e.target.value)}

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1291,7 +1291,8 @@ class EntityAvailabilityCard extends LitElement {
     };
 
     // Hoist sort key — invariant across comparisons.
-    // In combined mode, group_sort_by drives entity order too (one control for both).
+    // In combined mode, group_sort_by drives entity order too (one control for both);
+    // sort_by is intentionally ignored — the editor does not expose it for combined cards.
     // "offline_desc" maps to "status" because status-sort puts problems first, matching group sort intent.
     let sortBy = this._config.sort_by || "status";
     if (this._isCombinedGroup()) {

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,3 @@
 [lint.per-file-ignores]
-"tests/*" = ["BLE001", "S110", "B018", "RUF059", "RUF015", "PERF102", "SIM117"]
+"tests/*" = ["BLE001", "S110", "B018", "RUF059", "RUF015", "PERF102", "SIM117", "E402"]
 "tests/integration/smoke.py" = ["BLE001", "S110", "B018"]


### PR DESCRIPTION
## Summary

- **Split `show_entities` into two independent controls** for combined mode: `show_groups` (groups breakdown table) and `show_entities` (flat entity list). Previously a single checkbox controlled both.
- **Entity list in combined mode** now has its own expand/collapse toggle, decoupled from the groups section.
- **Unified sort**: entity list in combined mode follows `group_sort_by` (`name_asc` → A-Z, `name_desc` → Z-A, `offline_desc` → problems first). Editor label updated to "Sort Groups & Entities By".
- **Backwards-compatible**: `show_groups` defaults to `true`, existing configs unaffected.

## Test plan

- [ ] Combined card with both checkboxes enabled → groups table and entity list both render
- [ ] Uncheck "Show Groups" → groups table hidden, entity list still shows with its own toggle
- [ ] Uncheck "Show Entity List" → entity list hidden, groups table still shows
- [ ] Uncheck both → nothing below stats
- [ ] Change sort to "Name Z → A" → both groups table and entity list sort Z-A
- [ ] Change sort to "Offline ↓" → both show problems first
- [ ] Non-combined card → single "Show Entity List" checkbox, "Sort Entities By" selector unchanged
- [ ] Existing YAML config with `show_entities: false` → entity list still hidden, groups table shows