### PR TITLE
fix: dedup on recorder-stored attr view to stop write amplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to this project will be documented in this file.
 
 ## [0.5.0] - 2026-08-26
 
-### Fixed — groups with `staleness_use_last_updated: true` raised `AttributeError: 'DeviceState' object has no attribute 'last_updated'` on every coordinator update cycle, leaving `*_group_summary` and combined sensors stuck `unavailable`. The `last_seen` diagnostic attribute now always uses `last_changed`; the staleness calculation itself is unaffected. (#85, #86)
+### Fixed
+- **`last_seen` attribute crash when "Count attribute updates as activity" is enabled** — groups with `staleness_use_last_updated: true` raised `AttributeError: 'DeviceState' object has no attribute 'last_updated'` on every coordinator update cycle, leaving `*_group_summary` and combined sensors stuck `unavailable`. The `last_seen` diagnostic attribute now always uses `last_changed`; the staleness calculation itself is unaffected. (#85, #86)
 - **Combined groups: suppression dedup is now deterministic** — when the same entity appears in multiple source groups, the combined view previously reflected whichever group was added first. Now: unsuppressed beats suppressed; if both suppressed, the longer/indefinite expiry wins. A per-group mute no longer silences the entity in combined when another group still monitors it actively. (#88)
 - **Combined card: suppression tooltip on collapsed rows** — the suppressed-until tooltip was keyed by entity_id; combined rows use row_key which may differ. Now checks row_key first. (#88)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.5.0] - 2026-08-26
+## [0.6.0] - 2026-09-05
+
+### Fixed
+- **Recorder write amplification on summary sensors** — the `*_group_summary` and combined-group summary sensors called `async_write_ha_state()` on every coordinator tick even when nothing recorded actually changed. Volatile-but-unrecorded attributes (`last_seen`, `signal_levels`, `battery_levels`, `offline_since`, `suppressed_until` …) advanced each tick and defeated the write-dedup guard, producing a redundant States row per tick per sensor (one class alone had accumulated ~729k rows). The dedup comparison now uses the *recorder-stored* view of the attributes — exactly the set Home Assistant strips (`_entity_component_unrecorded_attributes | _unrecorded_attributes`) — so a sensor only writes when a recorded value truly changes. Availability history is unchanged; this only stops the duplicate no-op rows. Forward-only: existing rows purge normally at the 40-day retention. (#95)
+
+### Changed
+- **Write-dedup attribute compare is now cheap on large groups** — the per-entity maps (moved to `_unrecorded_attributes`) are no longer part of the dedup equality check, so the comparison is over a handful of scalars instead of O(members) nested dicts.
 
 ### Fixed
 - **`last_seen` attribute crash when "Count attribute updates as activity" is enabled** — groups with `staleness_use_last_updated: true` raised `AttributeError: 'DeviceState' object has no attribute 'last_updated'` on every coordinator update cycle, leaving `*_group_summary` and combined sensors stuck `unavailable`. The `last_seen` diagnostic attribute now always uses `last_changed`; the staleness calculation itself is unaffected. (#85, #86)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.0] - 2026-09-05
+## [0.5.1] - 2026-09-05
 
 ### Fixed
 - **Recorder write amplification on summary sensors** — the `*_group_summary` and combined-group summary sensors called `async_write_ha_state()` on every coordinator tick even when nothing recorded actually changed. Volatile-but-unrecorded attributes (`last_seen`, `signal_levels`, `battery_levels`, `offline_since`, `suppressed_until` …) advanced each tick and defeated the write-dedup guard, producing a redundant States row per tick per sensor (one class alone had accumulated ~729k rows). The dedup comparison now uses the *recorder-stored* view of the attributes — exactly the set Home Assistant strips (`_entity_component_unrecorded_attributes | _unrecorded_attributes`) — so a sensor only writes when a recorded value truly changes. Availability history is unchanged; this only stops the duplicate no-op rows. Forward-only: existing rows purge normally at the 40-day retention. (#95)
 
 ### Changed
-- **Write-dedup attribute compare is now cheap on large groups** — the per-entity maps (moved to `_unrecorded_attributes`) are no longer part of the dedup equality check, so the comparison is over a handful of scalars instead of O(members) nested dicts.
+- **Write-dedup attribute compare is now cheap on large groups** — the per-entity maps (moved to `_unrecorded_attributes`) are no longer part of the dedup equality check, so the comparison is over a handful of scalars instead of O(members) nested dicts. (#95)
 
-### Fixed
-- **`last_seen` attribute crash when "Count attribute updates as activity" is enabled** — groups with `staleness_use_last_updated: true` raised `AttributeError: 'DeviceState' object has no attribute 'last_updated'` on every coordinator update cycle, leaving `*_group_summary` and combined sensors stuck `unavailable`. The `last_seen` diagnostic attribute now always uses `last_changed`; the staleness calculation itself is unaffected. (#85, #86)
+## [0.5.0] - 2026-08-26
+
+### Fixed — groups with `staleness_use_last_updated: true` raised `AttributeError: 'DeviceState' object has no attribute 'last_updated'` on every coordinator update cycle, leaving `*_group_summary` and combined sensors stuck `unavailable`. The `last_seen` diagnostic attribute now always uses `last_changed`; the staleness calculation itself is unaffected. (#85, #86)
 - **Combined groups: suppression dedup is now deterministic** — when the same entity appears in multiple source groups, the combined view previously reflected whichever group was added first. Now: unsuppressed beats suppressed; if both suppressed, the longer/indefinite expiry wins. A per-group mute no longer silences the entity in combined when another group still monitors it actively. (#88)
 - **Combined card: suppression tooltip on collapsed rows** — the suppressed-until tooltip was keyed by entity_id; combined rows use row_key which may differ. Now checks row_key first. (#88)
 

--- a/custom_components/entity_availability/combined_sensor.py
+++ b/custom_components/entity_availability/combined_sensor.py
@@ -353,7 +353,12 @@ class CombinedGroupSensor(CombinedSensorBase):
     _attr_icon = "mdi:format-list-group"
     # No state_class: see GroupSummarySensor.
 
-    # Per-entity list/dict attrs: large, no historical value.
+    # Per-entity list/dict attrs: large, no historical value. This set is now
+    # load-bearing for two concerns: (1) keeping recorder rows small, and
+    # (2) the write-dedup comparison (WriteDedupMixin._ea_dedup_attrs excludes
+    # exactly these keys). Any volatile attr this sensor emits MUST be listed
+    # here — otherwise it advances every tick and re-introduces the per-tick
+    # redundant-write amplification even though the recorder would strip it.
     _unrecorded_attributes = frozenset(
         {
             "display_names",

--- a/custom_components/entity_availability/manifest.json
+++ b/custom_components/entity_availability/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/italo-lombardi/Home-Assistant-EntityAvailability/issues",
     "quality_scale": "custom",
     "requirements": [],
-    "version": "0.6.0"
+    "version": "0.5.1"
 }

--- a/custom_components/entity_availability/manifest.json
+++ b/custom_components/entity_availability/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/italo-lombardi/Home-Assistant-EntityAvailability/issues",
     "quality_scale": "custom",
     "requirements": [],
-    "version": "0.5.0"
+    "version": "0.6.0"
 }

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -987,10 +987,13 @@ class GroupSummarySensor(DedupCoordinatorSensor):
     _attr_has_entity_name = True
 
     # Large dict/list attrs: live state machine access is fine but no value in
-    # recording per-entity snapshots historically. Keeps recorder rows small.
-    # These are also excluded from the write-dedup comparison by the base
-    # WriteDedupMixin (see write_dedup._ea_dedup_attrs), so volatile maps such
-    # as last_seen/signal_levels/battery_levels never force a redundant row.
+    # recording per-entity snapshots historically. This set is now load-bearing
+    # for two concerns: (1) keeping recorder rows small, and (2) the write-dedup
+    # comparison (WriteDedupMixin._ea_dedup_attrs excludes exactly these keys).
+    # Any volatile attr this sensor emits MUST be listed here — otherwise it
+    # advances every tick and re-introduces the per-tick redundant-write
+    # amplification (last_seen/signal_levels/battery_levels …) even though the
+    # recorder would strip it.
     _unrecorded_attributes = frozenset(
         {
             "display_names",

--- a/custom_components/entity_availability/sensor.py
+++ b/custom_components/entity_availability/sensor.py
@@ -986,12 +986,11 @@ class GroupSummarySensor(DedupCoordinatorSensor):
     # statistics would be constant rows sampled every 5 min. Stays a valid state sensor.
     _attr_has_entity_name = True
 
-    # last_seen timestamps advance every tick — exclude from dedup comparison
-    # so the sensor only writes when monitoring data actually changes.
-    _EA_SKIP_DEDUP_KEYS = frozenset({"last_seen"})
-
     # Large dict/list attrs: live state machine access is fine but no value in
     # recording per-entity snapshots historically. Keeps recorder rows small.
+    # These are also excluded from the write-dedup comparison by the base
+    # WriteDedupMixin (see write_dedup._ea_dedup_attrs), so volatile maps such
+    # as last_seen/signal_levels/battery_levels never force a redundant row.
     _unrecorded_attributes = frozenset(
         {
             "display_names",
@@ -1015,27 +1014,6 @@ class GroupSummarySensor(DedupCoordinatorSensor):
             "row_members",
         }
     )
-
-    def _ea_should_write(self) -> bool:
-        """Write only when attrs excluding last_seen change."""
-        value = self._ea_current_value()
-        raw_attrs = self.extra_state_attributes
-        attrs = (
-            {k: v for k, v in raw_attrs.items() if k not in self._EA_SKIP_DEDUP_KEYS}
-            if raw_attrs
-            else raw_attrs
-        )
-        available = getattr(self, "available", True)
-        if (
-            value == self._ea_last_value
-            and attrs == self._ea_last_attrs
-            and available == self._ea_last_available
-        ):
-            return False
-        self._ea_last_value = value
-        self._ea_last_attrs = attrs
-        self._ea_last_available = available
-        return True
 
     def __init__(
         self,

--- a/custom_components/entity_availability/write_dedup.py
+++ b/custom_components/entity_availability/write_dedup.py
@@ -8,7 +8,8 @@ lists, or per-device dictionaries, the value is identical the vast majority of
 ticks, so each refresh produces a redundant recorder row.
 
 The mixin and base classes in this module compare the just-computed
-``native_value``/``is_on``, ``extra_state_attributes`` and ``available``
+``native_value``/``is_on``, ``extra_state_attributes`` (restricted to the keys
+the recorder actually stores — see ``_ea_dedup_attrs``) and ``available``
 against the previously published triple and short-circuit
 ``async_write_ha_state`` when all three match. The first write always goes
 through (the cache starts empty), so an entity always publishes an initial
@@ -41,10 +42,30 @@ class WriteDedupMixin:
         """Return the value subclasses publish (``native_value`` or ``is_on``)."""
         raise NotImplementedError
 
+    def _ea_dedup_attrs(self) -> Any:
+        """Return the attrs view used for the dedup comparison.
+
+        Excludes any key in ``_unrecorded_attributes`` so the write decision
+        matches what the recorder actually stores. Volatile-but-unrecorded
+        maps (``last_seen``, ``signal_levels``, ``battery_levels`` …) advance
+        every coordinator tick, but the recorder strips them before storing —
+        comparing the full dict would force a fresh state row per tick that is
+        byte-identical once stored. Comparing the stored view instead means the
+        sensor only writes when a *recorded* value changes, and no future
+        volatile-but-unrecorded attribute can re-introduce this bug.
+        """
+        attrs = getattr(self, "extra_state_attributes", None)
+        if not attrs:
+            return attrs
+        skip = getattr(self, "_unrecorded_attributes", frozenset())
+        if not skip:
+            return attrs
+        return {k: v for k, v in attrs.items() if k not in skip}
+
     def _ea_should_write(self) -> bool:
         """Return True when value, attrs, or availability differ from cache."""
         value = self._ea_current_value()
-        attrs = getattr(self, "extra_state_attributes", None)
+        attrs = self._ea_dedup_attrs()
         available = getattr(self, "available", True)
         if (
             value == self._ea_last_value

--- a/custom_components/entity_availability/write_dedup.py
+++ b/custom_components/entity_availability/write_dedup.py
@@ -61,6 +61,9 @@ class WriteDedupMixin:
         attrs = getattr(self, "extra_state_attributes", None)
         if not attrs:
             return attrs
+        # ponytail: soft-coupled to HA's name-mangled __combined_unrecorded_attributes.
+        # If a future HA renames it, getattr(..., None) falls back to the per-instance
+        # set — we lose only component-level exclusions (mild amplification), never crash.
         skip = getattr(
             self,
             "_Entity__combined_unrecorded_attributes",

--- a/custom_components/entity_availability/write_dedup.py
+++ b/custom_components/entity_availability/write_dedup.py
@@ -45,19 +45,29 @@ class WriteDedupMixin:
     def _ea_dedup_attrs(self) -> Any:
         """Return the attrs view used for the dedup comparison.
 
-        Excludes any key in ``_unrecorded_attributes`` so the write decision
-        matches what the recorder actually stores. Volatile-but-unrecorded
-        maps (``last_seen``, ``signal_levels``, ``battery_levels`` …) advance
-        every coordinator tick, but the recorder strips them before storing —
-        comparing the full dict would force a fresh state row per tick that is
-        byte-identical once stored. Comparing the stored view instead means the
-        sensor only writes when a *recorded* value changes, and no future
-        volatile-but-unrecorded attribute can re-introduce this bug.
+        Excludes any key the recorder strips so the write decision matches what
+        the recorder actually stores. HA strips the *combined* unrecorded set
+        (``_entity_component_unrecorded_attributes | _unrecorded_attributes``,
+        exposed as the name-mangled ``__combined_unrecorded_attributes``), so we
+        read that when present and fall back to the per-instance
+        ``_unrecorded_attributes``. Volatile-but-unrecorded maps (``last_seen``,
+        ``signal_levels``, ``battery_levels`` …) advance every coordinator tick,
+        but the recorder strips them before storing — comparing the full dict
+        would force a fresh state row per tick that is byte-identical once
+        stored. Comparing the stored view instead means the sensor only writes
+        when a *recorded* value changes, and no future volatile-but-unrecorded
+        attribute (ours or a component-level one) can re-introduce this bug.
         """
         attrs = getattr(self, "extra_state_attributes", None)
         if not attrs:
             return attrs
-        skip = getattr(self, "_unrecorded_attributes", frozenset())
+        skip = getattr(
+            self,
+            "_Entity__combined_unrecorded_attributes",
+            None,
+        )
+        if skip is None:
+            skip = getattr(self, "_unrecorded_attributes", frozenset())
         if not skip:
             return attrs
         return {k: v for k, v in attrs.items() if k not in skip}

--- a/tests/integration/smoke.py
+++ b/tests/integration/smoke.py
@@ -3593,6 +3593,69 @@ for e in cfg['data']['entries']:
             )
 
     # ------------------------------------------------------------------
+    # EC83: write dedup on recorder-stored attr view (PR#95)
+    # group_summary.native_value is the entity COUNT (constant across
+    # offline/online — those are recorded *attributes*), so HA last_changed
+    # never moves; we observe last_updated, which advances on every write and
+    # is frozen by dedup. A churn-only tick (a member's last_seen advances but
+    # no recorded summary value changes) must NOT rewrite the summary. A real
+    # recorded change (member offline → offline/online attrs change) must.
+    # ------------------------------------------------------------------
+    if ec_enabled(83):
+        print(
+            "\n=== EC83: write dedup on recorder-stored attr view (PR#95) ===",
+            flush=True,
+        )
+        restore_and_wait(ctx)
+        summary_eid = f"{prefix}_group_summary"
+        member = ctx["entities"][0]
+        base_attrs = dict(gs(member).get("attributes", {}))
+
+        # Let the summary settle, then snapshot its last write time.
+        wait(WAIT_FOR_TIMEOUT // 2 or 20)
+        u0 = gs(summary_eid).get("last_updated")
+
+        # Churn-only: bump a non-state attr on the member. Its last_updated
+        # advances (feeding the summary's volatile unrecorded maps) while its
+        # STATE — and thus every recorded summary count — stays put.
+        for i in range(3):
+            bumped = dict(base_attrs)
+            bumped["_ea_smoke_churn"] = i
+            ss(member, gs(member).get("state", "on"), bumped)
+            wait(WAIT_FOR_TIMEOUT // 3 or 15)
+
+        chk(
+            "EC83 offline_count unchanged across churn-only ticks",
+            gs(f"{prefix}_offline_count").get("state"),
+            "0",
+        )
+        # Dedup held: the summary did not rewrite → last_updated frozen.
+        u1 = gs(summary_eid).get("last_updated")
+        chk(
+            "EC83 summary last_updated frozen on churn-only ticks (dedup held)",
+            u1,
+            u0,
+            f"u0={u0} u1={u1}",
+        )
+
+        # A genuine recorded change: take the member offline (EC1's trigger).
+        # offline/online attrs change → the summary must write → last_updated
+        # advances past the frozen value.
+        ss(member, "unavailable", {"friendly_name": "test"})
+        wait_for(
+            lambda: gs(f"{prefix}_offline_count").get("state"),
+            "1",
+        )
+        u2 = gs(summary_eid).get("last_updated")
+        chk(
+            "EC83 summary last_updated advances on a real recorded change",
+            u2 != u1,
+            True,
+            f"u1={u1} u2={u2}",
+        )
+        restore_and_wait(ctx)
+
+    # ------------------------------------------------------------------
     restore_all(ctx)
     print(
         f"offline_count={gs(f'{prefix}_offline_count').get('state')} (expected 0)",

--- a/tests/test_write_dedup.py
+++ b/tests/test_write_dedup.py
@@ -171,6 +171,41 @@ def test_mixin_unrecorded_attrs_excluded_from_dedup() -> None:
     assert s._ea_should_write() is True
 
 
+def test_mixin_combined_unrecorded_attrs_preferred() -> None:
+    """Component-level unrecorded attrs (HA's combined set) are also stripped.
+
+    HA strips ``_entity_component_unrecorded_attributes | _unrecorded_attributes``
+    (the name-mangled ``__combined_unrecorded_attributes``). The dedup view must
+    mirror that union, not just the per-instance set, or a component-level
+    unrecorded key would drive a write the recorder then strips.
+    """
+
+    class _S(WriteDedupMixin):
+        # Name-mangled exactly as HA's Entity metaclass writes it.
+        _Entity__combined_unrecorded_attributes = frozenset({"comp_only", "last_seen"})
+        _unrecorded_attributes = frozenset({"last_seen"})
+
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes: dict = {
+                "offline": 0,
+                "last_seen": {"a": "t0"},
+                "comp_only": 1,
+            }
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True  # first publish
+    # Only the component-level unrecorded key churns → recorder strips it → dedup.
+    s.extra_state_attributes = {"offline": 0, "last_seen": {"a": "t1"}, "comp_only": 2}
+    assert s._ea_should_write() is False
+    # A recorded key still writes.
+    s.extra_state_attributes = {"offline": 1, "last_seen": {"a": "t1"}, "comp_only": 2}
+    assert s._ea_should_write() is True
+
+
 def test_mixin_no_unrecorded_attrs_compares_full() -> None:
     """Without ``_unrecorded_attributes`` the full attrs dict is compared."""
 

--- a/tests/test_write_dedup.py
+++ b/tests/test_write_dedup.py
@@ -184,6 +184,8 @@ def test_mixin_no_unrecorded_attrs_compares_full() -> None:
 
     s = _S()
     assert s._ea_should_write() is True
+    # Identical attrs + value: dedups even on the no-``_unrecorded`` path.
+    assert s._ea_should_write() is False
     s.extra_state_attributes = {"x": 2}
     assert s._ea_should_write() is True
 

--- a/tests/test_write_dedup.py
+++ b/tests/test_write_dedup.py
@@ -141,6 +141,53 @@ def test_mixin_default_value_raises() -> None:
         WriteDedupMixin()._ea_current_value()
 
 
+def test_mixin_unrecorded_attrs_excluded_from_dedup() -> None:
+    """Keys in ``_unrecorded_attributes`` never drive the write decision.
+
+    Volatile-but-unrecorded maps (``last_seen`` etc.) advance every tick but
+    the recorder strips them before storing, so comparing them would force a
+    redundant state row per tick. The dedup compare must use the stored view.
+    """
+
+    class _S(WriteDedupMixin):
+        _unrecorded_attributes = frozenset({"last_seen"})
+
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes: dict = {"offline": 0, "last_seen": {"a": "t0"}}
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True  # first publish
+    # Only the unrecorded key churns → no recorded change → dedup wins.
+    s.extra_state_attributes = {"offline": 0, "last_seen": {"a": "t1"}}
+    assert s._ea_should_write() is False
+    s.extra_state_attributes = {"offline": 0, "last_seen": {"a": "t2", "b": "t3"}}
+    assert s._ea_should_write() is False
+    # A recorded key changing still writes.
+    s.extra_state_attributes = {"offline": 1, "last_seen": {"a": "t4"}}
+    assert s._ea_should_write() is True
+
+
+def test_mixin_no_unrecorded_attrs_compares_full() -> None:
+    """Without ``_unrecorded_attributes`` the full attrs dict is compared."""
+
+    class _S(WriteDedupMixin):
+        def __init__(self) -> None:
+            self.value = 1
+            self.extra_state_attributes: dict = {"x": 1}
+
+        def _ea_current_value(self):
+            return self.value
+
+    s = _S()
+    assert s._ea_should_write() is True
+    s.extra_state_attributes = {"x": 2}
+    assert s._ea_should_write() is True
+
+
 def test_dedup_coordinator_sensor_skips_unchanged(mock_coordinator) -> None:
     """`OfflineCountSensor._handle_coordinator_update` writes once, then dedups."""
     sensor = OfflineCountSensor(mock_coordinator, "Test Group", "test_group", "eid")
@@ -247,6 +294,79 @@ async def test_combined_sensor_dedup(
         coord.device_states["binary_sensor.device_a"].is_offline = False
         callback_fn()  # changed -> write
     assert write.call_count == 2
+
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_combined_sensor_last_seen_churn_dedups(
+    mock_hass: HomeAssistant, mock_config_entry
+) -> None:
+    """Regression: last_seen churn must NOT defeat CombinedGroupSensor dedup.
+
+    A busy multi-member group advances a member's ``last_changed`` (and so the
+    ``last_seen`` attr map) on nearly every tick even when the count and all
+    recorded attrs are stable. ``last_seen`` is in ``_unrecorded_attributes``,
+    so the recorder strips it — comparing it in dedup produced one redundant
+    state row per tick (~68k/day on the worst combined_summary sensor). The
+    base ``WriteDedupMixin`` now excludes unrecorded keys from the compare, so
+    only a genuine recorded change writes.
+    """
+    with patch.object(
+        EntityAvailabilityCoordinator, "_async_save_storage", new_callable=AsyncMock
+    ):
+        coord = EntityAvailabilityCoordinator(mock_hass, mock_config_entry)
+        coord._device_states = {
+            "binary_sensor.device_a": DeviceState(
+                entity_id="binary_sensor.device_a",
+                is_offline=False,
+                last_changed=datetime.now(timezone.utc),
+            ),
+        }
+    mock_hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = coord
+
+    combined_entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="Combined",
+        data={},
+        entry_id="combined_last_seen_eid",
+    )
+    sensor = CombinedGroupSensor(
+        mock_hass, combined_entry, "Combined", "combined", [mock_config_entry.entry_id]
+    )
+    # last_seen is derived from d.last_changed; confirm it's actually emitted so
+    # the test would fail if the attr were dropped rather than dedup-excluded.
+    assert "last_seen" in sensor.extra_state_attributes
+    assert "last_seen" in CombinedGroupSensor._unrecorded_attributes
+
+    captured: list = []
+
+    def _fake_add_listener(cb):
+        captured.append(cb)
+        return lambda: None
+
+    coord.async_add_listener = MagicMock(side_effect=_fake_add_listener)
+    with patch.object(sensor, "async_write_ha_state") as write:
+        await sensor.async_added_to_hass()
+        cb = captured[0]
+        cb()  # first publish
+        # Only last_seen advances (a member re-reports) — no recorded change.
+        for i in range(1, 6):
+            coord.device_states["binary_sensor.device_a"].last_changed = datetime.now(
+                timezone.utc
+            ) + timedelta(seconds=i)
+            cb()
+        assert write.call_count == 1, (
+            f"last_seen churn defeated dedup: {write.call_count} writes"
+        )
+        # A real recorded change (device goes offline) still writes.
+        coord.device_states["binary_sensor.device_a"].is_offline = True
+        coord.device_states["binary_sensor.device_a"].offline_since = datetime.now(
+            timezone.utc
+        )
+        cb()
+        assert write.call_count == 2
 
     await sensor.async_will_remove_from_hass()
 


### PR DESCRIPTION
## Problem

Combined/group summary sensors wrote a new recorder state row on nearly every coordinator tick, even when nothing recorded changed.

**Root cause:** `WriteDedupMixin._ea_should_write` compared the full `extra_state_attributes` dict, which includes volatile maps the recorder strips before storing (`last_seen`, `signal_levels`, `battery_levels`):

- `last_seen` mirrors each member's `last_changed` and advances whenever **any** monitored entity changes value.
- `signal_levels` holds raw RSSI, read fresh every tick.

So the pre-strip dict differed every tick → forced `async_write_ha_state()` → but once the recorder stripped the `_unrecorded_attributes` keys, the stored row was byte-identical to the prior one. Pure write amplification.

**Live DB analysis (40-day window):** `entity_availability` = 42% of all state rows, concentrated in `*_combined_summary` / `*_group_summary`. Worst sensor: ~68.8k writes/day, only 51 distinct states.

## Fix

`_ea_dedup_attrs()` computes the dedup comparison against the **post-unrecorded-attrs view** — what the recorder actually stores — so a write fires only when a *recorded* value changes.

- Reads HA's **combined** unrecorded set (`_entity_component_unrecorded_attributes | _unrecorded_attributes`, exposed as the name-mangled `__combined_unrecorded_attributes`), falling back to the per-instance set if HA ever renames it. This closes a residual over-write path: a future component-level unrecorded attr the recorder strips would otherwise still drive a write.
- Single place, covers both summary sensors.
- Self-maintaining: any future volatile-but-unrecorded attribute is automatically excluded from the compare and cannot reintroduce the bug.
- Removes `GroupSummarySensor`'s now-redundant override (it only skipped `last_seen`, missed `signal_levels`).

**Availability history is unchanged** — recorded KPI attrs (online/offline/stale/…) still drive writes exactly as before. Only churn from stripped attrs is eliminated. Recorder exclusion was explicitly *not* an option; this is entirely integration-side.

Ships as **0.5.1** (manifest bumped; CHANGELOG updated).

## Testing

- Regression tests in `test_write_dedup.py`:
  - integration-level guard: advances a member's `last_changed` 5× → asserts **one** write, then a genuine offline transition → asserts a **second**;
  - `_unrecorded_attributes` keys excluded from the compare;
  - **combined** (component-level) unrecorded key excluded — `test_mixin_combined_unrecorded_attrs_preferred`;
  - no-`_unrecorded` path still dedups on identical value+attrs.
- Full suite: **845 passing, 100% line+branch coverage**.
- Live smoke (devcontainer):
  - EC55, EC69–EC71 → all unrecorded attrs still present in the state machine, `groups` dict intact (**63/63**).
  - EC1, EC4–EC8, EC16–EC18 → real state transitions still write through (**32/32**).
  - EC83 (new) → churn-only ticks leave `*_group_summary` `last_updated` frozen (write-dedup holds); a real offline transition advances it. Verified live in the devcontainer.
