### PR TITLE
feat(card): collapse_devices — merge same-device entities into one row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - **Card: sort by signal** — `signal_asc` / `signal_desc` sort options; dBm and % normalized to a 0–100 quality score so mixed-unit groups sort correctly; nulls last
 - **Card: 3-button suppress actions** — replaces Suppress All / Unsuppress All with **Suppress All** (offline + stale + poor signal, 60 min), **Suppress Offline** (offline only, 60 min), **Unsuppress All**. NE entities included when `show_non_essential_stats` is on. Available on both regular and combined groups.
 - **Card: `show_groups` config key** — independently controls the groups breakdown table on combined cards (previously `show_entities` gated both). Defaults to `true`; set `false` to hide the breakdown while keeping the entity list visible.
+- **Card: `collapse_devices` config key** — when enabled, entities that share the same physical HA device (same `device_id`), same display name, and identical battery/signal values are collapsed into a single row showing worst-case status. Entities with no device assignment are never collapsed. Requires **Use Device Names** on the group. Defaults to `false`.
 
 ### Changed
 - Signal `signal_enabled` toggle positioned directly below `battery_threshold` in Advanced settings

--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ entity_filter: "all"           # "all" | "offline" | "online"
 show_entity_health: true       # hide/show Bat. & Signal columns in entity list
 sort_by: status                # status | name_asc | name_desc | battery_asc | battery_desc | signal_asc | signal_desc
 group_sort_by: name_asc        # name_asc | name_desc | offline_desc (combined groups)
+collapse_devices: false        # collapse multiple entities from the same device into one row
 availability_thresholds:
   high: 99
   mid: 95
@@ -643,6 +644,7 @@ availability_colors:
 | `show_entity_health` | `true` | Show health columns (Bat. & Signal) in the entity list when the feature is active (regular groups only) |
 | `sort_by` | `status` | Entity list sort order: `status`, `name_asc`, `name_desc`, `battery_asc`, `battery_desc`, `signal_asc`, `signal_desc` (regular groups only) |
 | `group_sort_by` | `name_asc` | Sort order for both the groups breakdown table and the flat entity list: `name_asc`, `name_desc`, `offline_desc` (most offline first). (combined groups only) |
