### PR TITLE
refactor(combined): remove dead use_last_updated_map + regression tests for #85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **`last_seen` attribute crash when "Count attribute updates as activity" is enabled** — groups with `staleness_use_last_updated: true` raised `AttributeError: 'DeviceState' object has no attribute 'last_updated'` on every coordinator update cycle, leaving `*_group_summary` and combined sensors stuck `unavailable`. The `last_seen` diagnostic attribute now always uses `last_changed` (the only timestamp `DeviceState` persists); the staleness calculation itself is unaffected and continues to use `last_updated` from the live HA state. (#85, #86)
+
 ## [0.5.0] - 2026-08-26
 
 ### ⚠️ Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-26
+
 ### Fixed
 - **`last_seen` attribute crash when "Count attribute updates as activity" is enabled** — groups with `staleness_use_last_updated: true` raised `AttributeError: 'DeviceState' object has no attribute 'last_updated'` on every coordinator update cycle, leaving `*_group_summary` and combined sensors stuck `unavailable`. The `last_seen` diagnostic attribute now always uses `last_changed` (the only timestamp `DeviceState` persists); the staleness calculation itself is unaffected and continues to use `last_updated` from the live HA state. (#85, #86)
-
-## [0.5.0] - 2026-08-26
 
 ### ⚠️ Breaking
 

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -24,7 +24,6 @@ from .const import (
     CONF_NON_ESSENTIAL_ENTITIES,
     CONF_SIGNAL_ENTITY_MAP,
     CONF_STALENESS_THRESHOLD,
-    CONF_STALENESS_USE_LAST_UPDATED,
     CONF_USE_DEVICE_NAMES,
     DEFAULT_BAD_STATES,
     DOMAIN,
@@ -142,7 +141,7 @@ class CombinedSensorBase(WriteDedupMixin, SensorEntity):
         # re-collapse (registry lookups) runs once per tick, not per property read.
         self._dm_cache_key: tuple | None = None
         self._dm_cache: dict[str, Any] | None = None
-        self._dm_full_cache: tuple[dict, dict, dict, dict] | None = None
+        self._dm_full_cache: tuple[dict, dict, dict] | None = None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to all included coordinators."""
@@ -238,26 +237,26 @@ class CombinedSensorBase(WriteDedupMixin, SensorEntity):
         )
         if self._dm_cache_key == cache_key and self._dm_cache is not None:
             return self._dm_cache
-        merged, rep_of, udn_map, ulu_map = self._device_map_of(coords)
+        merged, rep_of, udn_map = self._device_map_of(coords)
         reps = dict.fromkeys(rep_of.values())
         collapsed = {eid: merged[eid] for eid in reps}
         self._dm_cache_key = cache_key
         self._dm_cache = collapsed
-        self._dm_full_cache = (merged, rep_of, udn_map, ulu_map)
+        self._dm_full_cache = (merged, rep_of, udn_map)
         return collapsed
 
     def _device_map_cached(
         self, coords: list[EntityAvailabilityCoordinator]
-    ) -> tuple[dict[str, Any], dict[str, str], dict[str, bool], dict[str, bool]]:
-        """Return (merged, rep_of, udn_map, use_last_updated_map) — cached per tick."""
+    ) -> tuple[dict[str, Any], dict[str, str], dict[str, bool]]:
+        """Return (merged, rep_of, udn_map) — cached per tick via _build_device_map."""
         self._build_device_map(coords)
         assert self._dm_full_cache is not None  # always set by _build_device_map
         return self._dm_full_cache
 
     def _device_map_of(
         self, coords: list[EntityAvailabilityCoordinator]
-    ) -> tuple[dict[str, Any], dict[str, str], dict[str, bool], dict[str, bool]]:
-        """Return (merged states, row_key→rep, row_key→use_device_names, row_key→use_last_updated).
+    ) -> tuple[dict[str, Any], dict[str, str], dict[str, bool]]:
+        """Return (merged states, row_key→rep, row_key→use_device_names).
 
         Row key equals entity_id when the entity appears in only one group or
         all groups share identical config (same battery sensor, signal sensor,
@@ -273,7 +272,6 @@ class CombinedSensorBase(WriteDedupMixin, SensorEntity):
         merged: dict[str, Any] = {}
         collapsible: set[str] = set()
         udn_map: dict[str, bool] = {}
-        use_last_updated_map: dict[str, bool] = {}
 
         for coord in coords:
             udn = coord.entry.data.get(CONF_USE_DEVICE_NAMES, False)
@@ -282,9 +280,6 @@ class CombinedSensorBase(WriteDedupMixin, SensorEntity):
             non_essential = set(coord.entry.data.get(CONF_NON_ESSENTIAL_ENTITIES, []))
             bad_states = tuple(
                 sorted(coord.entry.data.get(CONF_BAD_STATES, DEFAULT_BAD_STATES))
-            )
-            use_last_updated = coord.entry.data.get(
-                CONF_STALENESS_USE_LAST_UPDATED, False
             )
             for eid, d in coord.device_states.items():
                 fingerprint = (
@@ -303,17 +298,15 @@ class CombinedSensorBase(WriteDedupMixin, SensorEntity):
                     row_key = f"{eid}::{coord.entry.entry_id}"
                 merged[row_key] = d
                 udn_map[row_key] = udn
-                use_last_updated_map[row_key] = use_last_updated
                 if udn:
                     collapsible.add(row_key)
 
         if not collapsible:
-            return merged, {rk: rk for rk in merged}, udn_map, use_last_updated_map
+            return merged, {rk: rk for rk in merged}, udn_map
         return (
             merged,
             collapse_representatives(self.hass, merged, collapsible),
             udn_map,
-            use_last_updated_map,
         )
 
     @staticmethod
@@ -510,7 +503,7 @@ class CombinedGroupSensor(CombinedSensorBase):
         self, coords: list[EntityAvailabilityCoordinator]
     ) -> frozenset[str]:
         """Return deduplicated set of offline, non-suppressed, essential entity IDs."""
-        merged, rep_of, _, _ = self._device_map_cached(coords)
+        merged, rep_of, _ = self._device_map_cached(coords)
         return frozenset(
             merged[rk].entity_id
             for rk in self._collapsed_match(
@@ -526,7 +519,7 @@ class CombinedGroupSensor(CombinedSensorBase):
         self, coords: list[EntityAvailabilityCoordinator]
     ) -> frozenset[str]:
         """Return deduplicated set of low-battery, non-suppressed, essential entity IDs."""
-        merged, rep_of, _, _ = self._device_map_cached(coords)
+        merged, rep_of, _ = self._device_map_cached(coords)
         return frozenset(
             merged[rk].entity_id
             for rk in self._collapsed_match(
@@ -549,7 +542,7 @@ class CombinedGroupSensor(CombinedSensorBase):
     @property
     def native_value(self) -> int:
         active = self._active_coordinators()
-        _, rep_of, _, _ = self._device_map_cached(active)
+        _, rep_of, _ = self._device_map_cached(active)
         reps = dict.fromkeys(rep_of.values())
         return len(reps)
 
@@ -684,7 +677,7 @@ class CombinedGroupSensor(CombinedSensorBase):
         # Full merged states + device-key map: category lists dedupe by DEVICE so a
         # device with siblings in different categories appears in each. total/membership
         # use the representative set (one row per device).
-        merged_states, rep_of, udn_map, _ = self._device_map_cached(active)
+        merged_states, rep_of, udn_map = self._device_map_cached(active)
 
         def _m(pred) -> list[str]:
             return self._collapsed_match(merged_states, rep_of, pred)
@@ -919,7 +912,7 @@ class CombinedOfflineCountSensor(CombinedSensorBase):
 
     @property
     def native_value(self) -> int:
-        merged, rep_of, _, _ = self._device_map_cached(self._active_coordinators())
+        merged, rep_of, _ = self._device_map_cached(self._active_coordinators())
         return len(
             self._collapsed_match(
                 merged,
@@ -932,7 +925,7 @@ class CombinedOfflineCountSensor(CombinedSensorBase):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        merged, rep_of, _, _ = self._device_map_cached(self._active_coordinators())
+        merged, rep_of, _ = self._device_map_cached(self._active_coordinators())
         offline = self._collapsed_match(
             merged,
             rep_of,
@@ -960,7 +953,7 @@ class CombinedOfflineEntitiesSensor(CombinedSensorBase):
     @property
     def native_value(self) -> str:
         coords = self._active_coordinators()
-        merged, rep_of, udn, _ = self._device_map_cached(coords)
+        merged, rep_of, udn = self._device_map_cached(coords)
         offline = [
             _friendly_name(self.hass, merged[rk].entity_id, udn.get(rk, False))
             for rk in self._collapsed_match(
@@ -982,7 +975,7 @@ class CombinedOfflineEntitiesSensor(CombinedSensorBase):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        merged, rep_of, _, _ = self._device_map_cached(self._active_coordinators())
+        merged, rep_of, _ = self._device_map_cached(self._active_coordinators())
         offline = self._collapsed_match(
             merged,
             rep_of,
@@ -1010,7 +1003,7 @@ class CombinedLowBatterySensor(CombinedSensorBase):
     @property
     def native_value(self) -> str:
         coords = self._active_coordinators()
-        merged, rep_of, udn, _ = self._device_map_cached(coords)
+        merged, rep_of, udn = self._device_map_cached(coords)
         low = [
             f"{_friendly_name(self.hass, merged[rk].entity_id, udn.get(rk, False))} ({merged[rk].battery_level}%)"
             for rk in self._collapsed_match(
@@ -1035,7 +1028,7 @@ class CombinedLowBatterySensor(CombinedSensorBase):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        merged, rep_of, _, _ = self._device_map_cached(self._active_coordinators())
+        merged, rep_of, _ = self._device_map_cached(self._active_coordinators())
         devices: dict[str, Any] = {
             merged[rk].entity_id: f"{merged[rk].battery_level}%"
             for rk in self._collapsed_match(
@@ -1068,7 +1061,7 @@ class CombinedLowBatteryCountSensor(CombinedSensorBase):
 
     @property
     def native_value(self) -> int:
-        merged, rep_of, _, _ = self._device_map_cached(self._active_coordinators())
+        merged, rep_of, _ = self._device_map_cached(self._active_coordinators())
         return len(
             self._collapsed_match(
                 merged,

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -567,6 +567,30 @@ class TestCombinedGroupSensor:
         assert "binary_sensor.b1" in attrs["suppressed_until"]
         assert "binary_sensor.a1" in attrs["last_seen"]
 
+    def test_last_seen_uses_last_changed_when_staleness_use_last_updated(
+        self, mock_hass, combined_entry, coordinators
+    ):
+        """last_seen uses last_changed regardless of staleness_use_last_updated flag.
+
+        Regression test for GitHub #85: DeviceState has no last_updated field;
+        the old code raised AttributeError when staleness_use_last_updated=True.
+        """
+        mock_hass.data[DOMAIN] = {
+            "entry_a": coordinators[0],
+            "entry_b": coordinators[1],
+        }
+        lc = datetime(2026, 3, 1, 10, 0, 0, tzinfo=timezone.utc)
+        coordinators[0]._device_states["binary_sensor.a1"].last_changed = lc
+        # Simulate staleness_use_last_updated=True on the coordinator — the old
+        # buggy code read use_last_updated_map per row_key and then accessed
+        # d.last_updated (which doesn't exist on DeviceState), crashing with
+        # AttributeError on every tick. The fix uses d.last_changed unconditionally.
+        coordinators[0]._staleness_use_last_updated = True
+        sensor = self._sensor(mock_hass, combined_entry, coordinators)
+        attrs = sensor.extra_state_attributes
+        assert "binary_sensor.a1" in attrs["last_seen"]
+        assert attrs["last_seen"]["binary_sensor.a1"] == lc.isoformat()
+
     def test_attributes_battery_powered_via_battery_map(
         self, mock_hass, group_entry_a, group_entry_b, coordinators
     ):

--- a/tests/test_combined_sensor.py
+++ b/tests/test_combined_sensor.py
@@ -34,6 +34,7 @@ from custom_components.entity_availability.const import (
     CONF_ENTRY_TYPE,
     CONF_GROUP_NAME,
     CONF_STALENESS_THRESHOLD,
+    CONF_STALENESS_USE_LAST_UPDATED,
     CONF_USE_DEVICE_NAMES,
     DEFAULT_AVAILABILITY_WINDOWS,
     DOMAIN,
@@ -568,28 +569,57 @@ class TestCombinedGroupSensor:
         assert "binary_sensor.a1" in attrs["last_seen"]
 
     def test_last_seen_uses_last_changed_when_staleness_use_last_updated(
-        self, mock_hass, combined_entry, coordinators
+        self, mock_hass, combined_entry
     ):
         """last_seen uses last_changed regardless of staleness_use_last_updated flag.
 
         Regression test for GitHub #85: DeviceState has no last_updated field;
         the old code raised AttributeError when staleness_use_last_updated=True.
+        Uses a real coordinator built from entry data with the flag set — mirrors
+        the actual prod flow that triggered the crash.
         """
-        mock_hass.data[DOMAIN] = {
-            "entry_a": coordinators[0],
-            "entry_b": coordinators[1],
-        }
         lc = datetime(2026, 3, 1, 10, 0, 0, tzinfo=timezone.utc)
-        coordinators[0]._device_states["binary_sensor.a1"].last_changed = lc
-        # Simulate staleness_use_last_updated=True on the coordinator — the old
-        # buggy code read use_last_updated_map per row_key and then accessed
-        # d.last_updated (which doesn't exist on DeviceState), crashing with
-        # AttributeError on every tick. The fix uses d.last_changed unconditionally.
-        coordinators[0]._staleness_use_last_updated = True
-        sensor = self._sensor(mock_hass, combined_entry, coordinators)
+        group_entry = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="Group ULU",
+            data={
+                CONF_ENTRY_TYPE: ENTRY_TYPE_GROUP,
+                CONF_GROUP_NAME: "Group ULU",
+                CONF_ENTITIES: ["binary_sensor.x1"],
+                CONF_AVAILABILITY_WINDOWS: DEFAULT_AVAILABILITY_WINDOWS,
+                CONF_STALENESS_USE_LAST_UPDATED: True,
+            },
+            entry_id="entry_ulu",
+            unique_id=f"{DOMAIN}_group_ulu",
+        )
+        group_entry.add_to_hass(mock_hass)
+        with patch.object(
+            EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+        ):
+            coord = EntityAvailabilityCoordinator(mock_hass, group_entry)
+            coord._device_states["binary_sensor.x1"] = DeviceState(
+                entity_id="binary_sensor.x1", last_changed=lc
+            )
+        mock_hass.data[DOMAIN] = {"entry_ulu": coord}
+        combined = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="Combined ULU",
+            data={
+                CONF_ENTRY_TYPE: ENTRY_TYPE_COMBINED,
+                CONF_GROUP_NAME: "Combined ULU",
+                CONF_COMBINED_GROUPS: ["entry_ulu"],
+            },
+            entry_id="combined_ulu",
+            unique_id=f"{DOMAIN}_combined_ulu",
+        )
+        sensor = CombinedGroupSensor(
+            mock_hass, combined, "Combined ULU", "combined_ulu", ["entry_ulu"]
+        )
         attrs = sensor.extra_state_attributes
-        assert "binary_sensor.a1" in attrs["last_seen"]
-        assert attrs["last_seen"]["binary_sensor.a1"] == lc.isoformat()
+        assert "binary_sensor.x1" in attrs["last_seen"]
+        assert attrs["last_seen"]["binary_sensor.x1"] == lc.isoformat()
 
     def test_attributes_battery_powered_via_battery_map(
         self, mock_hass, group_entry_a, group_entry_b, coordinators

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -17,6 +17,7 @@ from custom_components.entity_availability.const import (
     CONF_ENTRY_TYPE,
     CONF_GROUP_NAME,
     CONF_STALENESS_THRESHOLD,
+    CONF_STALENESS_USE_LAST_UPDATED,
     DOMAIN,
     ENTRY_TYPE_COMBINED,
 )
@@ -731,6 +732,42 @@ class TestGroupSummarySensor:
         sensor = GroupSummarySensor(coord, "Test", "test", entry.entry_id)
         sensor.hass = mock_hass
         assert sensor.extra_state_attributes["staleness_enabled"] is False
+
+    def test_last_seen_uses_last_changed_when_staleness_use_last_updated(
+        self, mock_hass, mock_config_data
+    ):
+        """last_seen uses last_changed regardless of staleness_use_last_updated flag.
+
+        Regression test for GitHub #85: DeviceState has no last_updated field;
+        the old code raised AttributeError when staleness_use_last_updated=True.
+        """
+        from datetime import datetime, timezone
+
+        lc = datetime(2026, 3, 1, 10, 0, 0, tzinfo=timezone.utc)
+        entry = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="Test",
+            data={
+                **mock_config_data,
+                CONF_STALENESS_USE_LAST_UPDATED: True,
+            },
+            entry_id="test_ulu_last_seen",
+            unique_id=f"{DOMAIN}_test_ulu_last_seen",
+        )
+        entry.add_to_hass(mock_hass)
+        with patch.object(
+            EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+        ):
+            coord = EntityAvailabilityCoordinator(mock_hass, entry)
+            coord._device_states["binary_sensor.device_a"] = DeviceState(
+                entity_id="binary_sensor.device_a", last_changed=lc
+            )
+        sensor = GroupSummarySensor(coord, "Test", "test", entry.entry_id)
+        sensor.hass = mock_hass
+        attrs = sensor.extra_state_attributes
+        assert "binary_sensor.device_a" in attrs["last_seen"]
+        assert attrs["last_seen"]["binary_sensor.device_a"] == lc.isoformat()
 
     def test_battery_enabled_false_when_key_absent(self, mock_hass, mock_config_data):
         """battery_enabled must be False when CONF_BATTERY_THRESHOLD is absent from config."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -741,8 +741,6 @@ class TestGroupSummarySensor:
         Regression test for GitHub #85: DeviceState has no last_updated field;
         the old code raised AttributeError when staleness_use_last_updated=True.
         """
-        from datetime import datetime, timezone
-
         lc = datetime(2026, 3, 1, 10, 0, 0, tzinfo=timezone.utc)
         entry = MockConfigEntry(
             version=1,


### PR DESCRIPTION
## Summary

Stacks on #86. After PR#86 switches `last_seen` to use `d.last_changed` unconditionally, the `use_last_updated_map` built in `_device_map_of` has no consumers. This PR cleans it up:

- Removes `use_last_updated_map` from `_device_map_of` / `_device_map_cached` / `_dm_full_cache` — back to a 3-tuple
- Removes the now-unused `CONF_STALENESS_USE_LAST_UPDATED` import from `combined_sensor.py`
- Cleans all `_, _` unpacks across 11 `_device_map_cached` call sites back to `_`
- Adds regression tests in `test_sensor.py` and `test_combined_sensor.py`: assert `last_seen` is populated correctly (uses `last_changed`) when `staleness_use_last_updated=True` — guards against reintroducing #85

## Test plan

- [x] 834 unit tests pass, 100% line + branch coverage
- [x] `ruff check` and `ruff format --check` clean
- [x] 162/162 smoke checks green against live HA devcontainer