### PR TITLE
chore(test): drop PHACC-controlled pins from requirements_test.txt

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-pytest>=9.0
-pytest-asyncio>=1.4.0
+# Only pin PHACC + repo-specific deps. PHACC transitively pins pytest,
+# pytest-asyncio, pytest-cov, etc. Pinning them directly causes unsatisfiable
+# dependabot bumps (pytest==9.0.3 is hard-pinned upstream).
 pytest-homeassistant-custom-component>=0.13.356
-pytest-cov>=7.1.0


### PR DESCRIPTION
pytest-homeassistant-custom-component (PHACC) hard-pins pytest==9.0.3, pytest-asyncio, pytest-cov, freezegun, etc. Listing those as direct `>=` requirements makes every dependabot bump of them unsatisfiable (pip resolution fails). This drops the redundant pins, keeping only PHACC + genuine repo-specific deps. Fixes the recurring dependabot CI failures at the source.