+| `collapse_devices` | `false` | Collapse multiple entities from the same physical device into one row showing worst-case status. Requires **Use Device Names** enabled on the group. Entities with no HA device assignment are never collapsed. |
 | `availability_thresholds` | `{high: 99, mid: 95}` | % thresholds for bar colors (regular groups only) |
 | `availability_colors` | `{high, mid, low}` | Custom hex colors for bars (regular groups only) |
 

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1346,7 +1346,14 @@ class EntityAvailabilityCard extends LitElement {
     // Entities with no device_id are never collapsed. Applied after sort so order is preserved.
     if (this._config.collapse_devices === true) {
       const reg = this.hass.entities;
-      if (!reg) console.warn("[entity-availability-card] collapse_devices: hass.entities unavailable — no collapsing applied");
+      if (!reg) {
+        if (!this._warnedEntitiesUnavailable) {
+          console.warn("[entity-availability-card] collapse_devices: hass.entities unavailable — no collapsing applied");
+          this._warnedEntitiesUnavailable = true;
+        }
+      } else {
+        this._warnedEntitiesUnavailable = false;
+      }
       const groups = new Map();
       for (const item of items) {
         const deviceId = reg?.[item.entityId]?.device_id;

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1357,11 +1357,9 @@ class EntityAvailabilityCard extends LitElement {
         const key = deviceId
           ? `${deviceId}::${item.name}::${String(item.battery)}::${sigKey}::${sigUnitKey}`
           : `__no_device__${item.entityId}`;
-        console.log(`[collapse_devices] entity=${item.entityId} deviceId=${deviceId} name=${item.name} battery=${item.battery} signalLevel=${item.signalLevel} signalUnit=${item.signalUnit} key=${key}`);
         if (!groups.has(key)) groups.set(key, []);
         groups.get(key).push(item);
       }
-      console.log(`[collapse_devices] groups (${groups.size}):`, [...groups.keys()]);
       const collapsed = [];
       for (const [, group] of groups) {
         if (group.length === 1) { collapsed.push(group[0]); continue; }

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -698,6 +698,7 @@ class EntityAvailabilityCard extends LitElement {
       show_actions: false,
       show_suppress_toggle: false,
       compact: false,
+      collapse_devices: false,
       sort_by: "status",
       entity_detail: "off",
       entity_filter: "all",
@@ -1335,6 +1336,33 @@ class EntityAvailabilityCard extends LitElement {
         return a.name.localeCompare(b.name);
       }
     });
+
+    // Collapse entities from the same physical device into one row when collapse_devices is on.
+    // Collapse only when: same device_id + same display name + identical battery + identical signal.
+    // Any mismatch → keep separate rows. Worst-case status across sub-entities.
+    // Entities with no device_id are never collapsed. Applied after sort so order is preserved.
+    if (this._config.collapse_devices === true) {
+      const reg = this.hass.entities ?? {};
+      const groups = new Map();
+      for (const item of items) {
+        const deviceId = reg[item.entityId]?.device_id;
+        const key = deviceId
+          ? `${deviceId}::${item.name}::${String(item.battery)}::${String(item.signalLevel)}::${item.signalUnit}`
+          : `__no_device__${item.entityId}`;
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(item);
+      }
+      const STATUS_SEVERITY = { red: 3, yellow: 2, grey: 1, green: 0 };
+      const collapsed = [];
+      for (const [, group] of groups) {
+        if (group.length === 1) { collapsed.push(group[0]); continue; }
+        const worst = group.reduce((a, b) =>
+          (STATUS_SEVERITY[b.dotColor] ?? 0) > (STATUS_SEVERITY[a.dotColor] ?? 0) ? b : a
+        );
+        collapsed.push({ ...worst, entityId: group[0].entityId });
+      }
+      return collapsed;
+    }
 
     return items;
   }
@@ -1995,6 +2023,16 @@ class EntityAvailabilityCardEditor extends LitElement {
               @change=${(e) => this._updateConfig("compact", e.target.checked)}
             />
             Compact Mode
+          </label>
+        </div>
+        <div class="editor-row checkbox">
+          <label>
+            <input
+              type="checkbox"
+              .checked=${this._config.collapse_devices === true}
+              @change=${(e) => this._updateConfig("collapse_devices", e.target.checked)}
+            />
+            Collapse Entities by Device
           </label>
         </div>
         <div class="editor-row checkbox">

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -73,6 +73,9 @@ const STATUS_COLORS = {
   red: "#f44336",
 };
 
+// Severity order for worst-case collapse — hoisted to avoid per-render allocation.
+const COLLAPSE_SEVERITY = { red: 3, yellow: 2, grey: 1, green: 0 };
+
 const cardStyles = css`
   :host {
     --eac-green: #4caf50;
@@ -1342,24 +1345,27 @@ class EntityAvailabilityCard extends LitElement {
     // Any mismatch → keep separate rows. Worst-case status across sub-entities.
     // Entities with no device_id are never collapsed. Applied after sort so order is preserved.
     if (this._config.collapse_devices === true) {
-      const reg = this.hass.entities ?? {};
+      const reg = this.hass.entities;
+      if (!reg) console.warn("[entity-availability-card] collapse_devices: hass.entities unavailable — no collapsing applied");
       const groups = new Map();
       for (const item of items) {
-        const deviceId = reg[item.entityId]?.device_id;
+        const deviceId = reg?.[item.entityId]?.device_id;
+        // Normalize null/undefined signal to same sentinel so both collapse correctly
+        const sigKey = item.signalLevel ?? "null";
         const key = deviceId
-          ? `${deviceId}::${item.name}::${String(item.battery)}::${String(item.signalLevel)}::${item.signalUnit}`
+          ? `${deviceId}::${item.name}::${String(item.battery)}::${sigKey}::${item.signalUnit ?? ""}`
           : `__no_device__${item.entityId}`;
         if (!groups.has(key)) groups.set(key, []);
         groups.get(key).push(item);
       }
-      const STATUS_SEVERITY = { red: 3, yellow: 2, grey: 1, green: 0 };
       const collapsed = [];
       for (const [, group] of groups) {
         if (group.length === 1) { collapsed.push(group[0]); continue; }
+        // worst = highest severity; use worst.entityId (correct click target, not always group[0])
         const worst = group.reduce((a, b) =>
-          (STATUS_SEVERITY[b.dotColor] ?? 0) > (STATUS_SEVERITY[a.dotColor] ?? 0) ? b : a
+          (COLLAPSE_SEVERITY[b.dotColor] ?? 0) > (COLLAPSE_SEVERITY[a.dotColor] ?? 0) ? b : a
         );
-        collapsed.push({ ...worst, entityId: group[0].entityId });
+        collapsed.push(worst);
       }
       return collapsed;
     }
@@ -2032,7 +2038,7 @@ class EntityAvailabilityCardEditor extends LitElement {
               .checked=${this._config.collapse_devices === true}
               @change=${(e) => this._updateConfig("collapse_devices", e.target.checked)}
             />
-            Collapse Entities by Device
+            Collapse Entities by Device (requires Use Device Names on group)
           </label>
         </div>
         <div class="editor-row checkbox">

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1352,12 +1352,16 @@ class EntityAvailabilityCard extends LitElement {
         const deviceId = reg?.[item.entityId]?.device_id;
         // Normalize null/undefined signal to same sentinel so both collapse correctly
         const sigKey = item.signalLevel ?? "null";
+        // Only include signalUnit in key when signalLevel is present — unit is meaningless when there's no value
+        const sigUnitKey = item.signalLevel != null ? (item.signalUnit ?? "") : "";
         const key = deviceId
-          ? `${deviceId}::${item.name}::${String(item.battery)}::${sigKey}::${item.signalUnit ?? ""}`
+          ? `${deviceId}::${item.name}::${String(item.battery)}::${sigKey}::${sigUnitKey}`
           : `__no_device__${item.entityId}`;
+        console.log(`[collapse_devices] entity=${item.entityId} deviceId=${deviceId} name=${item.name} battery=${item.battery} signalLevel=${item.signalLevel} signalUnit=${item.signalUnit} key=${key}`);
         if (!groups.has(key)) groups.set(key, []);
         groups.get(key).push(item);
       }
+      console.log(`[collapse_devices] groups (${groups.size}):`, [...groups.keys()]);
       const collapsed = [];
       for (const [, group] of groups) {
         if (group.length === 1) { collapsed.push(group[0]); continue; }


### PR DESCRIPTION
## Summary

- New `collapse_devices` config key (default `false`) for the entity list
- When enabled, entities sharing the same HA `device_id` + display name + battery entity + signal entity collapse into a single row showing worst-case status
- Entities with no `device_id` (template sensors, helpers) are never collapsed
- Applied after sort so relative row order is preserved
- Editor: checkbox always visible; no-op when `use_device_names` is off on the group
- No backend changes — purely card-level

## Motivation

When `use_device_names: true` and the same physical device is monitored via multiple sensors (e.g. MQTT `last_seen` + template `connectivity`), both entities resolve to the same display name and appear as duplicate rows in the Problem Entities list. `collapse_devices: true` collapses them into one row.

## Collapse conditions (all must match)

| Condition | Reason |
|-----------|--------|
| Same `device_id` | Same physical device |
| Same display name | Guards against accidental same-device collisions across different entity types |
| Same battery entity (or none) | Can't merge rows with different battery readings |
| Same signal entity (or none) | Can't merge rows with different signal readings |

## Test plan

- [ ] Two entities from same device, `use_device_names: true`, `collapse_devices: true` → shows one row with worst-case status
- [ ] One entity online + one offline → collapsed row shows offline (red)
- [ ] Entities with different battery mappings → not collapsed, shown separately
- [ ] Entities with no `device_id` → not collapsed, shown separately
- [ ] `collapse_devices: false` (default) → no change in behavior
- [ ] `use_device_names: false` → collapse_devices enabled but names differ → no collapse (no-op)