### PR TITLE
ci: enforce 100% line and branch coverage

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements_test.txt 2>/dev/null || true
-          pip install pytest pytest-homeassistant-custom-component
+          pip install pytest pytest-homeassistant-custom-component pytest-cov
       - name: Run tests
         run: pytest tests/ --tb=short -q

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 asyncio_mode = auto
+addopts = --cov=custom_components/entity_availability --cov-branch --cov-report=term-missing --cov-fail-under=100


### PR DESCRIPTION
Enforces the existing 100% coverage as a hard gate.

## What
- `pytest.ini`: add `addopts = --cov=custom_components/entity_availability --cov-branch --cov-report=term-missing --cov-fail-under=100`
- `validate.yml`: ensure `pytest-cov` is installed in the CI test job

## Why
Suite already passes at **100% line and branch** (2958 stmts, 840 branches, 0 miss) but nothing enforced it — a regression could silently drop coverage. This locks it in locally and in CI.

## Verification
`pytest tests/` → `Required test coverage of 100% reached. Total coverage: 100.00%` · 842 passed.