### PR TITLE
chore: standardize dev/CI versions (Python 3.14, aligned test deps)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install ruff
         run: pip install ruff==0.16.1
       - name: Run ruff check
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           pip install -r requirements_test.txt 2>/dev/null || true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-pytest>=7.0
-pytest-asyncio>=0.21
-pytest-homeassistant-custom-component>=0.13
-pytest-cov>=4.0
+pytest>=9.0
+pytest-asyncio>=1.4.0
+pytest-homeassistant-custom-component>=0.13.356
+pytest-cov>=7.1.0


### PR DESCRIPTION
## Summary

Standardizes dev/CI tool versions to a common baseline.

### Key fix
CI Python bumped **3.12 → 3.14** in `.github/workflows/validate.yml` (both `lint` and `test` jobs). The floating `phacc>=0.13` pin resolves to a version that requires Python 3.14; on 3.12 CI this silently failed via the `|| true` fallback in the install step.

### Changes
- `.github/workflows/validate.yml`: `python-version: "3.12"` → `"3.14"` (lint + test jobs)
- `requirements_test.txt`:
  - `pytest>=7.0` → `pytest>=9.0`
  - `pytest-asyncio>=0.21` → `pytest-asyncio>=1.4.0`
  - `pytest-homeassistant-custom-component>=0.13` → `>=0.13.356`
  - `pytest-cov>=4.0` → `pytest-cov>=7.1.0`

Ruff CI pin (`0.16.1`) already correct — unchanged. `hacs.json` HA minimum untouched. No production code touched.

### Verification
Fresh `python3.14 -m venv` + `pip install -r requirements_test.txt pytest`, then `pytest tests/`:

- Resolved: pytest 9.0.3, pytest-asyncio 1.4.0, phacc 0.13.360, pytest-cov 7.1.0
- **842 passed**, 100% coverage on Python 3.14.7