### PR TITLE
fix: AttributeError building last_seen when staleness_use_last_updated=True

### DIFF
--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -684,9 +684,7 @@ class CombinedGroupSensor(CombinedSensorBase):
         # Full merged states + device-key map: category lists dedupe by DEVICE so a
         # device with siblings in different categories appears in each. total/membership
         # use the representative set (one row per device).
-        merged_states, rep_of, udn_map, use_last_updated_map = self._device_map_cached(
-            active
-        )
+        merged_states, rep_of, udn_map, _ = self._device_map_cached(active)
 
         def _m(pred) -> list[str]:
             return self._collapsed_match(merged_states, rep_of, pred)
@@ -814,10 +812,12 @@ class CombinedGroupSensor(CombinedSensorBase):
                 suppressed_until[rk] = d.suppress_until.isoformat()
             if d.offline_since is not None:
                 offline_since[rk] = d.offline_since.isoformat()
-            use_last_updated = use_last_updated_map.get(rk, False)
-            ts = d.last_updated if use_last_updated else d.last_changed
-            if ts is not None:
-                last_seen[rk] = ts.isoformat()
+            # DeviceState only tracks `last_changed` (the coordinator reads
+            # `last_updated` directly off the live HA State object for the
+            # staleness calculation itself, but never persists it here) —
+            # so use_last_updated_map does not apply to this attribute.
+            if d.last_changed is not None:
+                last_seen[rk] = d.last_changed.isoformat()
             if (
                 signal_enabled
                 and d.signal_quality == "ok"

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -1142,7 +1142,6 @@ class GroupSummarySensor(DedupCoordinatorSensor):
         )
 
         use_device_names = self.coordinator.entry.data.get(CONF_USE_DEVICE_NAMES, False)
-        use_last_updated = self.coordinator._staleness_use_last_updated
         battery_enabled = self.coordinator.entry.data.get(CONF_BATTERY_THRESHOLD, 0) > 0
         staleness_enabled = self.coordinator._staleness_threshold > 0
         signal_enabled = self.coordinator._signal_enabled
@@ -1236,10 +1235,13 @@ class GroupSummarySensor(DedupCoordinatorSensor):
                 if d.offline_since is not None
             },
             "last_seen": {
-                eid: ts.isoformat()
+                # DeviceState only tracks `last_changed` (the coordinator reads
+                # `last_updated` directly off the live HA State object for the
+                # staleness calculation itself, but never persists it here) —
+                # so `use_last_updated` does not apply to this attribute.
+                eid: d.last_changed.isoformat()
                 for eid, d in states.items()
-                if (ts := d.last_updated if use_last_updated else d.last_changed)
-                is not None
+                if d.last_changed is not None
             },
         }
 


### PR DESCRIPTION
Fixes #85.

**Bug:** `sensor.py`'s `GroupSummarySensor.extra_state_attributes` and `combined_sensor.py`'s `CombinedGroupSensor` build a `last_seen` dict via `d.last_updated if use_last_updated else d.last_changed`, where `d` is the internal `DeviceState` dataclass. `DeviceState` (`models.py`) only ever defines `last_changed` — it has no `last_updated` field — so this raises `AttributeError` on every update cycle whenever a group has `staleness_use_last_updated: true`, leaving the `*_group_summary` sensor stuck `unavailable` and flooding the log.

Note this is unrelated to (and does not touch) the staleness calculation itself in `coordinator.py`, which correctly reads `state.last_updated` off the live HA `State` object rather than off `DeviceState` — that logic is intentional and important for entities that report on a fixed interval but rarely change value, and is left exactly as-is.

**Fix:** since `DeviceState` never carries `last_updated`, the `last_seen` attribute in both places now just uses `d.last_changed` unconditionally. Also removed the now-dead `use_last_updated` / `use_last_updated_map` locals that only existed to feed the buggy branch.

**Testing:** `ruff check` and `ruff format --check` both pass on the changed files. I wasn't able to run the `pytest-homeassistant-custom-component` suite locally (it imports `fcntl`, POSIX-only, so it can't run on Windows) — should run fine in CI. Manually reviewed `tests/test_combined_sensor.py` and `tests/integration/smoke.py`'s `last_seen`-related assertions (EC45, EC67) — they only check presence and that timestamps are in the past, not which underlying field was used, so this change should not break them.
