### PR TITLE
fix(card): clean up collapsed device row tooltip and inline detail

### DIFF
--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1295,7 +1295,7 @@ class EntityAvailabilityCard extends LitElement {
         status = "Poor Signal";
       }
 
-      return { entityId, rowKey, deviceId, memberCount, name: friendlyName, dotColor, status, battery, isOffline, isStale, isSuppressed, isNonEssential, signalLevel, signalUnit, isPoorSignal, isOkSignal };
+      return { entityId, rowKey, deviceId, memberCount, members, name: friendlyName, dotColor, status, battery, isOffline, isStale, isSuppressed, isNonEssential, signalLevel, signalUnit, isPoorSignal, isOkSignal };
     });
 
     // Normalize signal level to 0–100 quality score (higher = better).
@@ -1381,21 +1381,21 @@ class EntityAvailabilityCard extends LitElement {
       : null;
 
     const identityRow = deviceName
-      ? { label: "Device", value: `${deviceName} (${item.memberCount} entities)` }
+      ? { label: "Device", value: deviceName }
       : { label: "Entity ID", value: item.entityId };
 
     const conditionValue = suppressedUntil
       ? "Suppressed"
       : item.isOffline
-        ? (isCollapsed ? `≥1 entity offline for ${item.status}` : `Offline for ${item.status}`)
+        ? (isCollapsed ? `${item.memberCount} ${item.memberCount === 1 ? "entity" : "entities"} offline for ${item.status}` : `Offline for ${item.status}`)
         : isCollapsed
-          ? `≥1 entity: ${item.status}`
+          ? `${item.memberCount} ${item.memberCount === 1 ? "entity" : "entities"}: ${item.status}`
           : item.status;
 
     return [
       identityRow,
       areaName ? { label: "Area", value: areaName } : null,
-      { label: "HA State", value: lastChanged ? `${this._formatStateWithUnit(entityState)} · ${lastChanged}` : this._formatStateWithUnit(entityState) },
+      !isCollapsed ? { label: "HA State", value: lastChanged ? `${this._formatStateWithUnit(entityState)} · ${lastChanged}` : this._formatStateWithUnit(entityState) } : null,
       { label: "Condition", value: conditionValue },
       item.battery !== null ? { label: "Battery", value: `${item.battery}%` } : null,
       item.signalLevel !== null && item.signalLevel !== undefined ? { label: "Signal", value: `${item.signalLevel}${item.signalUnit ? " " + item.signalUnit : ""}${item.isPoorSignal ? " (poor)" : ""}` } : null,
@@ -1405,8 +1405,27 @@ class EntityAvailabilityCard extends LitElement {
 
   _renderDetailInline(item, suppressedUntilMap) {
     const compact = this._config.compact === true;
+    const isCollapsed = item.memberCount > 1;
     let rows;
-    if (compact) {
+    if (isCollapsed && compact) {
+      const suppressedUntil = suppressedUntilMap?.[item.rowKey] ?? suppressedUntilMap?.[item.entityId] ?? null;
+      const conditionValue = suppressedUntil
+        ? "Suppressed"
+        : item.isOffline
+          ? `${item.memberCount} ${item.memberCount === 1 ? "entity" : "entities"} offline for ${item.status}`
+          : `${item.memberCount} ${item.memberCount === 1 ? "entity" : "entities"}: ${item.status}`;
+      rows = [{ label: "Condition", value: conditionValue }];
+    } else if (isCollapsed && !compact) {
+      rows = (item.members || [item.entityId]).map((eid) => {
+        const entityState = this.hass.states[eid];
+        const lastChanged = this._computeDuration(eid);
+        const label = entityState?.attributes?.friendly_name || eid.split(".").pop();
+        const value = lastChanged
+          ? `${this._formatStateWithUnit(entityState)} · ${lastChanged}`
+          : this._formatStateWithUnit(entityState);
+        return { label, value };
+      });
+    } else if (compact) {
       const entityState = this.hass.states[item.entityId];
       const lastChanged = this._computeDuration(item.entityId);
       const haStateValue = lastChanged

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1391,11 +1391,13 @@ class EntityAvailabilityCard extends LitElement {
 
     const conditionValue = suppressedUntil
       ? "Suppressed"
-      : item.isOffline
-        ? (isCollapsed ? `${_entityWord(offlineCount)} offline for ${item.status}` : `Offline for ${item.status}`)
-        : isCollapsed
-          ? `${_entityWord(item.memberCount)}: ${item.status}`
-          : item.status;
+      : item.isOffline && isCollapsed
+        ? `${_entityWord(offlineCount)} offline for ${item.status} · ${_entityWord(item.memberCount - offlineCount)} online`
+        : item.isOffline
+          ? `Offline for ${item.status}`
+          : isCollapsed
+            ? `${_entityWord(item.memberCount)}: ${item.status}`
+            : item.status;
 
     return [
       identityRow,
@@ -1420,7 +1422,7 @@ class EntityAvailabilityCard extends LitElement {
       const conditionValue = suppressedUntil
         ? "Suppressed"
         : item.isOffline
-          ? `${_entityWord(offlineCount)} offline for ${item.status}`
+          ? `${_entityWord(offlineCount)} offline for ${item.status} · ${_entityWord(item.memberCount - offlineCount)} online`
           : `${_entityWord(item.memberCount)}: ${item.status}`;
       rows = [{ label: "Condition", value: conditionValue }];
     } else if (isCollapsed && !compact) {

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1379,7 +1379,7 @@ class EntityAvailabilityCard extends LitElement {
 
     const isCollapsed = item.memberCount > 1;
     const offlineCount = isCollapsed && item.members
-      ? item.members.filter(eid => this._getOfflineEntityIds().includes(eid)).length
+      ? Math.max(item.members.filter(eid => this._getOfflineEntityIds().includes(eid)).length, item.isOffline ? 1 : 0)
       : (item.isOffline ? 1 : 0);
     const deviceName = isCollapsed && item.deviceId
       ? (this.hass.devices?.[item.deviceId]?.name_by_user || this.hass.devices?.[item.deviceId]?.name || null)
@@ -1414,7 +1414,7 @@ class EntityAvailabilityCard extends LitElement {
     const compact = this._config.compact === true;
     const isCollapsed = item.memberCount > 1;
     const offlineCount = isCollapsed && item.members
-      ? item.members.filter(eid => this._getOfflineEntityIds().includes(eid)).length
+      ? Math.max(item.members.filter(eid => this._getOfflineEntityIds().includes(eid)).length, item.isOffline ? 1 : 0)
       : (item.isOffline ? 1 : 0);
     let rows;
     if (isCollapsed && compact) {

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1361,8 +1361,14 @@ class EntityAvailabilityCard extends LitElement {
     return items;
   }
 
-  _collapsedCondition(item, suppressedUntil) {
-    if (suppressedUntil) return "Suppressed";
+  _isSuppressed(item, suppressedUntilMap) {
+    const key = (item.rowKey != null && item.rowKey in suppressedUntilMap) ? item.rowKey
+      : item.entityId in suppressedUntilMap ? item.entityId : null;
+    return key !== null;
+  }
+
+  _collapsedCondition(item, suppressedUntilMap) {
+    if (this._isSuppressed(item, suppressedUntilMap)) return "Suppressed";
     if (!item.isOffline) return `${_entityWord(item.memberCount)}: ${item.status}`;
     const offlineSet = new Set(this._getOfflineEntityIds());
     const offlineCount = item.members
@@ -1399,7 +1405,7 @@ class EntityAvailabilityCard extends LitElement {
       : { label: "Entity ID", value: item.entityId };
 
     const conditionValue = isCollapsed
-      ? this._collapsedCondition(item, suppressedUntil)
+      ? this._collapsedCondition(item, suppressedUntilMap)
       : suppressedUntil ? "Suppressed" : item.isOffline ? `Offline for ${item.status}` : item.status;
 
     return [
@@ -1418,11 +1424,7 @@ class EntityAvailabilityCard extends LitElement {
     const isCollapsed = item.memberCount > 1;
     let rows;
     if (isCollapsed && compact) {
-      const suppressedUntilIso = (item.rowKey != null && item.rowKey in suppressedUntilMap)
-        ? suppressedUntilMap[item.rowKey]
-        : suppressedUntilMap[item.entityId];
-      const suppressedUntil = suppressedUntilIso === null ? "indefinitely" : suppressedUntilIso ? this._formatFutureDate(suppressedUntilIso) : null;
-      rows = [{ label: "Condition", value: this._collapsedCondition(item, suppressedUntil) }];
+      rows = [{ label: "Condition", value: this._collapsedCondition(item, suppressedUntilMap) }];
     } else if (isCollapsed && !compact) {
       if (!item.members) {
         console.warn("[EA] collapsed row missing members", item.entityId);

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1359,6 +1359,8 @@ class EntityAvailabilityCard extends LitElement {
     return items;
   }
 
+  _entityWord(n) { return `${n} ${n === 1 ? "entity" : "entities"}`; }
+
   _buildDetailRows(item, suppressedUntilMap) {
     const entityState = this.hass.states[item.entityId];
     const lastChanged = this._computeDuration(item.entityId);
@@ -1387,9 +1389,9 @@ class EntityAvailabilityCard extends LitElement {
     const conditionValue = suppressedUntil
       ? "Suppressed"
       : item.isOffline
-        ? (isCollapsed ? `${item.memberCount} ${item.memberCount === 1 ? "entity" : "entities"} offline for ${item.status}` : `Offline for ${item.status}`)
+        ? (isCollapsed ? `${this._entityWord(item.memberCount)} offline for ${item.status}` : `Offline for ${item.status}`)
         : isCollapsed
-          ? `${item.memberCount} ${item.memberCount === 1 ? "entity" : "entities"}: ${item.status}`
+          ? `${this._entityWord(item.memberCount)}: ${item.status}`
           : item.status;
 
     return [
@@ -1412,19 +1414,24 @@ class EntityAvailabilityCard extends LitElement {
       const conditionValue = suppressedUntil
         ? "Suppressed"
         : item.isOffline
-          ? `${item.memberCount} ${item.memberCount === 1 ? "entity" : "entities"} offline for ${item.status}`
-          : `${item.memberCount} ${item.memberCount === 1 ? "entity" : "entities"}: ${item.status}`;
+          ? `${this._entityWord(item.memberCount)} offline for ${item.status}`
+          : `${this._entityWord(item.memberCount)}: ${item.status}`;
       rows = [{ label: "Condition", value: conditionValue }];
     } else if (isCollapsed && !compact) {
-      rows = (item.members || [item.entityId]).map((eid) => {
-        const entityState = this.hass.states[eid];
-        const lastChanged = this._computeDuration(eid);
-        const label = entityState?.attributes?.friendly_name || eid.split(".").pop();
-        const value = lastChanged
-          ? `${this._formatStateWithUnit(entityState)} · ${lastChanged}`
-          : this._formatStateWithUnit(entityState);
-        return { label, value };
-      });
+      if (!item.members) {
+        console.warn("[EA] collapsed row missing members", item.entityId);
+        rows = [];
+      } else {
+        rows = item.members.map((eid) => {
+          const entityState = this.hass.states[eid];
+          const lastChanged = this._computeDuration(eid);
+          const label = entityState?.attributes?.friendly_name || eid.split(".").pop();
+          const value = lastChanged
+            ? `${this._formatStateWithUnit(entityState)} · ${lastChanged}`
+            : this._formatStateWithUnit(entityState);
+          return { label, value };
+        });
+      }
     } else if (compact) {
       const entityState = this.hass.states[item.entityId];
       const lastChanged = this._computeDuration(item.entityId);

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -651,6 +651,8 @@ const cardStyles = css`
   }
 `;
 
+const _entityWord = (n) => `${n} ${n === 1 ? "entity" : "entities"}`;
+
 class EntityAvailabilityCard extends LitElement {
   static get properties() {
     return {
@@ -1359,8 +1361,6 @@ class EntityAvailabilityCard extends LitElement {
     return items;
   }
 
-  _entityWord(n) { return `${n} ${n === 1 ? "entity" : "entities"}`; }
-
   _buildDetailRows(item, suppressedUntilMap) {
     const entityState = this.hass.states[item.entityId];
     const lastChanged = this._computeDuration(item.entityId);
@@ -1378,6 +1378,9 @@ class EntityAvailabilityCard extends LitElement {
       : null;
 
     const isCollapsed = item.memberCount > 1;
+    const offlineCount = isCollapsed && item.members
+      ? item.members.filter(eid => this._getOfflineEntityIds().includes(eid)).length
+      : (item.isOffline ? 1 : 0);
     const deviceName = isCollapsed && item.deviceId
       ? (this.hass.devices?.[item.deviceId]?.name_by_user || this.hass.devices?.[item.deviceId]?.name || null)
       : null;
@@ -1389,9 +1392,9 @@ class EntityAvailabilityCard extends LitElement {
     const conditionValue = suppressedUntil
       ? "Suppressed"
       : item.isOffline
-        ? (isCollapsed ? `${this._entityWord(item.memberCount)} offline for ${item.status}` : `Offline for ${item.status}`)
+        ? (isCollapsed ? `${_entityWord(offlineCount)} offline for ${item.status}` : `Offline for ${item.status}`)
         : isCollapsed
-          ? `${this._entityWord(item.memberCount)}: ${item.status}`
+          ? `${_entityWord(item.memberCount)}: ${item.status}`
           : item.status;
 
     return [
@@ -1408,14 +1411,17 @@ class EntityAvailabilityCard extends LitElement {
   _renderDetailInline(item, suppressedUntilMap) {
     const compact = this._config.compact === true;
     const isCollapsed = item.memberCount > 1;
+    const offlineCount = isCollapsed && item.members
+      ? item.members.filter(eid => this._getOfflineEntityIds().includes(eid)).length
+      : (item.isOffline ? 1 : 0);
     let rows;
     if (isCollapsed && compact) {
       const suppressedUntil = suppressedUntilMap?.[item.rowKey] ?? suppressedUntilMap?.[item.entityId] ?? null;
       const conditionValue = suppressedUntil
         ? "Suppressed"
         : item.isOffline
-          ? `${this._entityWord(item.memberCount)} offline for ${item.status}`
-          : `${this._entityWord(item.memberCount)}: ${item.status}`;
+          ? `${_entityWord(offlineCount)} offline for ${item.status}`
+          : `${_entityWord(item.memberCount)}: ${item.status}`;
       rows = [{ label: "Condition", value: conditionValue }];
     } else if (isCollapsed && !compact) {
       if (!item.members) {

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1406,7 +1406,7 @@ class EntityAvailabilityCard extends LitElement {
 
     const conditionValue = isCollapsed
       ? this._collapsedCondition(item, suppressedUntilMap)
-      : suppressedUntil ? "Suppressed" : item.isOffline ? `Offline for ${item.status}` : item.status;
+      : this._isSuppressed(item, suppressedUntilMap) ? "Suppressed" : item.isOffline ? `Offline for ${item.status}` : item.status;
 
     return [
       identityRow,

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1392,7 +1392,7 @@ class EntityAvailabilityCard extends LitElement {
     const conditionValue = suppressedUntil
       ? "Suppressed"
       : item.isOffline && isCollapsed
-        ? `${_entityWord(offlineCount)} offline for ${item.status} · ${_entityWord(item.memberCount - offlineCount)} online`
+        ? `${_entityWord(offlineCount)} offline for ${item.status} · ${_entityWord(item.memberCount - offlineCount)}: Online`
         : item.isOffline
           ? `Offline for ${item.status}`
           : isCollapsed
@@ -1422,7 +1422,7 @@ class EntityAvailabilityCard extends LitElement {
       const conditionValue = suppressedUntil
         ? "Suppressed"
         : item.isOffline
-          ? `${_entityWord(offlineCount)} offline for ${item.status} · ${_entityWord(item.memberCount - offlineCount)} online`
+          ? `${_entityWord(offlineCount)} offline for ${item.status} · ${_entityWord(item.memberCount - offlineCount)}: Online`
           : `${_entityWord(item.memberCount)}: ${item.status}`;
       rows = [{ label: "Condition", value: conditionValue }];
     } else if (isCollapsed && !compact) {

--- a/custom_components/entity_availability/frontend/entity-availability-card.js
+++ b/custom_components/entity_availability/frontend/entity-availability-card.js
@@ -1361,6 +1361,18 @@ class EntityAvailabilityCard extends LitElement {
     return items;
   }
 
+  _collapsedCondition(item, suppressedUntil) {
+    if (suppressedUntil) return "Suppressed";
+    if (!item.isOffline) return `${_entityWord(item.memberCount)}: ${item.status}`;
+    const offlineSet = new Set(this._getOfflineEntityIds());
+    const offlineCount = item.members
+      ? Math.max(item.members.filter(eid => offlineSet.has(eid)).length, 1)
+      : 1;
+    const onlineCount = item.memberCount - offlineCount;
+    const suffix = onlineCount > 0 ? ` · ${_entityWord(onlineCount)}: Online` : "";
+    return `${_entityWord(offlineCount)} offline for ${item.status}${suffix}`;
+  }
+
   _buildDetailRows(item, suppressedUntilMap) {
     const entityState = this.hass.states[item.entityId];
     const lastChanged = this._computeDuration(item.entityId);
@@ -1378,9 +1390,6 @@ class EntityAvailabilityCard extends LitElement {
       : null;
 
     const isCollapsed = item.memberCount > 1;
-    const offlineCount = isCollapsed && item.members
-      ? Math.max(item.members.filter(eid => this._getOfflineEntityIds().includes(eid)).length, item.isOffline ? 1 : 0)
-      : (item.isOffline ? 1 : 0);
     const deviceName = isCollapsed && item.deviceId
       ? (this.hass.devices?.[item.deviceId]?.name_by_user || this.hass.devices?.[item.deviceId]?.name || null)
       : null;
@@ -1389,15 +1398,9 @@ class EntityAvailabilityCard extends LitElement {
       ? { label: "Device", value: deviceName }
       : { label: "Entity ID", value: item.entityId };
 
-    const conditionValue = suppressedUntil
-      ? "Suppressed"
-      : item.isOffline && isCollapsed
-        ? `${_entityWord(offlineCount)} offline for ${item.status} · ${_entityWord(item.memberCount - offlineCount)}: Online`
-        : item.isOffline
-          ? `Offline for ${item.status}`
-          : isCollapsed
-            ? `${_entityWord(item.memberCount)}: ${item.status}`
-            : item.status;
+    const conditionValue = isCollapsed
+      ? this._collapsedCondition(item, suppressedUntil)
+      : suppressedUntil ? "Suppressed" : item.isOffline ? `Offline for ${item.status}` : item.status;
 
     return [
       identityRow,
@@ -1413,18 +1416,13 @@ class EntityAvailabilityCard extends LitElement {
   _renderDetailInline(item, suppressedUntilMap) {
     const compact = this._config.compact === true;
     const isCollapsed = item.memberCount > 1;
-    const offlineCount = isCollapsed && item.members
-      ? Math.max(item.members.filter(eid => this._getOfflineEntityIds().includes(eid)).length, item.isOffline ? 1 : 0)
-      : (item.isOffline ? 1 : 0);
     let rows;
     if (isCollapsed && compact) {
-      const suppressedUntil = suppressedUntilMap?.[item.rowKey] ?? suppressedUntilMap?.[item.entityId] ?? null;
-      const conditionValue = suppressedUntil
-        ? "Suppressed"
-        : item.isOffline
-          ? `${_entityWord(offlineCount)} offline for ${item.status} · ${_entityWord(item.memberCount - offlineCount)}: Online`
-          : `${_entityWord(item.memberCount)}: ${item.status}`;
-      rows = [{ label: "Condition", value: conditionValue }];
+      const suppressedUntilIso = (item.rowKey != null && item.rowKey in suppressedUntilMap)
+        ? suppressedUntilMap[item.rowKey]
+        : suppressedUntilMap[item.entityId];
+      const suppressedUntil = suppressedUntilIso === null ? "indefinitely" : suppressedUntilIso ? this._formatFutureDate(suppressedUntilIso) : null;
+      rows = [{ label: "Condition", value: this._collapsedCondition(item, suppressedUntil) }];
     } else if (isCollapsed && !compact) {
       if (!item.members) {
         console.warn("[EA] collapsed row missing members", item.entityId);


### PR DESCRIPTION
## Summary

- Tooltip condition shows exact count (`5 entities: Online`) instead of hardcoded `≥1`
- Offline variant also uses exact count (`5 entities offline for 2h`)
- Device row label drops redundant `(N entities)` — count already in Condition row
- HA State hidden for collapsed rows in tooltip (single arbitrary member is misleading)
- Compact inline detail: collapsed rows show single Condition row only
- Non-compact inline detail: collapsed rows show per-member entity HA state list (`friendly_name: state · duration`)
- `members` array stored on item object to support per-member rendering

## Test plan

- [ ] Single group card with a combined group containing a collapsed device (≥2 entities)
- [ ] Tooltip shows correct entity count in Condition (not `≥1`)
- [ ] Tooltip Device row shows name only, no `(N entities)` suffix
- [ ] Tooltip has no HA State row for collapsed device rows
- [ ] Compact mode inline: collapsed row shows `Condition: N entities: Online`
- [ ] Non-compact inline: collapsed row shows one line per member with state + duration
- [ ] Single-entity rows unaffected in both compact and non-compact